### PR TITLE
Build TrackedVehiclePlugin as shared library

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -165,7 +165,7 @@ set (DARTplugins
   GravityCompensationPlugin
 )
 
-add_library(TrackedVehiclePlugin STATIC TrackedVehiclePlugin.cc)
+add_library(TrackedVehiclePlugin SHARED TrackedVehiclePlugin.cc)
 target_link_libraries(TrackedVehiclePlugin
         libgazebo
         ${ogre_libraries}


### PR DESCRIPTION
Attempting to solve https://github.com/osrf/gazebo/issues/2691 which prevents gazebo11 compilation on ARM

I'm not sure what the git workflow on this repo is; so I've targeted the PR at `gazebo11` because it was the default branch.