### PR TITLE
Change type from float to double to ensure correct eigen assert

### DIFF
--- a/gazebo/physics/HeightmapShape.hh
+++ b/gazebo/physics/HeightmapShape.hh
@@ -45,7 +45,7 @@ namespace gazebo
     class GZ_PHYSICS_VISIBLE HeightmapShape : public Shape
     {
       /// \brief height field type, float or double
-      public: typedef float HeightType;
+      public: typedef double HeightType;
 
       /// \brief Constructor.
       /// \param[in] _parent Parent Collision object.


### PR DESCRIPTION
This pull request resolve this issue observed during compilation on Arch Linux:

```
In file included from /usr/include/eigen3/Eigen/Core:366,
                 from /usr/local/include/dart/config.hpp:5,
                 from /usr/local/include/dart/dart.hpp:33,
                 from /meta/gazebo/gazebo/physics/dart/dart_inc.h:24,
                 from /meta/gazebo/gazebo/physics/dart/DARTCollision.hh:23,
                 from /meta/gazebo/gazebo/physics/dart/DARTHeightmapShape.cc:20:
/usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h: In instantiation of ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Matrix<double, 3,
1>; Src = Eigen::Matrix<float, 3, 1>; Func = Eigen::internal::assign_op<double, float>]’:
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:732:41:   required from ‘Derived& Eigen::PlainObjectBase<Derived>::_set_noalias(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived
 = Eigen::Matrix<float, 3, 1>; Derived = Eigen::Matrix<double, 3, 1>]’
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:537:7:   required from ‘Eigen::PlainObjectBase<Derived>::PlainObjectBase(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eige
n::Matrix<float, 3, 1>; Derived = Eigen::Matrix<double, 3, 1>]’
/usr/include/eigen3/Eigen/src/Core/Matrix.h:377:29:   required from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(const Eigen::EigenBase<OtherDerived>&) [with O
therDerived = Eigen::Matrix<float, 3, 1>; _Scalar = double; int _Rows = 3; int _Cols = 1; int _Options = 0; int _MaxRows = 3; int _MaxCols = 1]’
/meta/gazebo/gazebo/physics/dart/DARTHeightmapShape.cc:68:63:   required from here
/usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:834:3: error: static assertion failed: YOU_MIXED_DIFFERENT_NUMERIC_TYPES__YOU_NEED_TO_USE_THE_CAST_METHOD_OF_MATRIXBASE_TO_CAST_NUMERIC_T
YPES_EXPLICITLY
  834 |   EIGEN_CHECK_BINARY_COMPATIBILIY(Func,typename ActualDstTypeCleaned::Scalar,typename Src::Scalar);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

Signed-off-by: Omar Shrit <shrit@lri.fr>