### PR TITLE
LensFlare: initialize OGRE compositors during plugin initialization

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,18 @@
 ## Gazebo 9
 
+## Gazebo 9.xx.x (202x-xx-xx)
+
+1. LensFlare: initialize OGRE compositors during plugin initialization
+    * [Pull request #2762](https://github.com/osrf/gazebo/pull/2762)
+
+1. Fixes for ARM: FindSSE, TrackedVehiclePlugin and PluginInterfaceTest
+    * [Pull request #2754](https://github.com/osrf/gazebo/pull/2754)
+    * [Pull request #2748](https://github.com/osrf/gazebo/pull/2748)
+
 ## Gazebo 9.13.1 (2020-05-28)
 
 1. Fix multiple reflectance maps and improve performance
-    * [Pull request #2724](https://github.com/osrf/gazebo/pull/2742)
+    * [Pull request #2742](https://github.com/osrf/gazebo/pull/2742)
 
 ## Gazebo 9.13.0 (2020-04-03)
 

--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -76,6 +76,12 @@ namespace gazebo
       public: virtual void notifyMaterialRender(unsigned int _passId,
                                                 Ogre::MaterialPtr &_mat)
       {
+        if (!this->light)
+        {
+          // return if this->light is not set, we may still be initializing
+          return;
+        }
+
         GZ_ASSERT(!_mat.isNull(), "Null OGRE material");
         // These calls are setting parameters that are declared in two places:
         // 1. media/materials/scripts/gazebo.material, in
@@ -96,12 +102,6 @@ namespace gazebo
         params->setNamedConstant("viewport",
             Ogre::Vector3(static_cast<double>(this->camera->ViewportWidth()),
             static_cast<double>(this->camera->ViewportHeight()), 1.0));
-
-        if (!this->light)
-        {
-          // return if this->light is not set, we may still be initializing
-          return;
-        }
 
         // use light's world position for lens flare position
         if (this->light->Type() == "directional")
@@ -472,10 +472,8 @@ void LensFlare::Update()
 
   this->dataPtr->lightName = directionalLight->Name();
 
-  {
-    this->dataPtr->lensFlareCompositorListener->SetLight(directionalLight);
-    this->dataPtr->lensFlareInstance->setEnabled(true);
-  }
+  this->dataPtr->lensFlareCompositorListener->SetLight(directionalLight);
+  this->dataPtr->lensFlareInstance->setEnabled(true);
 
   // disconnect
   this->dataPtr->preRenderConnection.reset();


### PR DESCRIPTION
There are several `SensorPlugin`s that create Ogre compositors (such as [LensFlareSensorPlugin](https://github.com/osrf/gazebo/blob/gazebo11/plugins/LensFlareSensorPlugin.cc)). It was reported by @mogumbo that the order in which compositors are applied affects the rendered output, but the `LensFlareSensorPlugin` always seems to be applied last, regardless of the order in which plugins are specified in an SDFormat file. @iche033 suggested moving the code for initializing a `gazebo::rendering::LensFlare` compositor from `LensFlare::Update` to `Lensflare::SetCamera`, so that the compositor would be added during plugin initialization.

The initialization code expects a pointer to a `DirectionalLight`, which is not available until the first render update. It seems to work to initialize with a `nullptr` for the `DirectionalLight` since the light ptr is being set every update. I also added logic to exit `notifyMaterialRender` early if the light pointer is `nullptr`.