### PR TITLE
Fixed crash when collision size is zero

### DIFF
--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -14,8 +14,6 @@
  * limitations under the License.
  *
 */
-#include <math.h>
-
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/lexical_cast.hpp>

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
 */
+#include <math.h>
+
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/lexical_cast.hpp>

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -811,9 +811,14 @@ void Visual::SetScale(const ignition::math::Vector3d &_scale)
 
   this->dataPtr->scale = _scale;
 
-  this->dataPtr->sceneNode->setScale(
-      Conversions::Convert(this->dataPtr->scale));
-
+  if (!isnan(this->dataPtr->scale.X()) && !isnan(this->dataPtr->scale.Y())
+      && !isnan(this->dataPtr->scale.Z()))
+  {
+    this->dataPtr->sceneNode->setScale(
+        Conversions::Convert(this->dataPtr->scale));
+  } else {
+    gzerr << Name() << " Scale contains NaNs. Collisions may not visualize properly." << std::endl;
+  }
   // Scale selection object in case we have one attached. Other children were
   // scaled from UpdateGeomSize
   for (auto child : this->dataPtr->children)

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -813,8 +813,9 @@ void Visual::SetScale(const ignition::math::Vector3d &_scale)
 
   this->dataPtr->scale = _scale;
 
-  if (!isnan(this->dataPtr->scale.X()) && !isnan(this->dataPtr->scale.Y())
-      && !isnan(this->dataPtr->scale.Z()))
+  if (!ignition::math::isnan(this->dataPtr->scale.X())
+      && !ignition::math::isnan(this->dataPtr->scale.Y())
+      && !ignition::math::isnan(this->dataPtr->scale.Z()))
   {
     this->dataPtr->sceneNode->setScale(
         Conversions::Convert(this->dataPtr->scale));

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -820,7 +820,8 @@ void Visual::SetScale(const ignition::math::Vector3d &_scale)
     this->dataPtr->sceneNode->setScale(
         Conversions::Convert(this->dataPtr->scale));
   } else {
-    gzerr << Name() << " Scale contains NaNs. Collisions may not visualize properly." << std::endl;
+    gzerr << Name() << ": Size of the collision contains one or several zeros." <<
+      " Collisions may not visualize properly." << std::endl;
   }
   // Scale selection object in case we have one attached. Other children were
   // scaled from UpdateGeomSize


### PR DESCRIPTION
This PR fixed an issue when the collision size of a link is `0 0 0`.

Signed-off-by: ahcorde <ahcorde@gmail.com>