### PR TITLE
Find OGRE correctly in a system with pkg-config but without OGRE .pc files

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -333,21 +333,6 @@ if (PKG_CONFIG_FOUND)
 
   #################################################
   # Find OGRE
-  if (PKG_CONFIG_EXECUTABLE AND NOT DEFINED OGRE_VERSION)
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --modversion OGRE
-                    OUTPUT_VARIABLE OGRE_VERSION)
-    string(REPLACE "\n" "" OGRE_VERSION ${OGRE_VERSION})
-
-    string (REGEX REPLACE "^([0-9]+).*" "\\1"
-      OGRE_MAJOR_VERSION "${OGRE_VERSION}")
-    string (REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1"
-      OGRE_MINOR_VERSION "${OGRE_VERSION}")
-    string (REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1"
-      OGRE_PATCH_VERSION ${OGRE_VERSION})
-
-    set(OGRE_VERSION
-      ${OGRE_MAJOR_VERSION}.${OGRE_MINOR_VERSION}.${OGRE_PATCH_VERSION})
-  endif()
 
   pkg_check_modules(OGRE-RTShaderSystem
                     OGRE-RTShaderSystem>=${MIN_OGRE_VERSION})
@@ -365,6 +350,36 @@ if (PKG_CONFIG_FOUND)
   endif ()
 
   pkg_check_modules(OGRE OGRE>=${MIN_OGRE_VERSION})
+  
+  if (PKG_CONFIG_EXECUTABLE AND OGRE_FOUND AND NOT DEFINED OGRE_VERSION)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --modversion OGRE
+                    OUTPUT_VARIABLE OGRE_VERSION)
+    string(REPLACE "\n" "" OGRE_VERSION ${OGRE_VERSION})
+
+    string (REGEX REPLACE "^([0-9]+).*" "\\1"
+      OGRE_MAJOR_VERSION "${OGRE_VERSION}")
+    string (REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1"
+      OGRE_MINOR_VERSION "${OGRE_VERSION}")
+    string (REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1"
+      OGRE_PATCH_VERSION ${OGRE_VERSION})
+
+    set(OGRE_VERSION
+      ${OGRE_MAJOR_VERSION}.${OGRE_MINOR_VERSION}.${OGRE_PATCH_VERSION})
+  endif()
+  
+  # Also find OGRE's plugin directory, which is provided in its .pc file as the
+  # `plugindir` variable.  We have to call pkg-config manually to get it.
+  if (PKG_CONFIG_EXECUTABLE AND OGRE_FOUND)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=plugindir OGRE
+                    OUTPUT_VARIABLE _pkgconfig_invoke_result
+                    RESULT_VARIABLE _pkgconfig_failed)
+    if(_pkgconfig_failed)
+      BUILD_WARNING ("Failed to find OGRE's plugin directory.  The build will succeed, but gazebo will likely fail to run.")
+    else()
+      # This variable will be substituted into cmake/setup.sh.in
+      set (OGRE_PLUGINDIR ${_pkgconfig_invoke_result})
+    endif()
+  endif()
 
   if (NOT OGRE_FOUND)
     # Workaround for CMake bug https://gitlab.kitware.com/cmake/cmake/issues/17135,
@@ -426,20 +441,6 @@ if (PKG_CONFIG_FOUND)
 
   set (OGRE_INCLUDE_DIRS ${ogre_include_dirs}
        CACHE INTERNAL "Ogre include path")
-
-  # Also find OGRE's plugin directory, which is provided in its .pc file as the
-  # `plugindir` variable.  We have to call pkg-config manually to get it.
-  if (PKG_CONFIG_EXECUTABLE)
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=plugindir OGRE
-                    OUTPUT_VARIABLE _pkgconfig_invoke_result
-                    RESULT_VARIABLE _pkgconfig_failed)
-    if(_pkgconfig_failed)
-      BUILD_WARNING ("Failed to find OGRE's plugin directory.  The build will succeed, but gazebo will likely fail to run.")
-    else()
-      # This variable will be substituted into cmake/setup.sh.in
-      set (OGRE_PLUGINDIR ${_pkgconfig_invoke_result})
-    endif()
-  endif()
 
   ########################################
   # Check and find libccd (if needed)


### PR DESCRIPTION
This PR fixes the configuration in a system in which `pkg-config` is available in the path, but OGRE did not install any `.pc` file.

This works by ensuing that any invocation of pkg-config to extract OGRE-specific versions only occurs if OGRE has been found by the `pkg_check_modules(OGRE OGRE>=${MIN_OGRE_VERSION})` call. 

An example of such a setup is when you build Gazebo for Windows using the vcpkg-installed OGRE (that as of 04/2020 does not install `.pc` files) on the `windows-2019` image of GitHub Actions (that instead  contains `pkg-config`). 

Without this fix, the configuration fails with the following error (from https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/runs/626432931): 
~~~
 CMake Error at cmake/SearchForStuff.cmake:339 (string):
  string sub-command REPLACE requires at least four arguments.
Call Stack (most recent call first):
  CMakeLists.txt:151 (include)


CMake Error at cmake/SearchForStuff.cmake:345 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  CMakeLists.txt:151 (include)
~~~

An example of successful Gazebo configuration on GitHub Action with this fix is https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/runs/626459680 .  
