### PR TITLE
Fix pkg-config boost entries for Ubuntu Focal (gazebo9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,8 @@ else (build_errors)
     endif()
     # Remove the prefix lib (not always present, like in pthread)
     string (REPLACE "lib" "" bname "${bname}")
+    # Some boost versions add the Boost:: component toe cmake, need to change that to boost_ prefix
+    string (REPLACE "Boost::" "boost_" bname "${bname}")
     set (Boost_PKGCONFIG_LIBS "${Boost_PKGCONFIG_LIBS} ${bname}")
   endforeach(b)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set (GAZEBO_MINOR_VERSION 13)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.
-set (GAZEBO_PATCH_VERSION 1)
+set (GAZEBO_PATCH_VERSION 2)
 
 set (GAZEBO_VERSION ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION})
 set (GAZEBO_VERSION_FULL ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION}.${GAZEBO_PATCH_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,7 @@ else (build_errors)
     endif()
     # Remove the prefix lib (not always present, like in pthread)
     string (REPLACE "lib" "" bname "${bname}")
-    # Some boost versions add the Boost:: component toe cmake, need to change that to boost_ prefix
+    # Some boost versions add the Boost:: component to cmake, need to change that to boost_ prefix
     string (REPLACE "Boost::" "boost_" bname "${bname}")
     set (Boost_PKGCONFIG_LIBS "${Boost_PKGCONFIG_LIBS} ${bname}")
   endforeach(b)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,8 +5,14 @@
 1. Fix sensor update rate throttling when new sensors are spawned
     * [Pull request #2784](https://github.com/osrf/gazebo/pull/2784)
 
+1. Fix crash when collision size is zero
+    * [Pull request #2768](https://github.com/osrf/gazebo/pull/2768)
+
 1. LensFlare: initialize OGRE compositors during plugin initialization
-    * [Pull request #2762](https://github.com/osrf/gazebo/pull/2762)
+    * [Pull request #2764](https://github.com/osrf/gazebo/pull/2764)
+
+1. Fix pkg-config boost entries for Ubuntu Focal
+    * [Pull request #2751](https://github.com/osrf/gazebo/pull/2751)
 
 1. Fixes for ARM: FindSSE, TrackedVehiclePlugin and PluginInterfaceTest
     * [Pull request #2754](https://github.com/osrf/gazebo/pull/2754)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Gazebo 9.xx.x (202x-xx-xx)
 
+## Gazebo 9.13.2 (202x-xx-xx)
+
 1. Fix sensor update rate throttling when new sensors are spawned
     * [Pull request #2784](https://github.com/osrf/gazebo/pull/2784)
 


### PR DESCRIPTION
Partial fix for https://github.com/osrf/gazebo/issues/2735 . Need another PR for Gazebo11