### PR TITLE
Fix DepthCameraSensor Scoped Name

### DIFF
--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -604,7 +604,7 @@ CameraPtr Scene::CreateCamera(const std::string &_name, const bool _autoRender)
 DepthCameraPtr Scene::CreateDepthCamera(const std::string &_name,
                                         const bool _autoRender)
 {
-  DepthCameraPtr camera(new DepthCamera(this->dataPtr->name + "::" + _name,
+  DepthCameraPtr camera(new DepthCamera(_name,
         shared_from_this(), _autoRender));
   this->dataPtr->cameras.push_back(camera);
 

--- a/gazebo/sensors/DepthCameraSensor.cc
+++ b/gazebo/sensors/DepthCameraSensor.cc
@@ -75,8 +75,8 @@ void DepthCameraSensor::Init()
     if (!this->scene)
       this->scene = rendering::create_scene(worldName, false, true);
 
-    this->dataPtr->depthCamera = this->scene->CreateDepthCamera(
-        this->sdf->Get<std::string>("name"), false);
+    std::string scopedName = this->parentName + "::" + this->Name();
+    this->dataPtr->depthCamera = this->scene->CreateDepthCamera(scopedName, false);
 
     if (!this->dataPtr->depthCamera)
     {
@@ -97,13 +97,13 @@ void DepthCameraSensor::Init()
 
     this->dataPtr->depthCamera->Init();
     this->dataPtr->depthCamera->CreateRenderTexture(
-        this->Name() + "_RttTex_Image");
+        scopedName + "_RttTex_Image");
     this->dataPtr->depthCamera->CreateDepthTexture(
-        this->Name() + "_RttTex_Depth");
+        scopedName + "_RttTex_Depth");
     this->dataPtr->depthCamera->CreateReflectanceTexture(
-        this->Name() + "_RttTex_Reflectance");
+        scopedName + "_RttTex_Reflectance");
     this->dataPtr->depthCamera->CreateNormalsTexture(
-        this->Name() + "_RttTex_Normals");
+        scopedName + "_RttTex_Normals");
 
     ignition::math::Pose3d cameraPose = this->pose;
     if (cameraSdf->HasElement("pose"))


### PR DESCRIPTION
Currently, the Depth Camera Sensor does not create its sensor with a scoped name like the Camera Sensor. This is an issue because it becomes difficult maintaining multiple vehicles with the same depth sensor name. Currently, there is no way to access a sensor unique to a specific model but with the same name as other models sensors. This pull request should fix this issue. It should be noted that this problem persists in gazebo10 and gazebo11. I created issue #2729 that describes the problem more.