### PR TITLE
Fix multiple reflectance maps and improve performance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## Gazebo 9.XX.X (20XX-XX-XX)
 
 1. Fix multiple reflectance maps and improve performance
-    * [Pull request ]()
+    * [Pull request #2724](https://github.com/osrf/gazebo/pull/2742)
 
 ## Gazebo 9.13.0 (2020-04-03)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Gazebo 9
 
+## Gazebo 9.XX.X (20XX-XX-XX)
+
+1. Fix multiple reflectance maps and improve performance
+    * [Pull request ]()
+
 ## Gazebo 9.13.0 (2020-04-03)
 
 1. Use target based compile options to specify C++ standard

--- a/gazebo/rendering/DepthCamera.cc
+++ b/gazebo/rendering/DepthCamera.cc
@@ -140,7 +140,7 @@ namespace gazebo
       /// \brief Default reflectance material
       private: Ogre::MaterialPtr reflectanceMaterial;
 
-      /// \brief Default reflectance material
+      /// \brief Black material for objects with no reflectance map
       private: Ogre::MaterialPtr blackMaterial;
     };
   }

--- a/media/materials/scripts/gazebo.material
+++ b/media/materials/scripts/gazebo.material
@@ -73,9 +73,9 @@ material Gazebo/Reflectance
       texture_unit
       {
       }
-      }
     }
   }
+}
 
 vertex_program Gazebo/XYZNormalsVS glsl
 {


### PR DESCRIPTION
**Changes**

* Fixes issue when there are multiple objects in the scene with different reflectance maps by creating a unique reflectance material for each reflectance map

* Improves performance by disabling shadows during reflectance render updates.

**Testing**

Build this branch with gazebo_ros_pkgs `noetic-devel` branch 

Here is a [reflectance_test.world](https://gist.github.com/iche033/5014dc802d45c2d40c8c4346fe36b64d) for testing. The world consists of 3 depth cameras with depth, normals, reflectance output, and 100 boxes in front of the depth cameras.

For verifying multiple reflectance maps, launch gazebo with the `reflectance_test.world`:

```
roslaunch gazebo_ros empty_world.launch verbose:=true world_name:=<path_to_reflectance_test.world>
```

launch `rqt_image_viewer` to see data from the reflectance topic:

```
rqt_image_view /depth_cam/reflectance
```

You should see two different reflectance maps rendered side by side. Before the changes in the PR, I see two identical reflectances maps.  

For testing performance, launch the `reflectance_test.world`, and see the frame rates using `rostopic hz`. Subscribe to all 3 depth cameras:

```
# you can do this in 3 terminals
rostopic hz /depth_cam/image_raw
rostopic hz /depth_cam2/image_raw
rostopic hz /depth_cam3/image_raw
```

The target framerate is set to 30Hz but the cameras do not hit the target frame rate (which is what we want for testing so we can see the differences in performance). These are the frame rates I get on my laptop before and after the change:

Before:
* depth;normals;reflectance: 10Hz
* depth;normals: 19Hz
* depth;reflectance: 14Hz

After:
* depth;normals;reflectance: 15Hz
* depth;normals: 19Hz
* depth;reflectance: 21Hz

In two cases that refletance is enabled, the frame rate improves by 5~7Hz


Signed-off-by: Ian Chen <ichen@osrfoundation.org>