### PR TITLE
Fix compilation with Boost 1.73

### DIFF
--- a/gazebo/gui/model/ModelTreeWidget.cc
+++ b/gazebo/gui/model/ModelTreeWidget.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
 */
+#include <boost/bind.hpp>
 
 #include "gazebo/common/Events.hh"
 


### PR DESCRIPTION
The `ModelTreeWidget.cc` file was using the Boost Bind placeholders, but it was not  including `boost/bind.hpp` . Before Boost 1.73, this was working probably due to transitive includes.

Slightly related issue: https://github.com/osrf/gazebo/issues/2757 . 

This change is required to build Gazebo11 with the latest version of vcpkg.