### PR TITLE
[Gazebo 11] Added ignition common profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ filter_valid_compiler_flags(${WARN_LEVEL}
 # Check and add visibility hidden by default. Only in UNIX
 # Windows and MacosX does not handled properly the hidden compilation
 if (UNIX AND NOT APPLE)
-  filter_valid_compiler_flags(-fvisibility=hidden -fvisibility-inlines-hidden)
+  filter_valid_compiler_flags(-fvisibility-inlines-hidden)
 endif()
 
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,14 @@ if(NOT DEFINED BUILD_TESTING)
     set(BUILD_TESTING OFF)
 endif()
 
+option(ENABLE_PROFILER "Enable Ignition Profiler" FALSE)
+
+if(ENABLE_PROFILER)
+  add_definitions("-DIGN_PROFILER_ENABLE=1")
+else()
+  add_definitions("-DIGN_PROFILER_ENABLE=0")
+endif()
+
 #============================================================================
 # We turn off extensions because (1) we do not ever want to use non-standard
 # compiler extensions, and (2) this variable is on by default, causing cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,11 @@ filter_valid_compiler_flags(${WARN_LEVEL}
 # Check and add visibility hidden by default. Only in UNIX
 # Windows and MacosX does not handled properly the hidden compilation
 if (UNIX AND NOT APPLE)
-  filter_valid_compiler_flags(-fvisibility-inlines-hidden)
+  if (ENABLE_PROFILER)
+    filter_valid_compiler_flags(-fvisibility-inlines-hidden)
+  else()
+    filter_valid_compiler_flags(-fvisibility=hidden -fvisibility-inlines-hidden)
+  endif()
 endif()
 
 if (MSVC)

--- a/gazebo/CMakeLists.txt
+++ b/gazebo/CMakeLists.txt
@@ -51,6 +51,12 @@ add_dependencies(gazebo_sensors gazebo_rendering)
 
 gz_add_executable(gzserver server_main.cc)
 
+if (${IGN_PROFILER_ENABLE})
+  target_compile_definitions(gzserver PUBLIC "IGN_PROFILER_ENABLE=1")
+  set(IGN_PROFILE_LIBS ${IGNITION-COMMON_LIBRARIES})
+  target_include_directories(gzserver PUBLIC ${ignition-common3_INCLUDE_DIRS})
+endif()
+
 target_link_libraries(gzserver
   libgazebo
   gazebo_common
@@ -64,6 +70,7 @@ target_link_libraries(gzserver
   ${freeimage_LIBRARIES}
   ${TBB_LIBRARIES}
   ${ogre_libraries}
+  ${IGN_PROFILE_LIBS}
 )
 
 if (UNIX)

--- a/gazebo/CMakeLists.txt
+++ b/gazebo/CMakeLists.txt
@@ -51,10 +51,8 @@ add_dependencies(gazebo_sensors gazebo_rendering)
 
 gz_add_executable(gzserver server_main.cc)
 
-if (${IGN_PROFILER_ENABLE})
-  target_compile_definitions(gzserver PUBLIC "IGN_PROFILER_ENABLE=1")
+if (${ENABLE_PROFILER})
   set(IGN_PROFILE_LIBS ${IGNITION-COMMON_LIBRARIES})
-  target_include_directories(gzserver PUBLIC ${ignition-common3_INCLUDE_DIRS})
 endif()
 
 target_link_libraries(gzserver

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -588,17 +588,20 @@ void Server::Run()
   // The server and sensor manager outlive worlds
   while (!this->dataPtr->stop)
   {
-    IGN_PROFILE("gzserver_loop");
+    IGN_PROFILE("Server::Run");
     IGN_PROFILE_BEGIN("ProcessControlMsgs");
     this->ProcessControlMsgs();
     IGN_PROFILE_END();
 
-    if (physics::worlds_running()) {
-      IGN_PROFILE_BEGIN("sensors::run_once");
+    if (physics::worlds_running())
+    {
+      IGN_PROFILE_BEGIN("run_once");
       sensors::run_once();
       IGN_PROFILE_END();
-    } else if (sensors::running()) {
-      IGN_PROFILE_BEGIN("sensors::stop");
+    }
+    else if (sensors::running())
+    {
+      IGN_PROFILE_BEGIN("stop");
       sensors::stop();
       IGN_PROFILE_END();
     }

--- a/gazebo/common/CMakeLists.txt
+++ b/gazebo/common/CMakeLists.txt
@@ -242,6 +242,7 @@ target_link_libraries(gazebo_common
     ignition-common3::graphics
     ${IGNITION-FUEL_TOOLS_LIBRARIES}
     ${IGNITION-MATH_LIBRARIES}
+    ${IGNITION-COMMON_LIBRARIES}
     ${libdl_library}
     ${libtar_LIBRARIES}
     ${SDFormat_LIBRARIES}

--- a/gazebo/common/Event.hh
+++ b/gazebo/common/Event.hh
@@ -29,6 +29,8 @@
 #include <gazebo/common/CommonTypes.hh>
 #include "gazebo/util/system.hh"
 
+#include <ignition/common/Profiler.hh>
+
 namespace gazebo
 {
   /// \ingroup gazebo_event
@@ -268,13 +270,18 @@ namespace gazebo
       /// \brief Signal the event for all subscribers.
       public: void Signal()
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback0");
             iter.second->callback();
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -283,13 +290,18 @@ namespace gazebo
       public: template< typename P >
               void Signal(const P &_p)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback1");
             iter.second->callback(_p);
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -299,13 +311,18 @@ namespace gazebo
       public: template< typename P1, typename P2 >
               void Signal(const P1 &_p1, const P2 &_p2)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback2");
             iter.second->callback(_p1, _p2);
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -316,13 +333,18 @@ namespace gazebo
       public: template< typename P1, typename P2, typename P3 >
               void Signal(const P1 &_p1, const P2 &_p2, const P3 &_p3)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback3");
             iter.second->callback(_p1, _p2, _p3);
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -335,13 +357,18 @@ namespace gazebo
               void Signal(const P1 &_p1, const P2 &_p2, const P3 &_p3,
                           const P4 &_p4)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback4");
             iter.second->callback(_p1, _p2, _p3, _p4);
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -356,13 +383,18 @@ namespace gazebo
               void Signal(const P1 &_p1, const P2 &_p2, const P3 &_p3,
                           const P4 &_p4, const P5 &_p5)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback5");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5);
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -378,13 +410,18 @@ namespace gazebo
               void Signal(const P1 &_p1, const P2 &_p2, const P3 &_p3,
                   const P4 &_p4, const P5 &_p5, const P6 &_p6)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback6");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6);
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -401,13 +438,18 @@ namespace gazebo
               void Signal(const P1 &_p1, const P2 &_p2, const P3 &_p3,
                   const P4 &_p4, const P5 &_p5, const P6 &_p6, const P7 &_p7)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if (iter.second->on){
+            IGN_PROFILE_BEGIN("callback7");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6, _p7);
+            IGN_PROFILE_END();
+          }
         }
       }
 
@@ -426,6 +468,8 @@ namespace gazebo
                   const P4 &_p4, const P5 &_p5, const P6 &_p6, const P7 &_p7,
                   const P8 &_p8)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
@@ -433,7 +477,9 @@ namespace gazebo
         {
           if (iter.second->on)
           {
+            IGN_PROFILE_BEGIN("callback8");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6, _p7, _p8);
+            IGN_PROFILE_END();
           }
         }
       }
@@ -455,6 +501,8 @@ namespace gazebo
                   const P4 &_p4, const P5 &_p5, const P6 &_p6, const P7 &_p7,
                   const P8 &_p8, const P9 &_p9)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
@@ -462,8 +510,10 @@ namespace gazebo
         {
           if (iter.second->on)
           {
+            IGN_PROFILE_BEGIN("callback9");
             iter.second->callback(
                 _p1, _p2, _p3, _p4, _p5, _p6, _p7, _p8, _p9);
+            IGN_PROFILE_END();
           }
         }
       }
@@ -491,10 +541,14 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
+          IGN_PROFILE("Event::Signal");
+
           if (iter.second->on)
           {
+            IGN_PROFILE_BEGIN("callback10");
             iter.second->callback(
                 _p1, _p2, _p3, _p4, _p5, _p6, _p7, _p8, _p9, _p10);
+            IGN_PROFILE_END();
           }
         }
       }

--- a/gazebo/common/Event.hh
+++ b/gazebo/common/Event.hh
@@ -24,12 +24,12 @@
 #include <memory>
 #include <mutex>
 
-#include <gazebo/gazebo_config.h>
-#include <gazebo/common/Time.hh>
-#include <gazebo/common/CommonTypes.hh>
+#include "gazebo/gazebo_config.h"
+#include "gazebo/common/Time.hh"
+#include "gazebo/common/CommonTypes.hh"
 #include "gazebo/util/system.hh"
 
-#include <ignition/common/Profiler.hh>
+#include "ignition/common/Profiler.hh"
 
 namespace gazebo
 {
@@ -277,7 +277,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback0");
             iter.second->callback();
             IGN_PROFILE_END();
@@ -297,7 +298,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback1");
             iter.second->callback(_p);
             IGN_PROFILE_END();
@@ -318,7 +320,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback2");
             iter.second->callback(_p1, _p2);
             IGN_PROFILE_END();
@@ -340,7 +343,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback3");
             iter.second->callback(_p1, _p2, _p3);
             IGN_PROFILE_END();
@@ -364,7 +368,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback4");
             iter.second->callback(_p1, _p2, _p3, _p4);
             IGN_PROFILE_END();
@@ -390,7 +395,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback5");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5);
             IGN_PROFILE_END();
@@ -417,7 +423,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback6");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6);
             IGN_PROFILE_END();
@@ -445,7 +452,8 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on){
+          if (iter.second->on)
+          {
             IGN_PROFILE_BEGIN("callback7");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6, _p7);
             IGN_PROFILE_END();

--- a/gazebo/physics/CMakeLists.txt
+++ b/gazebo/physics/CMakeLists.txt
@@ -158,6 +158,12 @@ target_compile_definitions(gazebo_physics
   PRIVATE BUILDING_DLL_GZ_PHYSICS
 )
 
+if (${IGN_PROFILER_ENABLE})
+  target_compile_definitions(gazebo_physics PUBLIC "IGN_PROFILER_ENABLE=1")
+  set(IGN_PROFILE_LIBS ${IGNITION-COMMON_LIBRARIES})
+  target_include_directories(gazebo_physics PUBLIC ${ignition-common3_INCLUDE_DIRS})
+endif()
+
 target_link_libraries(gazebo_physics
   gazebo_common
   gazebo_util
@@ -165,6 +171,7 @@ target_link_libraries(gazebo_physics
   gazebo_opcode
   ${Boost_LIBRARIES}
   ${IGNITION-TRANSPORT_LIBRARIES}
+  ${IGN_PROFILE_LIBS}
 )
 
 # Link in Bullet support if present

--- a/gazebo/physics/CMakeLists.txt
+++ b/gazebo/physics/CMakeLists.txt
@@ -158,10 +158,8 @@ target_compile_definitions(gazebo_physics
   PRIVATE BUILDING_DLL_GZ_PHYSICS
 )
 
-if (${IGN_PROFILER_ENABLE})
-  target_compile_definitions(gazebo_physics PUBLIC "IGN_PROFILER_ENABLE=1")
+if (${ENABLE_PROFILER})
   set(IGN_PROFILE_LIBS ${IGNITION-COMMON_LIBRARIES})
-  target_include_directories(gazebo_physics PUBLIC ${ignition-common3_INCLUDE_DIRS})
 endif()
 
 target_link_libraries(gazebo_physics

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -670,7 +670,7 @@ void World::Step()
   DIAG_TIMER_START("World::Step");
 
   IGN_PROFILE("World::Step");
-  IGN_PROFILE_BEGIN("World::loadPlugins");
+  IGN_PROFILE_BEGIN("loadPlugins");
   /// need this because ODE does not call dxReallocateWorldProcessContext()
   /// until dWorld.*Step
   /// Plugins that manipulate joints (and probably other properties) require
@@ -684,14 +684,14 @@ void World::Step()
   IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Step", "loadPlugins");
 
-  IGN_PROFILE_BEGIN("World::publishWorldStats");
+  IGN_PROFILE_BEGIN("publishWorldStats");
   // Send statistics about the world simulation
   this->PublishWorldStats();
   IGN_PROFILE_END();
 
   DIAG_TIMER_LAP("World::Step", "publishWorldStats");
 
-  IGN_PROFILE_BEGIN("World::sleepOffset");
+  IGN_PROFILE_BEGIN("sleepOffset");
   double updatePeriod = this->dataPtr->physicsEngine->GetUpdatePeriod();
   // sleep here to get the correct update rate
   common::Time tmpTime = common::Time::GetWallTime();
@@ -714,7 +714,7 @@ void World::Step()
   IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Step", "sleepOffset");
 
-  IGN_PROFILE_BEGIN("World::worldUpdateMutex");
+  IGN_PROFILE_BEGIN("worldUpdateMutex");
   // throttling update rate, with sleepOffset as tolerance
   // the tolerance is needed as the sleep time is not exact
   if (common::Time::GetWallTime() - this->dataPtr->prevStepWallTime +
@@ -751,7 +751,7 @@ void World::Step()
   }
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("World::Step");
+  IGN_PROFILE_BEGIN("Step");
 
   gazebo::util::IntrospectionManager::Instance()->NotifyUpdates();
 
@@ -795,7 +795,7 @@ void World::Update()
   DIAG_TIMER_START("World::Update");
 
   IGN_PROFILE("World::Update");
-  IGN_PROFILE_BEGIN("World::Events::needsReset");
+  IGN_PROFILE_BEGIN("needsReset");
   if (this->dataPtr->needsReset)
   {
     if (this->dataPtr->resetAll)
@@ -810,26 +810,26 @@ void World::Update()
   IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "needsReset");
 
-  IGN_PROFILE_BEGIN("World::Events::worldUpdateBegin");
+  IGN_PROFILE_BEGIN("worldUpdateBegin");
   this->dataPtr->updateInfo.simTime = this->SimTime();
   this->dataPtr->updateInfo.realTime = this->RealTime();
   event::Events::worldUpdateBegin(this->dataPtr->updateInfo);
   IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "Events::worldUpdateBegin");
 
-  IGN_PROFILE_BEGIN("World::Model::Update");
+  IGN_PROFILE_BEGIN("Update");
   // Update all the models
   (*this.*dataPtr->modelUpdateFunc)();
   IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "Model::Update");
 
-  IGN_PROFILE_BEGIN("World::PhysicsEngine::UpdateCollision");
+  IGN_PROFILE_BEGIN("UpdateCollision");
   // This must be called before PhysicsEngine::UpdatePhysics for ODE.
   this->dataPtr->physicsEngine->UpdateCollision();
   IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "PhysicsEngine::UpdateCollision");
 
-  IGN_PROFILE_BEGIN("World::PhysicsEngine::beforePhysicsUpdate");
+  IGN_PROFILE_BEGIN("beforePhysicsUpdate");
   // Wait for logging to finish, if it's running.
   if (util::LogRecord::Instance()->Running())
   {
@@ -856,7 +856,7 @@ void World::Update()
   // Update the physics engine
   if (this->dataPtr->enablePhysicsEngine && this->dataPtr->physicsEngine)
   {
-    IGN_PROFILE_BEGIN("World::PhysicsEngine::UpdatePhysics");
+    IGN_PROFILE_BEGIN("UpdatePhysics");
     // This must be called directly after PhysicsEngine::UpdateCollision.
     this->dataPtr->physicsEngine->UpdatePhysics();
 
@@ -867,7 +867,7 @@ void World::Update()
     //   ode --> MoveCallback sets the dirtyPoses
     //           and we need to propagate it into Entity::worldPose
     {
-      IGN_PROFILE_BEGIN("World::SetWorldPose(dirtyPoses)");
+      IGN_PROFILE_BEGIN("SetWorldPose(dirtyPoses)");
       // block any other pose updates (e.g. Joint::SetPosition)
       boost::recursive_mutex::scoped_lock plock(
           *this->Physics()->GetPhysicsUpdateMutex());
@@ -884,14 +884,14 @@ void World::Update()
     DIAG_TIMER_LAP("World::Update", "SetWorldPose(dirtyPoses)");
   }
 
-  IGN_PROFILE_BEGIN("World::LogRecordNotify");
+  IGN_PROFILE_BEGIN("LogRecordNotify");
   // Only update state information if logging data.
   if (util::LogRecord::Instance()->Running())
     this->dataPtr->logCondition.notify_one();
   IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "LogRecordNotify");
 
-  IGN_PROFILE_BEGIN("World::ContactManager::PublishContacts");
+  IGN_PROFILE_BEGIN("PublishContacts");
   // Output the contact information
   this->dataPtr->physicsEngine->GetContactManager()->PublishContacts();
 

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -36,6 +36,7 @@
 #include <ignition/msgs/plugin_v.pb.h>
 #include <ignition/msgs/stringmsg.pb.h>
 
+#include "ignition/common/Profiler.hh"
 #include <ignition/common/URI.hh>
 #include "gazebo/common/FuelModelDatabase.hh"
 
@@ -668,6 +669,8 @@ void World::Step()
 {
   DIAG_TIMER_START("World::Step");
 
+  IGN_PROFILE("World::Step");
+  IGN_PROFILE_BEGIN("World::loadPlugins");
   /// need this because ODE does not call dxReallocateWorldProcessContext()
   /// until dWorld.*Step
   /// Plugins that manipulate joints (and probably other properties) require
@@ -678,13 +681,17 @@ void World::Step()
     this->dataPtr->pluginsLoaded = true;
   }
 
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Step", "loadPlugins");
 
+  IGN_PROFILE_BEGIN("World::publishWorldStats");
   // Send statistics about the world simulation
   this->PublishWorldStats();
+  IGN_PROFILE_END();
 
   DIAG_TIMER_LAP("World::Step", "publishWorldStats");
 
+  IGN_PROFILE_BEGIN("World::sleepOffset");
   double updatePeriod = this->dataPtr->physicsEngine->GetUpdatePeriod();
   // sleep here to get the correct update rate
   common::Time tmpTime = common::Time::GetWallTime();
@@ -704,8 +711,10 @@ void World::Step()
   this->dataPtr->sleepOffset = (actualSleep - sleepTime) * 0.01 +
                       this->dataPtr->sleepOffset * 0.99;
 
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Step", "sleepOffset");
 
+  IGN_PROFILE_BEGIN("World::worldUpdateMutex");
   // throttling update rate, with sleepOffset as tolerance
   // the tolerance is needed as the sleep time is not exact
   if (common::Time::GetWallTime() - this->dataPtr->prevStepWallTime +
@@ -740,6 +749,9 @@ void World::Step()
       this->dataPtr->pauseTime += stepTime;
     }
   }
+  IGN_PROFILE_END();
+
+  IGN_PROFILE_BEGIN("World::Step");
 
   gazebo::util::IntrospectionManager::Instance()->NotifyUpdates();
 
@@ -749,6 +761,7 @@ void World::Step()
 
   if (g_clearModels)
     this->ClearModels();
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////
@@ -781,6 +794,8 @@ void World::Update()
 {
   DIAG_TIMER_START("World::Update");
 
+  IGN_PROFILE("World::Update");
+  IGN_PROFILE_BEGIN("World::Events::needsReset");
   if (this->dataPtr->needsReset)
   {
     if (this->dataPtr->resetAll)
@@ -792,24 +807,29 @@ void World::Update()
     this->dataPtr->needsReset = false;
     return;
   }
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "needsReset");
 
+  IGN_PROFILE_BEGIN("World::Events::worldUpdateBegin");
   this->dataPtr->updateInfo.simTime = this->SimTime();
   this->dataPtr->updateInfo.realTime = this->RealTime();
   event::Events::worldUpdateBegin(this->dataPtr->updateInfo);
-
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "Events::worldUpdateBegin");
 
+  IGN_PROFILE_BEGIN("World::Model::Update");
   // Update all the models
   (*this.*dataPtr->modelUpdateFunc)();
-
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "Model::Update");
 
+  IGN_PROFILE_BEGIN("World::PhysicsEngine::UpdateCollision");
   // This must be called before PhysicsEngine::UpdatePhysics for ODE.
   this->dataPtr->physicsEngine->UpdateCollision();
-
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "PhysicsEngine::UpdateCollision");
 
+  IGN_PROFILE_BEGIN("World::PhysicsEngine::beforePhysicsUpdate");
   // Wait for logging to finish, if it's running.
   if (util::LogRecord::Instance()->Running())
   {
@@ -830,20 +850,24 @@ void World::Update()
   this->dataPtr->updateInfo.realTime = this->RealTime();
   event::Events::beforePhysicsUpdate(this->dataPtr->updateInfo);
 
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "Events::beforePhysicsUpdate");
 
   // Update the physics engine
   if (this->dataPtr->enablePhysicsEngine && this->dataPtr->physicsEngine)
   {
+    IGN_PROFILE_BEGIN("World::PhysicsEngine::UpdatePhysics");
     // This must be called directly after PhysicsEngine::UpdateCollision.
     this->dataPtr->physicsEngine->UpdatePhysics();
 
+    IGN_PROFILE_END();
     DIAG_TIMER_LAP("World::Update", "PhysicsEngine::UpdatePhysics");
 
     // do this after physics update as
     //   ode --> MoveCallback sets the dirtyPoses
     //           and we need to propagate it into Entity::worldPose
     {
+      IGN_PROFILE_BEGIN("World::SetWorldPose(dirtyPoses)");
       // block any other pose updates (e.g. Joint::SetPosition)
       boost::recursive_mutex::scoped_lock plock(
           *this->Physics()->GetPhysicsUpdateMutex());
@@ -854,19 +878,24 @@ void World::Update()
       }
 
       this->dataPtr->dirtyPoses.clear();
+      IGN_PROFILE_END();
     }
 
     DIAG_TIMER_LAP("World::Update", "SetWorldPose(dirtyPoses)");
   }
 
+  IGN_PROFILE_BEGIN("World::LogRecordNotify");
   // Only update state information if logging data.
   if (util::LogRecord::Instance()->Running())
     this->dataPtr->logCondition.notify_one();
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "LogRecordNotify");
 
+  IGN_PROFILE_BEGIN("World::ContactManager::PublishContacts");
   // Output the contact information
   this->dataPtr->physicsEngine->GetContactManager()->PublishContacts();
 
+  IGN_PROFILE_END();
   DIAG_TIMER_LAP("World::Update", "ContactManager::PublishContacts");
 
   event::Events::worldUpdateEnd();

--- a/gazebo/physics/bullet/BulletPhysics.cc
+++ b/gazebo/physics/bullet/BulletPhysics.cc
@@ -524,7 +524,7 @@ void BulletPhysics::UpdatePhysics()
   // need to lock, otherwise might conflict with world resetting
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);
 
-  IGN_PROFILE_BEGIN("BulletPhysics:stepSimulation");
+  IGN_PROFILE_BEGIN("stepSimulation");
   this->dynamicsWorld->stepSimulation(
     this->maxStepSize, 1, this->maxStepSize);
   IGN_PROFILE_END();

--- a/gazebo/physics/bullet/BulletPhysics.cc
+++ b/gazebo/physics/bullet/BulletPhysics.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <string>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Rand.hh>
 
 #include "gazebo/physics/bullet/BulletTypes.hh"
@@ -384,6 +385,7 @@ void BulletPhysics::Init()
 //////////////////////////////////////////////////
 void BulletPhysics::InitForThread()
 {
+  IGN_PROFILE_THREAD_NAME("BullerPhysics");
 }
 
 /////////////////////////////////////////////////
@@ -485,6 +487,8 @@ void BulletPhysics::OnPhysicsMsg(ConstPhysicsPtr &_msg)
 //////////////////////////////////////////////////
 void BulletPhysics::UpdateCollision()
 {
+  IGN_PROFILE("BulletPhysics:UpdateCollision");
+
   this->contactManager->ResetCount();
 
   if (!this->world->PhysicsEnabled())
@@ -499,21 +503,31 @@ void BulletPhysics::UpdateCollision()
     // points to happen. So because UpdatePhysics() won't be
     // called, we have to do this here with
     // this->dynamicsWorld->performDiscreteCollisionDetection().
+
+    IGN_PROFILE_BEGIN("performDiscreteCollisionDetection");
     this->dynamicsWorld->performDiscreteCollisionDetection();
+    IGN_PROFILE_END();
+
     // In addition, the contacts have to be updated in the contact
     // manager and for the feedback.
+    IGN_PROFILE_BEGIN("UpdateContacts");
     UpdateContacts(this->dynamicsWorld, this->maxStepSize);
+    IGN_PROFILE_END();
   }
 }
 
 //////////////////////////////////////////////////
 void BulletPhysics::UpdatePhysics()
 {
+  IGN_PROFILE("BulletPhysics:UpdatePhysics");
+
   // need to lock, otherwise might conflict with world resetting
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);
 
+  IGN_PROFILE_BEGIN("BulletPhysics:stepSimulation");
   this->dynamicsWorld->stepSimulation(
     this->maxStepSize, 1, this->maxStepSize);
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/dart/DARTPhysics.cc
+++ b/gazebo/physics/dart/DARTPhysics.cc
@@ -25,6 +25,8 @@
 #include <dart/collision/dart/dart.hpp>
 #include <dart/collision/fcl/fcl.hpp>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/Assert.hh"
 #include "gazebo/common/Console.hh"
 #include "gazebo/common/Exception.hh"
@@ -125,6 +127,7 @@ void DARTPhysics::Reset()
 //////////////////////////////////////////////////
 void DARTPhysics::InitForThread()
 {
+  IGN_PROFILE_THREAD_NAME("DARTPhysics");
 }
 
 
@@ -411,6 +414,9 @@ static void RetrieveDARTCollisions(
 //////////////////////////////////////////////////
 void DARTPhysics::UpdateCollision()
 {
+  IGN_PROFILE("DARTPhysics::UpdateCollision");
+  IGN_PROFILE_BEGIN("DARTPhysics::UpdateCollision");
+
   if (!this->world->PhysicsEnabled())
   {
     dart::collision::CollisionResult localResult;
@@ -427,11 +433,15 @@ void DARTPhysics::UpdateCollision()
 
     RetrieveDARTCollisions(this, &localResult, this->GetContactManager());
   }
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////
 void DARTPhysics::UpdatePhysics()
 {
+  IGN_PROFILE("DARTPhysics::UpdatePhysics");
+  IGN_PROFILE_BEGIN("DARTPhysics::Update");
+
   // need to lock, otherwise might conflict with world resetting
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);
 
@@ -466,6 +476,7 @@ void DARTPhysics::UpdatePhysics()
         this,
         &(this->dataPtr->dtWorld->getLastCollisionResult()),
         this->GetContactManager());
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////
@@ -880,4 +891,3 @@ DARTLinkPtr DARTPhysics::FindDARTLink(
 {
   return StaticFindDARTLink(this, _dtBodyNode);
 }
-

--- a/gazebo/physics/dart/DARTPhysics.cc
+++ b/gazebo/physics/dart/DARTPhysics.cc
@@ -415,7 +415,7 @@ static void RetrieveDARTCollisions(
 void DARTPhysics::UpdateCollision()
 {
   IGN_PROFILE("DARTPhysics::UpdateCollision");
-  IGN_PROFILE_BEGIN("DARTPhysics::UpdateCollision");
+  IGN_PROFILE_BEGIN("UpdateCollision");
 
   if (!this->world->PhysicsEnabled())
   {
@@ -440,7 +440,7 @@ void DARTPhysics::UpdateCollision()
 void DARTPhysics::UpdatePhysics()
 {
   IGN_PROFILE("DARTPhysics::UpdatePhysics");
-  IGN_PROFILE_BEGIN("DARTPhysics::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   // need to lock, otherwise might conflict with world resetting
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);

--- a/gazebo/physics/ode/ODEPhysics.cc
+++ b/gazebo/physics/ode/ODEPhysics.cc
@@ -400,7 +400,7 @@ void ODEPhysics::UpdateCollision()
     ODECollision *collision2 = this->dataPtr->trimeshColliders[i].second;
     this->Collide(collision1, collision2, this->dataPtr->contactCollisions);
   }
-  DIAG_TIMER_LAP("ODEPhysics::UpdateCollision", "collideTrimeshes");
+  DIAG_TIMER_LAP("UpdateCollision", "collideTrimeshes");
   IGN_PROFILE_END();
 
   DIAG_TIMER_STOP("ODEPhysics::UpdateCollision");
@@ -947,7 +947,7 @@ void ODEPhysics::SetGravity(const ignition::math::Vector3d &_gravity)
 //////////////////////////////////////////////////
 void ODEPhysics::CollisionCallback(void *_data, dGeomID _o1, dGeomID _o2)
 {
-  IGN_PROFILE("CollisionCallback");
+  IGN_PROFILE("ODEPhysics::CollisionCallback");
   dBodyID b1 = dGeomGetBody(_o1);
   dBodyID b2 = dGeomGetBody(_o2);
 

--- a/gazebo/physics/ode/ODEPhysics.cc
+++ b/gazebo/physics/ode/ODEPhysics.cc
@@ -28,6 +28,7 @@
 
 #include <ignition/math/Rand.hh>
 #include <ignition/math/Vector3.hh>
+#include <ignition/common/Profiler.hh>
 
 #include "gazebo/util/Diagnostics.hh"
 #include "gazebo/common/Assert.hh"
@@ -352,6 +353,7 @@ void ODEPhysics::Init()
 //////////////////////////////////////////////////
 void ODEPhysics::InitForThread()
 {
+  IGN_PROFILE_THREAD_NAME("ODEPhysics");
   dAllocateODEDataForThread(dAllocateMaskAll);
 }
 
@@ -359,6 +361,8 @@ void ODEPhysics::InitForThread()
 void ODEPhysics::UpdateCollision()
 {
   DIAG_TIMER_START("ODEPhysics::UpdateCollision");
+  IGN_PROFILE("ODEPhysics:UpdateCollision");
+  IGN_PROFILE_BEGIN("dSpaceCollide");
 
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);
   dJointGroupEmpty(this->dataPtr->contactGroup);
@@ -374,7 +378,9 @@ void ODEPhysics::UpdateCollision()
   // Do collision detection; this will add contacts to the contact group
   dSpaceCollide(this->dataPtr->spaceId, this, CollisionCallback);
   DIAG_TIMER_LAP("ODEPhysics::UpdateCollision", "dSpaceCollide");
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("collideShapes");
   // Generate non-trimesh collisions.
   for (i = 0; i < this->dataPtr->collidersCount; ++i)
   {
@@ -382,7 +388,10 @@ void ODEPhysics::UpdateCollision()
         this->dataPtr->colliders[i].second, this->dataPtr->contactCollisions);
   }
   DIAG_TIMER_LAP("ODEPhysics::UpdateCollision", "collideShapes");
+  IGN_PROFILE_END();
 
+
+  IGN_PROFILE_BEGIN("collideTrimeshes");
   // Generate trimesh collision.
   // This must happen in this thread sequentially
   for (i = 0; i < this->dataPtr->trimeshCollidersCount; ++i)
@@ -392,6 +401,7 @@ void ODEPhysics::UpdateCollision()
     this->Collide(collision1, collision2, this->dataPtr->contactCollisions);
   }
   DIAG_TIMER_LAP("ODEPhysics::UpdateCollision", "collideTrimeshes");
+  IGN_PROFILE_END();
 
   DIAG_TIMER_STOP("ODEPhysics::UpdateCollision");
 }
@@ -400,6 +410,7 @@ void ODEPhysics::UpdateCollision()
 void ODEPhysics::UpdatePhysics()
 {
   DIAG_TIMER_START("ODEPhysics::UpdatePhysics");
+  IGN_PROFILE("ODEPhysics:UpdatePhysics");
 
   // need to lock, otherwise might conflict with world resetting
   {
@@ -936,6 +947,7 @@ void ODEPhysics::SetGravity(const ignition::math::Vector3d &_gravity)
 //////////////////////////////////////////////////
 void ODEPhysics::CollisionCallback(void *_data, dGeomID _o1, dGeomID _o2)
 {
+  IGN_PROFILE("CollisionCallback");
   dBodyID b1 = dGeomGetBody(_o1);
   dBodyID b2 = dGeomGetBody(_o2);
 

--- a/gazebo/physics/simbody/SimbodyPhysics.cc
+++ b/gazebo/physics/simbody/SimbodyPhysics.cc
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/physics/simbody/SimbodyTypes.hh"
 #include "gazebo/physics/simbody/SimbodyModel.hh"
 #include "gazebo/physics/simbody/SimbodyLink.hh"
@@ -404,11 +406,14 @@ void SimbodyPhysics::InitModel(const physics::ModelPtr _model)
 //////////////////////////////////////////////////
 void SimbodyPhysics::InitForThread()
 {
+  IGN_PROFILE_THREAD_NAME("SimbodyPhysics");
 }
 
 //////////////////////////////////////////////////
 void SimbodyPhysics::UpdateCollision()
 {
+  IGN_PROFILE("SimbodyPhysics::UpdateCollision");
+  IGN_PROFILE_BEGIN("SimbodyPhysics::UpdateCollision");
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);
 
   this->contactManager->ResetCount();
@@ -632,11 +637,15 @@ void SimbodyPhysics::UpdateCollision()
       }
     }
   }
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////
 void SimbodyPhysics::UpdatePhysics()
 {
+  IGN_PROFILE("SimbodyPhysics::UpdatePhysics");
+  IGN_PROFILE_BEGIN("SimbodyPhysics::UpdatePhysics");
+
   // need to lock, otherwise might conflict with world resetting
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);
 
@@ -705,6 +714,7 @@ void SimbodyPhysics::UpdatePhysics()
   // FIXME:  this needs to happen before forces are applied for the next step
   // FIXME:  but after we've gotten everything from current state
   this->discreteForces.clearAllForces(this->integ->updAdvancedState());
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/simbody/SimbodyPhysics.cc
+++ b/gazebo/physics/simbody/SimbodyPhysics.cc
@@ -413,7 +413,7 @@ void SimbodyPhysics::InitForThread()
 void SimbodyPhysics::UpdateCollision()
 {
   IGN_PROFILE("SimbodyPhysics::UpdateCollision");
-  IGN_PROFILE_BEGIN("SimbodyPhysics::UpdateCollision");
+  IGN_PROFILE_BEGIN("UpdateCollision");
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);
 
   this->contactManager->ResetCount();
@@ -644,7 +644,7 @@ void SimbodyPhysics::UpdateCollision()
 void SimbodyPhysics::UpdatePhysics()
 {
   IGN_PROFILE("SimbodyPhysics::UpdatePhysics");
-  IGN_PROFILE_BEGIN("SimbodyPhysics::UpdatePhysics");
+  IGN_PROFILE_BEGIN("UpdatePhysics");
 
   // need to lock, otherwise might conflict with world resetting
   boost::recursive_mutex::scoped_lock lock(*this->physicsUpdateMutex);

--- a/gazebo/rendering/CMakeLists.txt
+++ b/gazebo/rendering/CMakeLists.txt
@@ -219,10 +219,8 @@ target_compile_definitions(gazebo_rendering
   PRIVATE BUILDING_DLL_GZ_RENDERING
 )
 
-if (${IGN_PROFILER_ENABLE})
-  target_compile_definitions(gazebo_rendering PUBLIC "IGN_PROFILER_ENABLE=1")
+if (${ENABLE_PROFILER})
   set(IGN_PROFILE_LIBS ${IGNITION-COMMON_LIBRARIES})
-  target_include_directories(gazebo_rendering PUBLIC ${ignition-common3_INCLUDE_DIRS})
 endif()
 
 target_link_libraries(gazebo_rendering

--- a/gazebo/rendering/CMakeLists.txt
+++ b/gazebo/rendering/CMakeLists.txt
@@ -219,6 +219,12 @@ target_compile_definitions(gazebo_rendering
   PRIVATE BUILDING_DLL_GZ_RENDERING
 )
 
+if (${IGN_PROFILER_ENABLE})
+  target_compile_definitions(gazebo_rendering PUBLIC "IGN_PROFILER_ENABLE=1")
+  set(IGN_PROFILE_LIBS ${IGNITION-COMMON_LIBRARIES})
+  target_include_directories(gazebo_rendering PUBLIC ${ignition-common3_INCLUDE_DIRS})
+endif()
+
 target_link_libraries(gazebo_rendering
   gazebo_common
   gazebo_msgs
@@ -228,6 +234,7 @@ target_link_libraries(gazebo_rendering
   ${tinyxml_LIBRARIES}
   ${IGNITION-TRANSPORT_LIBRARIES}
   ${IGNITION-MSGS_LIBRARIES}
+  ${IGN_PROFILE_LIBS}
 )
 
 if (HAVE_OCULUS)

--- a/gazebo/sensors/AltimeterSensor.cc
+++ b/gazebo/sensors/AltimeterSensor.cc
@@ -125,8 +125,8 @@ void AltimeterSensor::Init()
 //////////////////////////////////////////////////
 bool AltimeterSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("AltimeterSensor");
-  IGN_PROFILE_BEGIN("AltimeterSensor::update");
+  IGN_PROFILE("AltimeterSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   // Get latest pose information
@@ -167,7 +167,7 @@ bool AltimeterSensor::UpdateImpl(const bool /*_force*/)
     }
   }
   IGN_PROFILE_END();
-  IGN_PROFILE_BEGIN("AltimeterSensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
   // Save the time of the measurement
   msgs::Set(this->dataPtr->altMsg.mutable_time(), this->world->SimTime());
 

--- a/gazebo/sensors/AltimeterSensor.cc
+++ b/gazebo/sensors/AltimeterSensor.cc
@@ -15,6 +15,9 @@
  *
 */
 #include <boost/algorithm/string.hpp>
+
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/common.hh"
 #include "gazebo/physics/physics.hh"
 #include "gazebo/transport/transport.hh"
@@ -122,6 +125,8 @@ void AltimeterSensor::Init()
 //////////////////////////////////////////////////
 bool AltimeterSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("AltimeterSensor");
+  IGN_PROFILE_BEGIN("AltimeterSensor::update");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   // Get latest pose information
@@ -161,14 +166,15 @@ bool AltimeterSensor::UpdateImpl(const bool /*_force*/)
       this->dataPtr->altMsg.set_vertical_velocity(altVel.Z());
     }
   }
-
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("AltimeterSensor::publish");
   // Save the time of the measurement
   msgs::Set(this->dataPtr->altMsg.mutable_time(), this->world->SimTime());
 
   // Publish the message if needed
   if (this->dataPtr->altPub)
     this->dataPtr->altPub->Publish(this->dataPtr->altMsg);
-
+  IGN_PROFILE_END();
   return true;
 }
 

--- a/gazebo/sensors/CameraSensor.cc
+++ b/gazebo/sensors/CameraSensor.cc
@@ -225,16 +225,16 @@ void CameraSensor::Render()
 //////////////////////////////////////////////////
 bool CameraSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("CameraSensor");
+  IGN_PROFILE("CameraSensor::UpdateImpl");
 
   if (!this->dataPtr->rendered)
     return false;
 
-  IGN_PROFILE_BEGIN("CameraSensor::PostRender");
+  IGN_PROFILE_BEGIN("PostRender");
   this->camera->PostRender();
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("DepthCameraSensor::fillarray");
+  IGN_PROFILE_BEGIN("fillarray");
 
   if ((this->imagePub && this->imagePub->HasConnections()) ||
       this->imagePubIgn.HasConnections())
@@ -375,4 +375,3 @@ void CameraSensor::ResetLastUpdateTime()
 {
   Sensor::ResetLastUpdateTime();
 }
-

--- a/gazebo/sensors/CameraSensor.cc
+++ b/gazebo/sensors/CameraSensor.cc
@@ -16,7 +16,7 @@
 */
 #include <boost/algorithm/string.hpp>
 #include <functional>
-
+#include <ignition/common/Profiler.hh>
 #include <ignition/msgs/Utility.hh>
 
 #include "gazebo/common/Events.hh"
@@ -225,11 +225,16 @@ void CameraSensor::Render()
 //////////////////////////////////////////////////
 bool CameraSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("CameraSensor");
+
   if (!this->dataPtr->rendered)
     return false;
 
+  IGN_PROFILE_BEGIN("CameraSensor::PostRender");
   this->camera->PostRender();
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("DepthCameraSensor::fillarray");
 
   if ((this->imagePub && this->imagePub->HasConnections()) ||
       this->imagePubIgn.HasConnections())
@@ -275,6 +280,7 @@ bool CameraSensor::UpdateImpl(const bool /*_force*/)
   }
 
   this->dataPtr->rendered = false;
+  IGN_PROFILE_END();
   return true;
 }
 

--- a/gazebo/sensors/ContactSensor.cc
+++ b/gazebo/sensors/ContactSensor.cc
@@ -133,8 +133,8 @@ void ContactSensor::Init()
 //////////////////////////////////////////////////
 bool ContactSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("ContactSensor");
-  IGN_PROFILE_BEGIN("ContactSensor::update");
+  IGN_PROFILE("ContactSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
@@ -192,7 +192,7 @@ bool ContactSensor::UpdateImpl(const bool /*_force*/)
   }
 
   IGN_PROFILE_END();
-  IGN_PROFILE_BEGIN("ContactSensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
 
   // Clear the incoming contact list.
   this->dataPtr->incomingContacts.clear();

--- a/gazebo/sensors/ContactSensor.cc
+++ b/gazebo/sensors/ContactSensor.cc
@@ -17,6 +17,8 @@
 #include <boost/algorithm/string.hpp>
 #include <sstream>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/Exception.hh"
 
 #include "gazebo/transport/Node.hh"
@@ -131,6 +133,9 @@ void ContactSensor::Init()
 //////////////////////////////////////////////////
 bool ContactSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("ContactSensor");
+  IGN_PROFILE_BEGIN("ContactSensor::update");
+
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   // Don't do anything if there is no new data to process.
@@ -186,6 +191,9 @@ bool ContactSensor::UpdateImpl(const bool /*_force*/)
     }
   }
 
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("ContactSensor::publish");
+
   // Clear the incoming contact list.
   this->dataPtr->incomingContacts.clear();
 
@@ -200,6 +208,7 @@ bool ContactSensor::UpdateImpl(const bool /*_force*/)
     this->dataPtr->contactsPub->Publish(this->dataPtr->contactsMsg);
   }
 
+  IGN_PROFILE_END();
   return true;
 }
 

--- a/gazebo/sensors/DepthCameraSensor.cc
+++ b/gazebo/sensors/DepthCameraSensor.cc
@@ -16,6 +16,8 @@
 */
 #include <functional>
 
+#include "ignition/common/Profiler.hh"
+
 #include "gazebo/physics/World.hh"
 
 #include "gazebo/rendering/DepthCamera.hh"
@@ -132,10 +134,15 @@ void DepthCameraSensor::Init()
 //////////////////////////////////////////////////
 bool DepthCameraSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("DepthCameraSensor");
   if (!this->Rendered())
     return false;
 
+  IGN_PROFILE_BEGIN("DepthCameraSensor::PostRender");
   this->camera->PostRender();
+  IGN_PROFILE_END();
+
+  IGN_PROFILE_BEGIN("DepthCameraSensor::fillarray");
 
   if (this->imagePub && this->imagePub->HasConnections() &&
       // check if depth data is available. If not, the depth camera could be
@@ -180,6 +187,7 @@ bool DepthCameraSensor::UpdateImpl(const bool /*_force*/)
   }
 
   this->SetRendered(false);
+  IGN_PROFILE_END();
   return true;
 }
 

--- a/gazebo/sensors/DepthCameraSensor.cc
+++ b/gazebo/sensors/DepthCameraSensor.cc
@@ -134,15 +134,15 @@ void DepthCameraSensor::Init()
 //////////////////////////////////////////////////
 bool DepthCameraSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("DepthCameraSensor");
+  IGN_PROFILE("DepthCameraSensor::UpdateImpl");
   if (!this->Rendered())
     return false;
 
-  IGN_PROFILE_BEGIN("DepthCameraSensor::PostRender");
+  IGN_PROFILE_BEGIN("PostRender");
   this->camera->PostRender();
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("DepthCameraSensor::fillarray");
+  IGN_PROFILE_BEGIN("fillarray");
 
   if (this->imagePub && this->imagePub->HasConnections() &&
       // check if depth data is available. If not, the depth camera could be

--- a/gazebo/sensors/ForceTorqueSensor.cc
+++ b/gazebo/sensors/ForceTorqueSensor.cc
@@ -16,6 +16,8 @@
 */
 #include <boost/algorithm/string.hpp>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/physics/World.hh"
 #include "gazebo/physics/PhysicsEngine.hh"
 #include "gazebo/physics/Joint.hh"
@@ -200,6 +202,9 @@ ignition::math::Vector3d ForceTorqueSensor::Torque() const
 //////////////////////////////////////////////////
 bool ForceTorqueSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("ForceTorqueSensor");
+  IGN_PROFILE_BEGIN("ForceTorqueSensor::update");
+
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   this->lastMeasurementTime = this->world->SimTime();
@@ -259,6 +264,9 @@ bool ForceTorqueSensor::UpdateImpl(const bool /*_force*/)
     }
   }
 
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("ForceTorqueSensor::publish");
+
   msgs::Set(this->dataPtr->wrenchMsg.mutable_wrench()->mutable_force(),
       measuredForce);
   msgs::Set(this->dataPtr->wrenchMsg.mutable_wrench()->mutable_torque(),
@@ -268,6 +276,7 @@ bool ForceTorqueSensor::UpdateImpl(const bool /*_force*/)
 
   if (this->dataPtr->wrenchPub)
     this->dataPtr->wrenchPub->Publish(this->dataPtr->wrenchMsg);
+  IGN_PROFILE_END();
 
   return true;
 }

--- a/gazebo/sensors/ForceTorqueSensor.cc
+++ b/gazebo/sensors/ForceTorqueSensor.cc
@@ -202,8 +202,8 @@ ignition::math::Vector3d ForceTorqueSensor::Torque() const
 //////////////////////////////////////////////////
 bool ForceTorqueSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("ForceTorqueSensor");
-  IGN_PROFILE_BEGIN("ForceTorqueSensor::update");
+  IGN_PROFILE("ForceTorqueSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
@@ -265,7 +265,7 @@ bool ForceTorqueSensor::UpdateImpl(const bool /*_force*/)
   }
 
   IGN_PROFILE_END();
-  IGN_PROFILE_BEGIN("ForceTorqueSensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
 
   msgs::Set(this->dataPtr->wrenchMsg.mutable_wrench()->mutable_force(),
       measuredForce);

--- a/gazebo/sensors/GpsSensor.cc
+++ b/gazebo/sensors/GpsSensor.cc
@@ -16,6 +16,8 @@
 */
 #include <boost/algorithm/string.hpp>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/sensors/SensorFactory.hh"
 
 #include "gazebo/common/common.hh"
@@ -123,6 +125,9 @@ void GpsSensor::Init()
 //////////////////////////////////////////////////
 bool GpsSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("GpsSensor");
+
+  IGN_PROFILE_BEGIN("GpsSensor::update");
   // Get latest pose information
   if (this->dataPtr->parentLink)
   {
@@ -179,10 +184,12 @@ bool GpsSensor::UpdateImpl(const bool /*_force*/)
   this->lastMeasurementTime = this->world->SimTime();
   msgs::Set(this->dataPtr->lastGpsMsg.mutable_time(),
       this->lastMeasurementTime);
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("GpsSensor::publish");
   if (this->dataPtr->gpsPub)
     this->dataPtr->gpsPub->Publish(this->dataPtr->lastGpsMsg);
-
+  IGN_PROFILE_END();
   return true;
 }
 

--- a/gazebo/sensors/GpsSensor.cc
+++ b/gazebo/sensors/GpsSensor.cc
@@ -125,9 +125,9 @@ void GpsSensor::Init()
 //////////////////////////////////////////////////
 bool GpsSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("GpsSensor");
+  IGN_PROFILE("GpsSensor::UpdateImpl");
 
-  IGN_PROFILE_BEGIN("GpsSensor::update");
+  IGN_PROFILE_BEGIN("Update");
   // Get latest pose information
   if (this->dataPtr->parentLink)
   {
@@ -186,7 +186,7 @@ bool GpsSensor::UpdateImpl(const bool /*_force*/)
       this->lastMeasurementTime);
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("GpsSensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
   if (this->dataPtr->gpsPub)
     this->dataPtr->gpsPub->Publish(this->dataPtr->lastGpsMsg);
   IGN_PROFILE_END();

--- a/gazebo/sensors/GpuRaySensor.cc
+++ b/gazebo/sensors/GpuRaySensor.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <boost/algorithm/string.hpp>
+#include <ignition/common/Profiler.hh>
 #include <functional>
 #include <ignition/math.hh>
 #include <ignition/math/Helpers.hh>
@@ -597,10 +598,15 @@ void GpuRaySensor::Render()
 //////////////////////////////////////////////////
 bool GpuRaySensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("GpuRaySensor");
+
   if (!this->dataPtr->rendered)
     return false;
-
+  IGN_PROFILE_BEGIN("GpuRaySensor::PostRender");
   this->dataPtr->laserCam->PostRender();
+  IGN_PROFILE_END();
+
+  IGN_PROFILE_BEGIN("GpuRaySensor::fillarray");
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
@@ -672,7 +678,7 @@ bool GpuRaySensor::UpdateImpl(const bool /*_force*/)
     this->dataPtr->scanPub->Publish(this->dataPtr->laserMsg);
 
   this->dataPtr->rendered = false;
-
+  IGN_PROFILE_END();
   return true;
 }
 

--- a/gazebo/sensors/GpuRaySensor.cc
+++ b/gazebo/sensors/GpuRaySensor.cc
@@ -598,15 +598,15 @@ void GpuRaySensor::Render()
 //////////////////////////////////////////////////
 bool GpuRaySensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("GpuRaySensor");
+  IGN_PROFILE("GpuRaySensor::UpdateImpl");
 
   if (!this->dataPtr->rendered)
     return false;
-  IGN_PROFILE_BEGIN("GpuRaySensor::PostRender");
+  IGN_PROFILE_BEGIN("PostRender");
   this->dataPtr->laserCam->PostRender();
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("GpuRaySensor::fillarray");
+  IGN_PROFILE_BEGIN("fillarray");
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 

--- a/gazebo/sensors/ImuSensor.cc
+++ b/gazebo/sensors/ImuSensor.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <boost/algorithm/string.hpp>
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Rand.hh>
 
 #include "gazebo/transport/Node.hh"
@@ -300,6 +301,8 @@ void ImuSensor::SetWorldToReferenceOrientation(
 //////////////////////////////////////////////////
 bool ImuSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("ImuSensor");
+  IGN_PROFILE_BEGIN("ImuSensor::update");
   msgs::LinkData msg;
   int readIndex = 0;
 
@@ -430,10 +433,13 @@ bool ImuSensor::UpdateImpl(const bool /*_force*/)
           break;
       }
     }
+    IGN_PROFILE_END();
 
+    IGN_PROFILE_BEGIN("ImuSensor::publish");
     // Publish the message
     if (this->dataPtr->pub)
       this->dataPtr->pub->Publish(this->dataPtr->imuMsg);
+    IGN_PROFILE_END();
   }
 
   return true;

--- a/gazebo/sensors/ImuSensor.cc
+++ b/gazebo/sensors/ImuSensor.cc
@@ -301,8 +301,8 @@ void ImuSensor::SetWorldToReferenceOrientation(
 //////////////////////////////////////////////////
 bool ImuSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("ImuSensor");
-  IGN_PROFILE_BEGIN("ImuSensor::update");
+  IGN_PROFILE("ImuSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
   msgs::LinkData msg;
   int readIndex = 0;
 
@@ -435,7 +435,7 @@ bool ImuSensor::UpdateImpl(const bool /*_force*/)
     }
     IGN_PROFILE_END();
 
-    IGN_PROFILE_BEGIN("ImuSensor::publish");
+    IGN_PROFILE_BEGIN("Publish");
     // Publish the message
     if (this->dataPtr->pub)
       this->dataPtr->pub->Publish(this->dataPtr->imuMsg);

--- a/gazebo/sensors/LogicalCameraSensor.cc
+++ b/gazebo/sensors/LogicalCameraSensor.cc
@@ -140,11 +140,11 @@ void LogicalCameraSensorPrivate::AddVisibleModels(
 //////////////////////////////////////////////////
 bool LogicalCameraSensor::UpdateImpl(const bool _force)
 {
-  IGN_PROFILE("LogicalCameraSensor");
+  IGN_PROFILE("LogicalCameraSensor::UpdateImpl");
   // Only compute if active, or the update is forced
   if (_force || this->IsActive())
   {
-    IGN_PROFILE_BEGIN("LogicalCameraSensor::update");
+    IGN_PROFILE_BEGIN("Update");
     std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
     this->dataPtr->msg.clear_model();
 
@@ -162,7 +162,7 @@ bool LogicalCameraSensor::UpdateImpl(const bool _force)
     this->dataPtr->AddVisibleModels(myPose, this->world->Models());
     IGN_PROFILE_END();
 
-    IGN_PROFILE_BEGIN("LogicalCameraSensor::publish");
+    IGN_PROFILE_BEGIN("Publish");
     // Send the message.
     this->dataPtr->pub->Publish(this->dataPtr->msg);
     IGN_PROFILE_END();

--- a/gazebo/sensors/LogicalCameraSensor.cc
+++ b/gazebo/sensors/LogicalCameraSensor.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <boost/algorithm/string.hpp>
+#include <ignition/common/Profiler.hh>
 #include "gazebo/transport/transport.hh"
 #include "gazebo/msgs/msgs.hh"
 #include "gazebo/physics/World.hh"
@@ -139,9 +140,11 @@ void LogicalCameraSensorPrivate::AddVisibleModels(
 //////////////////////////////////////////////////
 bool LogicalCameraSensor::UpdateImpl(const bool _force)
 {
+  IGN_PROFILE("LogicalCameraSensor");
   // Only compute if active, or the update is forced
   if (_force || this->IsActive())
   {
+    IGN_PROFILE_BEGIN("LogicalCameraSensor::update");
     std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
     this->dataPtr->msg.clear_model();
 
@@ -157,9 +160,12 @@ bool LogicalCameraSensor::UpdateImpl(const bool _force)
 
     // Recursively check if models and nested models are in the frustum.
     this->dataPtr->AddVisibleModels(myPose, this->world->Models());
+    IGN_PROFILE_END();
 
+    IGN_PROFILE_BEGIN("LogicalCameraSensor::publish");
     // Send the message.
     this->dataPtr->pub->Publish(this->dataPtr->msg);
+    IGN_PROFILE_END();
   }
 
   return true;

--- a/gazebo/sensors/MagnetometerSensor.cc
+++ b/gazebo/sensors/MagnetometerSensor.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <boost/algorithm/string.hpp>
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Pose3.hh>
 
 #include "gazebo/transport/Node.hh"
@@ -127,6 +128,8 @@ void MagnetometerSensor::Init()
 //////////////////////////////////////////////////
 bool MagnetometerSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("MagnetometerSensor");
+  IGN_PROFILE_BEGIN("MagnetometerSensor::update");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   // Get latest pose information
@@ -171,10 +174,13 @@ bool MagnetometerSensor::UpdateImpl(const bool /*_force*/)
 
   // Save the time of the measurement
   msgs::Set(this->dataPtr->magMsg.mutable_time(), this->world->SimTime());
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("ImuSensor::publish");
   // Publish the message if needed
   if (this->dataPtr->magPub)
     this->dataPtr->magPub->Publish(this->dataPtr->magMsg);
+  IGN_PROFILE_END();
 
   return true;
 }

--- a/gazebo/sensors/MagnetometerSensor.cc
+++ b/gazebo/sensors/MagnetometerSensor.cc
@@ -128,8 +128,8 @@ void MagnetometerSensor::Init()
 //////////////////////////////////////////////////
 bool MagnetometerSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("MagnetometerSensor");
-  IGN_PROFILE_BEGIN("MagnetometerSensor::update");
+  IGN_PROFILE("MagnetometerSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   // Get latest pose information
@@ -176,7 +176,7 @@ bool MagnetometerSensor::UpdateImpl(const bool /*_force*/)
   msgs::Set(this->dataPtr->magMsg.mutable_time(), this->world->SimTime());
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("ImuSensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
   // Publish the message if needed
   if (this->dataPtr->magPub)
     this->dataPtr->magPub->Publish(this->dataPtr->magMsg);

--- a/gazebo/sensors/MultiCameraSensor.cc
+++ b/gazebo/sensors/MultiCameraSensor.cc
@@ -252,8 +252,8 @@ void MultiCameraSensor::Render()
 //////////////////////////////////////////////////
 bool MultiCameraSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("MultiCameraSensor");
-  IGN_PROFILE_BEGIN("MultiCameraSensor::update");
+  IGN_PROFILE("MultiCameraSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
 
   std::lock_guard<std::mutex> lock(this->dataPtr->cameraMutex);
 
@@ -280,7 +280,7 @@ bool MultiCameraSensor::UpdateImpl(const bool /*_force*/)
   }
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("MultiCameraSensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
   if (publish)
     this->dataPtr->imagePub->Publish(this->dataPtr->msg);
   IGN_PROFILE_END();

--- a/gazebo/sensors/MultiCameraSensor.cc
+++ b/gazebo/sensors/MultiCameraSensor.cc
@@ -16,6 +16,7 @@
 */
 #include <boost/algorithm/string.hpp>
 #include <functional>
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Pose3.hh>
 
 #include "gazebo/common/Exception.hh"
@@ -251,6 +252,9 @@ void MultiCameraSensor::Render()
 //////////////////////////////////////////////////
 bool MultiCameraSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("MultiCameraSensor");
+  IGN_PROFILE_BEGIN("MultiCameraSensor::update");
+
   std::lock_guard<std::mutex> lock(this->dataPtr->cameraMutex);
 
   if (!this->dataPtr->rendered)
@@ -274,9 +278,12 @@ bool MultiCameraSensor::UpdateImpl(const bool /*_force*/)
           image->width() * (*iter)->ImageDepth() * image->height());
     }
   }
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("MultiCameraSensor::publish");
   if (publish)
     this->dataPtr->imagePub->Publish(this->dataPtr->msg);
+  IGN_PROFILE_END();
 
   this->dataPtr->rendered = false;
   return true;

--- a/gazebo/sensors/RFIDSensor.cc
+++ b/gazebo/sensors/RFIDSensor.cc
@@ -117,15 +117,15 @@ void RFIDSensor::Init()
 //////////////////////////////////////////////////
 bool RFIDSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("RFIDSensor");
-  IGN_PROFILE_BEGIN("RFIDSensor::EvaluateTags");
+  IGN_PROFILE("RFIDSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("EvaluateTags");
   this->EvaluateTags();
   IGN_PROFILE_END();
   this->lastMeasurementTime = this->world->SimTime();
 
   if (this->dataPtr->scanPub)
   {
-    IGN_PROFILE_BEGIN("ImuSensor::Publish");
+    IGN_PROFILE_BEGIN("Publish");
     msgs::Pose msg;
     msgs::Set(&msg, this->dataPtr->entity->WorldPose());
     this->dataPtr->scanPub->Publish(msg);

--- a/gazebo/sensors/RFIDSensor.cc
+++ b/gazebo/sensors/RFIDSensor.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
 */
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/msgs/msgs.hh"
 #include "gazebo/transport/transport.hh"
 #include "gazebo/physics/World.hh"
@@ -115,14 +117,19 @@ void RFIDSensor::Init()
 //////////////////////////////////////////////////
 bool RFIDSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("RFIDSensor");
+  IGN_PROFILE_BEGIN("RFIDSensor::EvaluateTags");
   this->EvaluateTags();
+  IGN_PROFILE_END();
   this->lastMeasurementTime = this->world->SimTime();
 
   if (this->dataPtr->scanPub)
   {
+    IGN_PROFILE_BEGIN("ImuSensor::Publish");
     msgs::Pose msg;
     msgs::Set(&msg, this->dataPtr->entity->WorldPose());
     this->dataPtr->scanPub->Publish(msg);
+    IGN_PROFILE_END();
   }
 
   return true;

--- a/gazebo/sensors/RaySensor.cc
+++ b/gazebo/sensors/RaySensor.cc
@@ -16,6 +16,8 @@
 */
 #include <boost/algorithm/string.hpp>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/physics/World.hh"
 #include "gazebo/physics/MultiRayShape.hh"
 #include "gazebo/physics/PhysicsEngine.hh"
@@ -342,6 +344,8 @@ int RaySensor::Fiducial(const unsigned int _index) const
 //////////////////////////////////////////////////
 bool RaySensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("RaySensor");
+  IGN_PROFILE_BEGIN("RaySensor::update");
   // do the collision checks
   // this eventually call OnNewScans, so move mutex lock behind it in case
   // need to move mutex lock after this? or make the OnNewLaserScan connection
@@ -496,9 +500,12 @@ bool RaySensor::UpdateImpl(const bool /*_force*/)
       scan->add_intensities(intensity);
     }
   }
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("RaySensor::publish");
   if (this->dataPtr->scanPub && this->dataPtr->scanPub->HasConnections())
     this->dataPtr->scanPub->Publish(this->dataPtr->laserMsg);
+  IGN_PROFILE_END();
 
   return true;
 }

--- a/gazebo/sensors/RaySensor.cc
+++ b/gazebo/sensors/RaySensor.cc
@@ -344,8 +344,8 @@ int RaySensor::Fiducial(const unsigned int _index) const
 //////////////////////////////////////////////////
 bool RaySensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("RaySensor");
-  IGN_PROFILE_BEGIN("RaySensor::update");
+  IGN_PROFILE("RaySensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
   // do the collision checks
   // this eventually call OnNewScans, so move mutex lock behind it in case
   // need to move mutex lock after this? or make the OnNewLaserScan connection
@@ -502,7 +502,7 @@ bool RaySensor::UpdateImpl(const bool /*_force*/)
   }
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("RaySensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
   if (this->dataPtr->scanPub && this->dataPtr->scanPub->HasConnections())
     this->dataPtr->scanPub->Publish(this->dataPtr->laserMsg);
   IGN_PROFILE_END();

--- a/gazebo/sensors/Sensor.cc
+++ b/gazebo/sensors/Sensor.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
 */
+#include "ignition/common/Profiler.hh"
+
 #include "gazebo/transport/transport.hh"
 
 #include "gazebo/physics/PhysicsIface.hh"
@@ -225,6 +227,9 @@ bool Sensor::NeedsUpdate()
 //////////////////////////////////////////////////
 void Sensor::Update(const bool _force)
 {
+  // //IGN_PROFILE_THREAD_NAME("Sensor");
+  //IGN_PROFILE("Sensor");
+  //IGN_PROFILE_BEGIN("Sensor::Update");
   if (this->IsActive() || _force)
   {
     common::Time simTime;
@@ -267,6 +272,7 @@ void Sensor::Update(const bool _force)
       this->updated();
     }
   }
+  //IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/sensors/Sensor.cc
+++ b/gazebo/sensors/Sensor.cc
@@ -227,9 +227,6 @@ bool Sensor::NeedsUpdate()
 //////////////////////////////////////////////////
 void Sensor::Update(const bool _force)
 {
-  // //IGN_PROFILE_THREAD_NAME("Sensor");
-  //IGN_PROFILE("Sensor");
-  //IGN_PROFILE_BEGIN("Sensor::Update");
   if (this->IsActive() || _force)
   {
     common::Time simTime;
@@ -272,7 +269,6 @@ void Sensor::Update(const bool _force)
       this->updated();
     }
   }
-  //IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/sensors/SensorManager.cc
+++ b/gazebo/sensors/SensorManager.cc
@@ -552,8 +552,7 @@ void SensorManager::SensorContainer::RunLoop()
 
   while (!this->stop)
   {
-    IGN_PROFILE("SensorManagerLoop");
-    // IGN_PROFILE_BEGIN("SensorManagerLoop");
+    IGN_PROFILE("SensorManager::RunLoop");
 
     // If all the sensors get deleted, wait here.
     // Use a while loop since world resets will notify the runCondition.
@@ -610,8 +609,6 @@ void SensorManager::SensorContainer::RunLoop()
       this->runCondition.wait(timingLock);
     }
     IGN_PROFILE_END();
-
-    // IGN_PROFILE_END();
   }
 }
 

--- a/gazebo/sensors/SonarSensor.cc
+++ b/gazebo/sensors/SonarSensor.cc
@@ -282,8 +282,8 @@ double SonarSensor::Range()
 //////////////////////////////////////////////////
 bool SonarSensor::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("SonarSensor");
-  IGN_PROFILE_BEGIN("SonarSensor::update");
+  IGN_PROFILE("SonarSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
@@ -353,7 +353,7 @@ bool SonarSensor::UpdateImpl(const bool /*_force*/)
   this->dataPtr->incomingContacts.clear();
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("SonarSensor::publish");
+  IGN_PROFILE_BEGIN("Publish");
   this->dataPtr->update(this->dataPtr->sonarMsg);
 
   if (this->dataPtr->sonarPub)

--- a/gazebo/sensors/SonarSensor.cc
+++ b/gazebo/sensors/SonarSensor.cc
@@ -16,6 +16,7 @@
 */
 #include <boost/algorithm/string.hpp>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Vector3.hh>
 
 #include "gazebo/physics/World.hh"
@@ -281,6 +282,9 @@ double SonarSensor::Range()
 //////////////////////////////////////////////////
 bool SonarSensor::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("SonarSensor");
+  IGN_PROFILE_BEGIN("SonarSensor::update");
+
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   this->lastMeasurementTime = this->world->SimTime();
@@ -347,11 +351,14 @@ bool SonarSensor::UpdateImpl(const bool /*_force*/)
 
   // Clear the incoming contact list.
   this->dataPtr->incomingContacts.clear();
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("SonarSensor::publish");
   this->dataPtr->update(this->dataPtr->sonarMsg);
 
   if (this->dataPtr->sonarPub)
     this->dataPtr->sonarPub->Publish(this->dataPtr->sonarMsg);
+  IGN_PROFILE_END();
 
   return true;
 }

--- a/gazebo/sensors/WideAngleCameraSensor.cc
+++ b/gazebo/sensors/WideAngleCameraSensor.cc
@@ -179,8 +179,8 @@ void WideAngleCameraSensor::Fini()
 //////////////////////////////////////////////////
 bool WideAngleCameraSensor::UpdateImpl(const bool _force)
 {
-  IGN_PROFILE("WideAngleCameraSensor");
-  IGN_PROFILE_BEGIN("WideAngleCameraSensor::update");
+  IGN_PROFILE("WideAngleCameraSensor::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
 
   if (!CameraSensor::UpdateImpl(_force)) {
     IGN_PROFILE_END();

--- a/gazebo/sensors/WideAngleCameraSensor.cc
+++ b/gazebo/sensors/WideAngleCameraSensor.cc
@@ -19,6 +19,8 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/Events.hh"
 #include "gazebo/common/Exception.hh"
 #include "gazebo/common/Image.hh"
@@ -177,8 +179,13 @@ void WideAngleCameraSensor::Fini()
 //////////////////////////////////////////////////
 bool WideAngleCameraSensor::UpdateImpl(const bool _force)
 {
-  if (!CameraSensor::UpdateImpl(_force))
+  IGN_PROFILE("WideAngleCameraSensor");
+  IGN_PROFILE_BEGIN("WideAngleCameraSensor::update");
+
+  if (!CameraSensor::UpdateImpl(_force)) {
+    IGN_PROFILE_END();
     return false;
+  }
 
   if (this->dataPtr->lensPub && this->dataPtr->lensPub->HasConnections())
   {
@@ -215,6 +222,7 @@ bool WideAngleCameraSensor::UpdateImpl(const bool _force)
 
     this->dataPtr->lensPub->Publish(msg);
   }
+  IGN_PROFILE_END();
 
   return true;
 }

--- a/gazebo/sensors/WideAngleCameraSensor.cc
+++ b/gazebo/sensors/WideAngleCameraSensor.cc
@@ -182,7 +182,8 @@ bool WideAngleCameraSensor::UpdateImpl(const bool _force)
   IGN_PROFILE("WideAngleCameraSensor::UpdateImpl");
   IGN_PROFILE_BEGIN("Update");
 
-  if (!CameraSensor::UpdateImpl(_force)) {
+  if (!CameraSensor::UpdateImpl(_force))
+  {
     IGN_PROFILE_END();
     return false;
   }

--- a/gazebo/sensors/WirelessReceiver.cc
+++ b/gazebo/sensors/WirelessReceiver.cc
@@ -103,8 +103,8 @@ void WirelessReceiver::Load(const std::string &_worldName)
 //////////////////////////////////////////////////
 bool WirelessReceiver::UpdateImpl(const bool /*_force*/)
 {
-  IGN_PROFILE("WirelessReceiver");
-  IGN_PROFILE_BEGIN("WirelessReceiver::update");
+  IGN_PROFILE("WirelessReceiver::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
 
   std::string txEssid;
   msgs::WirelessNodes msg;
@@ -143,7 +143,7 @@ bool WirelessReceiver::UpdateImpl(const bool /*_force*/)
     }
   }
   IGN_PROFILE_END();
-  IGN_PROFILE_BEGIN("WirelessReceiver::publish");
+  IGN_PROFILE_BEGIN("Publish");
   if (msg.node_size() > 0)
   {
     this->pub->Publish(msg);

--- a/gazebo/sensors/WirelessReceiver.cc
+++ b/gazebo/sensors/WirelessReceiver.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
 */
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Pose3.hh>
 
 #include "gazebo/msgs/msgs.hh"
@@ -102,6 +103,9 @@ void WirelessReceiver::Load(const std::string &_worldName)
 //////////////////////////////////////////////////
 bool WirelessReceiver::UpdateImpl(const bool /*_force*/)
 {
+  IGN_PROFILE("WirelessReceiver");
+  IGN_PROFILE_BEGIN("WirelessReceiver::update");
+
   std::string txEssid;
   msgs::WirelessNodes msg;
   double rxPower;
@@ -138,10 +142,13 @@ bool WirelessReceiver::UpdateImpl(const bool /*_force*/)
       wirelessNode->set_signal_level(rxPower);
     }
   }
+  IGN_PROFILE_END();
+  IGN_PROFILE_BEGIN("WirelessReceiver::publish");
   if (msg.node_size() > 0)
   {
     this->pub->Publish(msg);
   }
+  IGN_PROFILE_END();
 
   return true;
 }

--- a/plugins/ActorPlugin.cc
+++ b/plugins/ActorPlugin.cc
@@ -154,8 +154,8 @@ void ActorPlugin::HandleObstacles(ignition::math::Vector3d &_pos)
 /////////////////////////////////////////////////
 void ActorPlugin::OnUpdate(const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("ActorPlugin");
-  IGN_PROFILE_BEGIN("ActorPlugin::update");
+  IGN_PROFILE("ActorPlugin::UpdateImpl");
+  IGN_PROFILE_BEGIN("Update");
 
   // Time delta
   double dt = (_info.simTime - this->lastUpdate).Double();

--- a/plugins/ActorPlugin.cc
+++ b/plugins/ActorPlugin.cc
@@ -18,6 +18,7 @@
 #include <functional>
 
 #include <ignition/math.hh>
+#include <ignition/common/Profiler.hh>
 #include "gazebo/physics/physics.hh"
 #include "plugins/ActorPlugin.hh"
 
@@ -153,6 +154,9 @@ void ActorPlugin::HandleObstacles(ignition::math::Vector3d &_pos)
 /////////////////////////////////////////////////
 void ActorPlugin::OnUpdate(const common::UpdateInfo &_info)
 {
+  IGN_PROFILE("ActorPlugin");
+  IGN_PROFILE_BEGIN("ActorPlugin::update");
+
   // Time delta
   double dt = (_info.simTime - this->lastUpdate).Double();
 
@@ -206,4 +210,5 @@ void ActorPlugin::OnUpdate(const common::UpdateInfo &_info)
   this->actor->SetScriptTime(this->actor->ScriptTime() +
     (distanceTraveled * this->animationFactor));
   this->lastUpdate = _info.simTime;
+  IGN_PROFILE_END();
 }

--- a/plugins/ActuatorPlugin.cc
+++ b/plugins/ActuatorPlugin.cc
@@ -17,6 +17,8 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include "ActuatorPlugin.hh"
 
 using namespace gazebo;
@@ -166,6 +168,8 @@ void ActuatorPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 //////////////////////////////////////////////////
 void ActuatorPlugin::WorldUpdateCallback()
 {
+  IGN_PROFILE("ActuatorPlugin");
+  IGN_PROFILE_BEGIN("ActuatorPlugin::WorldUpdateCallback");
   // Update the stored joints according to the desired model.
   for (unsigned int i = 0; i < this->joints.size(); i++)
   {
@@ -176,4 +180,5 @@ void ActuatorPlugin::WorldUpdateCallback()
               this->actuators[i]);
     this->joints[i]->SetEffortLimit(index, maxForce);
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/ActuatorPlugin.cc
+++ b/plugins/ActuatorPlugin.cc
@@ -168,8 +168,8 @@ void ActuatorPlugin::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 //////////////////////////////////////////////////
 void ActuatorPlugin::WorldUpdateCallback()
 {
-  IGN_PROFILE("ActuatorPlugin");
-  IGN_PROFILE_BEGIN("ActuatorPlugin::WorldUpdateCallback");
+  IGN_PROFILE("ActuatorPlugin::WorldUpdateCallback");
+  IGN_PROFILE_BEGIN("WorldUpdateCallback");
   // Update the stored joints according to the desired model.
   for (unsigned int i = 0; i < this->joints.size(); i++)
   {

--- a/plugins/ArduCopterPlugin.cc
+++ b/plugins/ArduCopterPlugin.cc
@@ -466,8 +466,8 @@ void ArduCopterPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 /////////////////////////////////////////////////
 void ArduCopterPlugin::OnUpdate()
 {
-  IGN_PROFILE("ArduCopterPlugin");
-  IGN_PROFILE_BEGIN("ArduCopterPlugin::update");
+  IGN_PROFILE("ArduCopterPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   gazebo::common::Time curTime = this->dataPtr->model->GetWorld()->SimTime();
@@ -475,17 +475,17 @@ void ArduCopterPlugin::OnUpdate()
   // Update the control surfaces and publish the new state.
   if (curTime > this->dataPtr->lastControllerUpdateTime)
   {
-    IGN_PROFILE_BEGIN("ArduCopterPlugin::ReceiveMotorCommand");
+    IGN_PROFILE_BEGIN("ReceiveMotorCommand");
     this->ReceiveMotorCommand();
     IGN_PROFILE_END();
 
     if (this->dataPtr->arduCopterOnline)
     {
-      IGN_PROFILE_BEGIN("ArduCopterPlugin::ApplyMotorForces");
+      IGN_PROFILE_BEGIN("ApplyMotorForces");
       this->ApplyMotorForces((curTime -
         this->dataPtr->lastControllerUpdateTime).Double());
       IGN_PROFILE_END();
-      IGN_PROFILE_BEGIN("ArduCopterPlugin::SendState");
+      IGN_PROFILE_BEGIN("SendState");
       this->SendState();
       IGN_PROFILE_END();
     }

--- a/plugins/BuoyancyPlugin.cc
+++ b/plugins/BuoyancyPlugin.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include "ignition/common/Profiler.hh"
 #include "gazebo/common/Assert.hh"
 #include "gazebo/common/Events.hh"
 #include "plugins/BuoyancyPlugin.hh"
@@ -153,6 +154,8 @@ void BuoyancyPlugin::Init()
 /////////////////////////////////////////////////
 void BuoyancyPlugin::OnUpdate()
 {
+  IGN_PROFILE("BuoyancyPlugin");
+  IGN_PROFILE_BEGIN("BuoyancyPlugin::update");
   for (auto link : this->model->GetLinks())
   {
     VolumeProperties volumeProperties = this->volPropsMap[link->GetId()];
@@ -173,4 +176,5 @@ void BuoyancyPlugin::OnUpdate()
 
     link->AddLinkForce(buoyancyLinkFrame, volumeProperties.cov);
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/BuoyancyPlugin.cc
+++ b/plugins/BuoyancyPlugin.cc
@@ -154,8 +154,8 @@ void BuoyancyPlugin::Init()
 /////////////////////////////////////////////////
 void BuoyancyPlugin::OnUpdate()
 {
-  IGN_PROFILE("BuoyancyPlugin");
-  IGN_PROFILE_BEGIN("BuoyancyPlugin::update");
+  IGN_PROFILE("BuoyancyPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   for (auto link : this->model->GetLinks())
   {
     VolumeProperties volumeProperties = this->volPropsMap[link->GetId()];

--- a/plugins/CartDemoPlugin.cc
+++ b/plugins/CartDemoPlugin.cc
@@ -112,8 +112,8 @@ void CartDemoPlugin::Init()
 /////////////////////////////////////////////////
 void CartDemoPlugin::OnUpdate()
 {
-  IGN_PROFILE("CartDemoPlugin");
-  IGN_PROFILE_BEGIN("CartDemoPlugin::update");
+  IGN_PROFILE("CartDemoPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   common::Time currTime = this->model->GetWorld()->SimTime();
   common::Time stepTime = currTime - this->prevUpdateTime;
   this->prevUpdateTime = currTime;

--- a/plugins/CartDemoPlugin.cc
+++ b/plugins/CartDemoPlugin.cc
@@ -17,6 +17,8 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/physics/physics.hh"
 #include "gazebo/transport/transport.hh"
 #include "plugins/CartDemoPlugin.hh"
@@ -110,6 +112,8 @@ void CartDemoPlugin::Init()
 /////////////////////////////////////////////////
 void CartDemoPlugin::OnUpdate()
 {
+  IGN_PROFILE("CartDemoPlugin");
+  IGN_PROFILE_BEGIN("CartDemoPlugin::update");
   common::Time currTime = this->model->GetWorld()->SimTime();
   common::Time stepTime = currTime - this->prevUpdateTime;
   this->prevUpdateTime = currTime;
@@ -176,4 +180,5 @@ void CartDemoPlugin::OnUpdate()
     this->joints[i]->SetForce(0, eff);
   }
   gzdbg << "\n";
+  IGN_PROFILE_END();
 }

--- a/plugins/CessnaPlugin.cc
+++ b/plugins/CessnaPlugin.cc
@@ -18,6 +18,7 @@
 #include <functional>
 #include <string>
 #include <sdf/sdf.hh>
+#include <ignition/common/Profiler.hh>
 #include <gazebo/common/Assert.hh>
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/msgs/msgs.hh>
@@ -153,6 +154,7 @@ void CessnaPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 /////////////////////////////////////////////////
 void CessnaPlugin::Update(const common::UpdateInfo &/*_info*/)
 {
+  IGN_PROFILE("CessnaPlugin");
   std::lock_guard<std::mutex> lock(this->mutex);
 
   gazebo::common::Time curTime = this->model->GetWorld()->SimTime();
@@ -160,8 +162,12 @@ void CessnaPlugin::Update(const common::UpdateInfo &/*_info*/)
   if (curTime > this->lastControllerUpdateTime)
   {
     // Update the control surfaces and publish the new state.
+    IGN_PROFILE_BEGIN("CessnaPlugin::Update");
     this->UpdatePIDs((curTime - this->lastControllerUpdateTime).Double());
+    IGN_PROFILE_END();
+    IGN_PROFILE_BEGIN("CessnaPlugin::PublishState");
     this->PublishState();
+    IGN_PROFILE_END();
 
     this->lastControllerUpdateTime = curTime;
   }

--- a/plugins/CessnaPlugin.cc
+++ b/plugins/CessnaPlugin.cc
@@ -154,7 +154,7 @@ void CessnaPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
 /////////////////////////////////////////////////
 void CessnaPlugin::Update(const common::UpdateInfo &/*_info*/)
 {
-  IGN_PROFILE("CessnaPlugin");
+  IGN_PROFILE("CessnaPlugin::OnUpdate");
   std::lock_guard<std::mutex> lock(this->mutex);
 
   gazebo::common::Time curTime = this->model->GetWorld()->SimTime();
@@ -162,10 +162,10 @@ void CessnaPlugin::Update(const common::UpdateInfo &/*_info*/)
   if (curTime > this->lastControllerUpdateTime)
   {
     // Update the control surfaces and publish the new state.
-    IGN_PROFILE_BEGIN("CessnaPlugin::Update");
+    IGN_PROFILE_BEGIN("Update");
     this->UpdatePIDs((curTime - this->lastControllerUpdateTime).Double());
     IGN_PROFILE_END();
-    IGN_PROFILE_BEGIN("CessnaPlugin::PublishState");
+    IGN_PROFILE_BEGIN("Publish");
     this->PublishState();
     IGN_PROFILE_END();
 

--- a/plugins/DiffDrivePlugin.cc
+++ b/plugins/DiffDrivePlugin.cc
@@ -100,8 +100,8 @@ void DiffDrivePlugin::OnVelMsg(ConstPosePtr &_msg)
 /////////////////////////////////////////////////
 void DiffDrivePlugin::OnUpdate()
 {
-  IGN_PROFILE("DiffDrivePlugin");
-  IGN_PROFILE_BEGIN("DiffDrivePlugin::update");
+  IGN_PROFILE("DiffDrivePlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
 
   /* double d1, d2;
   double dr, da;

--- a/plugins/DiffDrivePlugin.cc
+++ b/plugins/DiffDrivePlugin.cc
@@ -17,6 +17,7 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/AxisAlignedBox.hh>
 
 #include "gazebo/physics/physics.hh"
@@ -99,6 +100,9 @@ void DiffDrivePlugin::OnVelMsg(ConstPosePtr &_msg)
 /////////////////////////////////////////////////
 void DiffDrivePlugin::OnUpdate()
 {
+  IGN_PROFILE("DiffDrivePlugin");
+  IGN_PROFILE_BEGIN("DiffDrivePlugin::update");
+
   /* double d1, d2;
   double dr, da;
 
@@ -119,4 +123,5 @@ void DiffDrivePlugin::OnUpdate()
 
   this->leftJoint->SetVelocity(0, leftVelDesired);
   this->rightJoint->SetVelocity(0, rightVelDesired);
+  IGN_PROFILE_END();
 }

--- a/plugins/ElevatorPlugin.cc
+++ b/plugins/ElevatorPlugin.cc
@@ -176,8 +176,8 @@ void ElevatorPlugin::MoveToFloor(const int _floor)
 /////////////////////////////////////////////////
 void ElevatorPlugin::Update(const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("ElevatorPlugin");
-  IGN_PROFILE_BEGIN("ElevatorPlugin::Update");
+  IGN_PROFILE("ElevatorPlugin::Update");
+  IGN_PROFILE_BEGIN("Update");
   std::lock_guard<std::mutex> lock(this->dataPtr->stateMutex);
 
   // Process the states
@@ -245,7 +245,7 @@ void ElevatorPluginPrivate::CloseState::Start()
 bool ElevatorPluginPrivate::CloseState::Update()
 {
   IGN_PROFILE("ElevatorPlugin::CloseState");
-  IGN_PROFILE_BEGIN("ElevatorPlugin::CloseState::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   if (!this->started)
   {
@@ -282,7 +282,7 @@ void ElevatorPluginPrivate::OpenState::Start()
 bool ElevatorPluginPrivate::OpenState::Update()
 {
   IGN_PROFILE("ElevatorPlugin::OpenState");
-  IGN_PROFILE_BEGIN("ElevatorPlugin::OpenState::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   if (!this->started)
   {
@@ -319,7 +319,7 @@ void ElevatorPluginPrivate::MoveState::Start()
 bool ElevatorPluginPrivate::MoveState::Update()
 {
   IGN_PROFILE("ElevatorPlugin::MoveState");
-  IGN_PROFILE_BEGIN("ElevatorPlugin::MoveState::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   if (!this->started)
   {
@@ -355,7 +355,7 @@ void ElevatorPluginPrivate::WaitState::Start()
 bool ElevatorPluginPrivate::WaitState::Update()
 {
   IGN_PROFILE("ElevatorPlugin::WaitState");
-  IGN_PROFILE_BEGIN("ElevatorPlugin::WaitState::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   if (!this->started)
   {
@@ -415,7 +415,7 @@ bool ElevatorPluginPrivate::DoorController::Update(
     const common::UpdateInfo &_info)
 {
   IGN_PROFILE("ElevatorPlugin::DoorController");
-  IGN_PROFILE_BEGIN("ElevatorPlugin::DoorController::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   // Bootstrap the time.
   if (this->prevSimTime == common::Time::Zero)
@@ -470,7 +470,7 @@ bool ElevatorPluginPrivate::LiftController::Update(
     const common::UpdateInfo &_info)
 {
   IGN_PROFILE("ElevatorPlugin::LiftController");
-  IGN_PROFILE_BEGIN("ElevatorPlugin::LiftController::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   // Bootstrap the time.
   if (this->prevSimTime == common::Time::Zero)

--- a/plugins/ElevatorPlugin.cc
+++ b/plugins/ElevatorPlugin.cc
@@ -176,7 +176,7 @@ void ElevatorPlugin::MoveToFloor(const int _floor)
 /////////////////////////////////////////////////
 void ElevatorPlugin::Update(const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("ElevatorPlugin")
+  IGN_PROFILE("ElevatorPlugin");
   IGN_PROFILE_BEGIN("ElevatorPlugin::Update");
   std::lock_guard<std::mutex> lock(this->dataPtr->stateMutex);
 
@@ -244,7 +244,7 @@ void ElevatorPluginPrivate::CloseState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::CloseState::Update()
 {
-  IGN_PROFILE("ElevatorPlugin::CloseState")
+  IGN_PROFILE("ElevatorPlugin::CloseState");
   IGN_PROFILE_BEGIN("ElevatorPlugin::CloseState::Update");
 
   if (!this->started)
@@ -281,7 +281,7 @@ void ElevatorPluginPrivate::OpenState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::OpenState::Update()
 {
-  IGN_PROFILE("ElevatorPlugin::OpenState")
+  IGN_PROFILE("ElevatorPlugin::OpenState");
   IGN_PROFILE_BEGIN("ElevatorPlugin::OpenState::Update");
 
   if (!this->started)
@@ -318,7 +318,7 @@ void ElevatorPluginPrivate::MoveState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::MoveState::Update()
 {
-  IGN_PROFILE("ElevatorPlugin::MoveState")
+  IGN_PROFILE("ElevatorPlugin::MoveState");
   IGN_PROFILE_BEGIN("ElevatorPlugin::MoveState::Update");
 
   if (!this->started)
@@ -354,7 +354,7 @@ void ElevatorPluginPrivate::WaitState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::WaitState::Update()
 {
-  IGN_PROFILE("ElevatorPlugin::WaitState")
+  IGN_PROFILE("ElevatorPlugin::WaitState");
   IGN_PROFILE_BEGIN("ElevatorPlugin::WaitState::Update");
 
   if (!this->started)
@@ -414,7 +414,7 @@ void ElevatorPluginPrivate::DoorController::Reset()
 bool ElevatorPluginPrivate::DoorController::Update(
     const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("ElevatorPlugin::DoorController")
+  IGN_PROFILE("ElevatorPlugin::DoorController");
   IGN_PROFILE_BEGIN("ElevatorPlugin::DoorController::Update");
 
   // Bootstrap the time.
@@ -469,7 +469,7 @@ void ElevatorPluginPrivate::LiftController::Reset()
 bool ElevatorPluginPrivate::LiftController::Update(
     const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("ElevatorPlugin::LiftController")
+  IGN_PROFILE("ElevatorPlugin::LiftController");
   IGN_PROFILE_BEGIN("ElevatorPlugin::LiftController::Update");
 
   // Bootstrap the time.

--- a/plugins/ElevatorPlugin.cc
+++ b/plugins/ElevatorPlugin.cc
@@ -17,6 +17,8 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include <gazebo/common/Events.hh>
 #include <gazebo/common/Assert.hh>
 #include <gazebo/common/Console.hh>
@@ -174,6 +176,8 @@ void ElevatorPlugin::MoveToFloor(const int _floor)
 /////////////////////////////////////////////////
 void ElevatorPlugin::Update(const common::UpdateInfo &_info)
 {
+  IGN_PROFILE("ElevatorPlugin")
+  IGN_PROFILE_BEGIN("ElevatorPlugin::Update");
   std::lock_guard<std::mutex> lock(this->dataPtr->stateMutex);
 
   // Process the states
@@ -190,6 +194,7 @@ void ElevatorPlugin::Update(const common::UpdateInfo &_info)
   // Update the controllers
   this->dataPtr->doorController->Update(_info);
   this->dataPtr->liftController->Update(_info);
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////
@@ -239,6 +244,9 @@ void ElevatorPluginPrivate::CloseState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::CloseState::Update()
 {
+  IGN_PROFILE("ElevatorPlugin::CloseState")
+  IGN_PROFILE_BEGIN("ElevatorPlugin::CloseState::Update");
+
   if (!this->started)
   {
     this->Start();
@@ -251,6 +259,7 @@ bool ElevatorPluginPrivate::CloseState::Update()
       this->ctrl->GetState() ==
       ElevatorPluginPrivate::DoorController::STATIONARY;
   }
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////
@@ -272,6 +281,9 @@ void ElevatorPluginPrivate::OpenState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::OpenState::Update()
 {
+  IGN_PROFILE("ElevatorPlugin::OpenState")
+  IGN_PROFILE_BEGIN("ElevatorPlugin::OpenState::Update");
+
   if (!this->started)
   {
     this->Start();
@@ -284,6 +296,7 @@ bool ElevatorPluginPrivate::OpenState::Update()
       this->ctrl->GetState() ==
       ElevatorPluginPrivate::DoorController::STATIONARY;
   }
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////
@@ -305,6 +318,9 @@ void ElevatorPluginPrivate::MoveState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::MoveState::Update()
 {
+  IGN_PROFILE("ElevatorPlugin::MoveState")
+  IGN_PROFILE_BEGIN("ElevatorPlugin::MoveState::Update");
+
   if (!this->started)
   {
     this->Start();
@@ -315,6 +331,7 @@ bool ElevatorPluginPrivate::MoveState::Update()
     return this->ctrl->GetState() ==
       ElevatorPluginPrivate::LiftController::STATIONARY;
   }
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////
@@ -337,6 +354,9 @@ void ElevatorPluginPrivate::WaitState::Start()
 /////////////////////////////////////////////////
 bool ElevatorPluginPrivate::WaitState::Update()
 {
+  IGN_PROFILE("ElevatorPlugin::WaitState")
+  IGN_PROFILE_BEGIN("ElevatorPlugin::WaitState::Update");
+
   if (!this->started)
   {
     this->Start();
@@ -349,6 +369,7 @@ bool ElevatorPluginPrivate::WaitState::Update()
     else
       return false;
   }
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////
@@ -393,6 +414,9 @@ void ElevatorPluginPrivate::DoorController::Reset()
 bool ElevatorPluginPrivate::DoorController::Update(
     const common::UpdateInfo &_info)
 {
+  IGN_PROFILE("ElevatorPlugin::DoorController")
+  IGN_PROFILE_BEGIN("ElevatorPlugin::DoorController::Update");
+
   // Bootstrap the time.
   if (this->prevSimTime == common::Time::Zero)
   {
@@ -420,6 +444,7 @@ bool ElevatorPluginPrivate::DoorController::Update(
     this->state = MOVING;
     return false;
   }
+  IGN_PROFILE_END();
 }
 
 ////////////////////////////////////////////////
@@ -444,6 +469,9 @@ void ElevatorPluginPrivate::LiftController::Reset()
 bool ElevatorPluginPrivate::LiftController::Update(
     const common::UpdateInfo &_info)
 {
+  IGN_PROFILE("ElevatorPlugin::LiftController")
+  IGN_PROFILE_BEGIN("ElevatorPlugin::LiftController::Update");
+
   // Bootstrap the time.
   if (this->prevSimTime == common::Time::Zero)
   {
@@ -469,6 +497,7 @@ bool ElevatorPluginPrivate::LiftController::Update(
     this->state = ElevatorPluginPrivate::LiftController::MOVING;
     return false;
   }
+  IGN_PROFILE_END();
 }
 
 /////////////////////////////////////////////////

--- a/plugins/FiducialCameraPlugin.cc
+++ b/plugins/FiducialCameraPlugin.cc
@@ -18,6 +18,7 @@
 #include <vector>
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Vector2.hh>
 
@@ -186,6 +187,8 @@ void FiducialCameraPlugin::OnNewFrame(const unsigned char */*_image*/,
     const unsigned int /*_width*/, const unsigned int /*_height*/,
     const unsigned int /*_depth*/, const std::string &/*_format*/)
 {
+  IGN_PROFILE("FiducialCameraPlugin");
+  IGN_PROFILE_BEGIN("FiducialCameraPlugin::update");
   if (!this->dataPtr->selectionBuffer)
   {
     std::string cameraName = this->dataPtr->camera->OgreCamera()->getName();
@@ -243,7 +246,11 @@ void FiducialCameraPlugin::OnNewFrame(const unsigned char */*_image*/,
     }
   }
 
+  IGN_PROFILE_END();
+
+  IGN_PROFILE_BEGIN("FiducialCameraPlugin::publish");
   this->dataPtr->Publish(results);
+  IGN_PROFILE_END();
 }
 
 /////////////////////////////////////////////////

--- a/plugins/FiducialCameraPlugin.cc
+++ b/plugins/FiducialCameraPlugin.cc
@@ -187,8 +187,8 @@ void FiducialCameraPlugin::OnNewFrame(const unsigned char */*_image*/,
     const unsigned int /*_width*/, const unsigned int /*_height*/,
     const unsigned int /*_depth*/, const std::string &/*_format*/)
 {
-  IGN_PROFILE("FiducialCameraPlugin");
-  IGN_PROFILE_BEGIN("FiducialCameraPlugin::update");
+  IGN_PROFILE("FiducialCameraPlugin::OnNewFrame");
+  IGN_PROFILE_BEGIN("Update");
   if (!this->dataPtr->selectionBuffer)
   {
     std::string cameraName = this->dataPtr->camera->OgreCamera()->getName();
@@ -248,7 +248,7 @@ void FiducialCameraPlugin::OnNewFrame(const unsigned char */*_image*/,
 
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("FiducialCameraPlugin::publish");
+  IGN_PROFILE_BEGIN("Publish");
   this->dataPtr->Publish(results);
   IGN_PROFILE_END();
 }

--- a/plugins/FollowerPlugin.cc
+++ b/plugins/FollowerPlugin.cc
@@ -261,7 +261,7 @@ void FollowerPlugin::OnNewDepthFrame(const float *_image,
     const unsigned int /*_depth*/, const std::string &/*_format*/)
 {
   IGN_PROFILE("FollowerPlugin::OnNewDepthFrame");
-  IGN_PROFILE_BEGIN("FollowerPlugin::fillarray");
+  IGN_PROFILE_BEGIN("fillarray");
 
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
@@ -284,8 +284,8 @@ void FollowerPlugin::OnNewDepthFrame(const float *_image,
 /////////////////////////////////////////////////
 void FollowerPlugin::UpdateFollower()
 {
-  IGN_PROFILE("FollowerPlugin");
-  IGN_PROFILE_BEGIN("FollowerPlugin::update");
+  IGN_PROFILE("FollowerPlugin::UpdateFollower");
+  IGN_PROFILE_BEGIN("Update");
 
   if (this->dataPtr->imageMsg.width() == 0u ||
       this->dataPtr->imageMsg.height() == 0u)

--- a/plugins/FollowerPlugin.cc
+++ b/plugins/FollowerPlugin.cc
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <string>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/AxisAlignedBox.hh>
 
 #include <sdf/sdf.hh>
@@ -259,6 +260,9 @@ void FollowerPlugin::OnNewDepthFrame(const float *_image,
     const unsigned int _width, const unsigned int _height,
     const unsigned int /*_depth*/, const std::string &/*_format*/)
 {
+  IGN_PROFILE("FollowerPlugin::OnNewDepthFrame");
+  IGN_PROFILE_BEGIN("FollowerPlugin::fillarray");
+
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
 
   float f;
@@ -274,14 +278,19 @@ void FollowerPlugin::OnNewDepthFrame(const float *_image,
   }
 
   memcpy(this->dataPtr->depthBuffer, _image, depthBufferSize);
+  IGN_PROFILE_END();
 }
 
 /////////////////////////////////////////////////
 void FollowerPlugin::UpdateFollower()
 {
+  IGN_PROFILE("FollowerPlugin");
+  IGN_PROFILE_BEGIN("FollowerPlugin::update");
+
   if (this->dataPtr->imageMsg.width() == 0u ||
       this->dataPtr->imageMsg.height() == 0u)
   {
+    IGN_PROFILE_END();
     return;
   }
 
@@ -311,6 +320,7 @@ void FollowerPlugin::UpdateFollower()
     // Brakes on!
     this->dataPtr->leftJoint->SetVelocity(0, 0);
     this->dataPtr->rightJoint->SetVelocity(0, 0);
+    IGN_PROFILE_END();
     return;
   }
 
@@ -334,4 +344,5 @@ void FollowerPlugin::UpdateFollower()
 
   this->dataPtr->leftJoint->SetVelocity(0, leftVelDesired);
   this->dataPtr->rightJoint->SetVelocity(0, rightVelDesired);
+  IGN_PROFILE_END();
 }

--- a/plugins/GimbalSmall2dPlugin.cc
+++ b/plugins/GimbalSmall2dPlugin.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "ignition/common/Profiler.hh"
 #include "gazebo/common/PID.hh"
 #include "gazebo/physics/physics.hh"
 #include "gazebo/transport/transport.hh"
@@ -132,12 +133,16 @@ void GimbalSmall2dPlugin::OnUpdate()
   if (!this->dataPtr->tiltJoint)
     return;
 
+  IGN_PROFILE("GimbalSmall2dPlugin");
+  IGN_PROFILE_BEGIN("GimbalSmall2dPlugin::update");
+
   double angle = this->dataPtr->tiltJoint->Position(0);
 
   common::Time time = this->dataPtr->model->GetWorld()->SimTime();
   if (time < this->dataPtr->lastUpdateTime)
   {
     this->dataPtr->lastUpdateTime = time;
+    IGN_PROFILE_END();
     return;
   }
   else if (time > this->dataPtr->lastUpdateTime)
@@ -159,4 +164,5 @@ void GimbalSmall2dPlugin::OnUpdate()
     m.set_data(ss.str());
     this->dataPtr->pub->Publish(m);
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/GimbalSmall2dPlugin.cc
+++ b/plugins/GimbalSmall2dPlugin.cc
@@ -133,8 +133,8 @@ void GimbalSmall2dPlugin::OnUpdate()
   if (!this->dataPtr->tiltJoint)
     return;
 
-  IGN_PROFILE("GimbalSmall2dPlugin");
-  IGN_PROFILE_BEGIN("GimbalSmall2dPlugin::update");
+  IGN_PROFILE("GimbalSmall2dPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
 
   double angle = this->dataPtr->tiltJoint->Position(0);
 

--- a/plugins/GravityCompensationPlugin.cc
+++ b/plugins/GravityCompensationPlugin.cc
@@ -19,6 +19,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <ignition/common/Profiler.hh>
+
 #include <gazebo/transport/Node.hh>
 #include <gazebo/transport/Subscriber.hh>
 #include <gazebo/common/Events.hh>
@@ -193,6 +195,9 @@ void GravityCompensationPlugin::Load(physics::ModelPtr _model,
 /////////////////////////////////////////////////
 void GravityCompensationPlugin::Update(const common::UpdateInfo &/*_info*/)
 {
+  IGN_PROFILE("GravityCompensationPlugin");
+  IGN_PROFILE_BEGIN("GravityCompensationPlugin::update");
+
   dart::dynamics::Joint *dtJoint = this->dataPtr->skel->getRootJoint();
   if (dtJoint == nullptr)
   {
@@ -238,6 +243,7 @@ void GravityCompensationPlugin::Update(const common::UpdateInfo &/*_info*/)
       joint->SetForce(i, forces[dtJoint->getIndexInSkeleton(i)]);
     }
   }
+  IGN_PROFILE_END();
 }
 
 /////////////////////////////////////////////////

--- a/plugins/GravityCompensationPlugin.cc
+++ b/plugins/GravityCompensationPlugin.cc
@@ -195,8 +195,8 @@ void GravityCompensationPlugin::Load(physics::ModelPtr _model,
 /////////////////////////////////////////////////
 void GravityCompensationPlugin::Update(const common::UpdateInfo &/*_info*/)
 {
-  IGN_PROFILE("GravityCompensationPlugin");
-  IGN_PROFILE_BEGIN("GravityCompensationPlugin::update");
+  IGN_PROFILE("GravityCompensationPlugin::Update");
+  IGN_PROFILE_BEGIN("Update");
 
   dart::dynamics::Joint *dtJoint = this->dataPtr->skel->getRootJoint();
   if (dtJoint == nullptr)

--- a/plugins/JointTrajectoryPlugin.cc
+++ b/plugins/JointTrajectoryPlugin.cc
@@ -83,8 +83,8 @@ void JointTrajectoryPlugin::Load(physics::ModelPtr _parent,
 /////////////////////////////////////////////////
 void JointTrajectoryPlugin::UpdateStates(const common::UpdateInfo & /*_info*/)
 {
-  IGN_PROFILE("JointTrajectoryPlugin");
-  IGN_PROFILE_BEGIN("JointTrajectoryPlugin::update");
+  IGN_PROFILE("JointTrajectoryPlugin::UpdateStates");
+  IGN_PROFILE_BEGIN("Update");
   common::Time cur_time = this->world->SimTime();
 
   // for (physics::Joint_V::const_iterator j = this->model->GetJoints().begin();

--- a/plugins/JointTrajectoryPlugin.cc
+++ b/plugins/JointTrajectoryPlugin.cc
@@ -17,6 +17,8 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include <plugins/JointTrajectoryPlugin.hh>
 
 namespace gazebo
@@ -81,6 +83,8 @@ void JointTrajectoryPlugin::Load(physics::ModelPtr _parent,
 /////////////////////////////////////////////////
 void JointTrajectoryPlugin::UpdateStates(const common::UpdateInfo & /*_info*/)
 {
+  IGN_PROFILE("JointTrajectoryPlugin");
+  IGN_PROFILE_BEGIN("JointTrajectoryPlugin::update");
   common::Time cur_time = this->world->SimTime();
 
   // for (physics::Joint_V::const_iterator j = this->model->GetJoints().begin();
@@ -104,6 +108,7 @@ void JointTrajectoryPlugin::UpdateStates(const common::UpdateInfo & /*_info*/)
 
   // resume original pause-state
   this->world->SetPaused(is_paused);
+  IGN_PROFILE_END();
 }
 
 GZ_REGISTER_MODEL_PLUGIN(JointTrajectoryPlugin)

--- a/plugins/LiftDragPlugin.cc
+++ b/plugins/LiftDragPlugin.cc
@@ -401,5 +401,4 @@ void LiftDragPlugin::OnUpdate()
   this->link->AddForceAtRelativePosition(force, this->cp);
   this->link->AddTorque(torque);
   IGN_PROFILE_END();
-
 }

--- a/plugins/LiftDragPlugin.cc
+++ b/plugins/LiftDragPlugin.cc
@@ -177,8 +177,8 @@ void LiftDragPlugin::OnUpdate()
   if (vel.Length() <= 0.01)
     return;
 
-  IGN_PROFILE("LiftDragPlugin");
-  IGN_PROFILE_BEGIN((std::string("LiftDragPlugin::Update") + std::string(this->link->GetName())).c_str());
+  IGN_PROFILE("LiftDragPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN(std::string(this->link->GetName()).c_str());
 
   // pose of body
   ignition::math::Pose3d pose = this->link->WorldPose();

--- a/plugins/LiftDragPlugin.cc
+++ b/plugins/LiftDragPlugin.cc
@@ -19,6 +19,7 @@
 #include <functional>
 #include <string>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Pose3.hh>
 
 #include "gazebo/common/Assert.hh"
@@ -175,6 +176,9 @@ void LiftDragPlugin::OnUpdate()
 
   if (vel.Length() <= 0.01)
     return;
+
+  IGN_PROFILE("LiftDragPlugin");
+  IGN_PROFILE_BEGIN((std::string("LiftDragPlugin::Update") + std::string(this->link->GetName())).c_str());
 
   // pose of body
   ignition::math::Pose3d pose = this->link->WorldPose();
@@ -396,4 +400,6 @@ void LiftDragPlugin::OnUpdate()
   // apply forces at cg (with torques for position shift)
   this->link->AddForceAtRelativePosition(force, this->cp);
   this->link->AddTorque(torque);
+  IGN_PROFILE_END();
+
 }

--- a/plugins/LinearBatteryPlugin.cc
+++ b/plugins/LinearBatteryPlugin.cc
@@ -128,8 +128,8 @@ void LinearBatteryPlugin::Reset()
 /////////////////////////////////////////////////
 double LinearBatteryPlugin::OnUpdateVoltage(const common::BatteryPtr &_battery)
 {
-  IGN_PROFILE("LinearBatteryPlugin");
-  IGN_PROFILE_BEGIN("LinearBatteryPlugin::update");
+  IGN_PROFILE("LinearBatteryPlugin::OnUpdateVoltage");
+  IGN_PROFILE_BEGIN("Update");
   double dt = this->world->Physics()->GetMaxStepSize();
   double totalpower = 0.0;
   double k = dt / this->tau;

--- a/plugins/LinearBatteryPlugin.cc
+++ b/plugins/LinearBatteryPlugin.cc
@@ -17,6 +17,8 @@
 #include <string>
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/Assert.hh"
 #include "gazebo/common/Time.hh"
 #include "gazebo/common/Battery.hh"
@@ -126,6 +128,8 @@ void LinearBatteryPlugin::Reset()
 /////////////////////////////////////////////////
 double LinearBatteryPlugin::OnUpdateVoltage(const common::BatteryPtr &_battery)
 {
+  IGN_PROFILE("LinearBatteryPlugin");
+  IGN_PROFILE_BEGIN("LinearBatteryPlugin::update");
   double dt = this->world->Physics()->GetMaxStepSize();
   double totalpower = 0.0;
   double k = dt / this->tau;
@@ -141,6 +145,8 @@ double LinearBatteryPlugin::OnUpdateVoltage(const common::BatteryPtr &_battery)
   this->ismooth = this->ismooth + k * (this->iraw - this->ismooth);
 
   this->q = this->q - GZ_SEC_TO_HOUR(dt * this->ismooth);
+
+  IGN_PROFILE_END();
 
   return this->e0 + this->e1 * (1 - this->q / this->c)
     - this->r * this->ismooth;

--- a/plugins/LinkPlot3DPlugin.cc
+++ b/plugins/LinkPlot3DPlugin.cc
@@ -204,7 +204,8 @@ void LinkPlot3DPlugin::OnUpdate()
   }
 
   // Throttle update
-  if ((currentTime - this->dataPtr->prevTime).Double() < this->dataPtr->period){
+  if ((currentTime - this->dataPtr->prevTime).Double() < this->dataPtr->period)
+  {
     IGN_PROFILE_END();
     return;
   }

--- a/plugins/LinkPlot3DPlugin.cc
+++ b/plugins/LinkPlot3DPlugin.cc
@@ -189,8 +189,8 @@ void LinkPlot3DPlugin::Load(physics::ModelPtr _model,
 /////////////////////////////////////////////////
 void LinkPlot3DPlugin::OnUpdate()
 {
-  IGN_PROFILE("LinkPlot3DPlugin");
-  IGN_PROFILE_BEGIN("LinkPlot3DPlugin::update");
+  IGN_PROFILE("LinkPlot3DPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   auto currentTime = this->dataPtr->world->SimTime();
 
   // check for world reset

--- a/plugins/LinkPlot3DPlugin.cc
+++ b/plugins/LinkPlot3DPlugin.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/msgs.hh>
@@ -188,6 +189,8 @@ void LinkPlot3DPlugin::Load(physics::ModelPtr _model,
 /////////////////////////////////////////////////
 void LinkPlot3DPlugin::OnUpdate()
 {
+  IGN_PROFILE("LinkPlot3DPlugin");
+  IGN_PROFILE_BEGIN("LinkPlot3DPlugin::update");
   auto currentTime = this->dataPtr->world->SimTime();
 
   // check for world reset
@@ -196,12 +199,15 @@ void LinkPlot3DPlugin::OnUpdate()
     this->dataPtr->prevTime = currentTime;
     for (auto &plot : this->dataPtr->plots)
       plot.msg.mutable_point()->Clear();
+    IGN_PROFILE_END();
     return;
   }
 
   // Throttle update
-  if ((currentTime - this->dataPtr->prevTime).Double() < this->dataPtr->period)
+  if ((currentTime - this->dataPtr->prevTime).Double() < this->dataPtr->period){
+    IGN_PROFILE_END();
     return;
+  }
 
   this->dataPtr->prevTime = currentTime;
 
@@ -224,4 +230,5 @@ void LinkPlot3DPlugin::OnUpdate()
       this->dataPtr->node.Request("/marker", plot.msg);
     }
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/MisalignmentPlugin.cc
+++ b/plugins/MisalignmentPlugin.cc
@@ -143,8 +143,8 @@ void MisalignmentPluginPrivate::Enable(ConstIntPtr &_msg)
 /////////////////////////////////////////////////
 void MisalignmentPluginPrivate::OnUpdate(const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("MisalignmentPluginPrivate");
-  IGN_PROFILE_BEGIN("MisalignmentPluginPrivate::update");
+  IGN_PROFILE("MisalignmentPluginPrivate::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   // These poses may or may not be in world frame
   ignition::math::Pose3d refPose = this->referencePose;
   ignition::math::Pose3d tgtPose = this->targetPose;

--- a/plugins/MisalignmentPlugin.cc
+++ b/plugins/MisalignmentPlugin.cc
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Pose3.hh>
 
 #include "gazebo/common/Events.hh"
@@ -142,6 +143,8 @@ void MisalignmentPluginPrivate::Enable(ConstIntPtr &_msg)
 /////////////////////////////////////////////////
 void MisalignmentPluginPrivate::OnUpdate(const common::UpdateInfo &_info)
 {
+  IGN_PROFILE("MisalignmentPluginPrivate");
+  IGN_PROFILE_BEGIN("MisalignmentPluginPrivate::update");
   // These poses may or may not be in world frame
   ignition::math::Pose3d refPose = this->referencePose;
   ignition::math::Pose3d tgtPose = this->targetPose;
@@ -162,6 +165,7 @@ void MisalignmentPluginPrivate::OnUpdate(const common::UpdateInfo &_info)
           gzwarn << "Did not find target " << this->targetFrameName << "\n";
           this->didWarnTgt = true;
         }
+        IGN_PROFILE_END();
         return;
       }
       this->didWarnTgt = false;
@@ -193,6 +197,7 @@ void MisalignmentPluginPrivate::OnUpdate(const common::UpdateInfo &_info)
             << this->referenceFrameName << "\n";
           this->didWarnRef = true;
         }
+        IGN_PROFILE_END();
         return;
       }
       this->didWarnRef = false;
@@ -246,6 +251,7 @@ void MisalignmentPluginPrivate::OnUpdate(const common::UpdateInfo &_info)
   msgs::Set(msg.mutable_time(), _info.simTime);
   msgs::Set(msg.mutable_pose(), misalignment);
   this->pubMisalignment->Publish(msg);
+  IGN_PROFILE_END();
 }
 
 

--- a/plugins/MudPlugin.cc
+++ b/plugins/MudPlugin.cc
@@ -21,6 +21,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Quaternion.hh>
@@ -179,6 +180,8 @@ void MudPlugin::OnContact(ConstContactsPtr &_msg)
 /////////////////////////////////////////////////
 void MudPlugin::OnUpdate()
 {
+  IGN_PROFILE("MudPlugin");
+  IGN_PROFILE_BEGIN("MudPlugin::update");
   double dt = this->physics->GetMaxStepSize();
   if (dt < 1e-6)
     dt = 1e-6;
@@ -352,4 +355,5 @@ void MudPlugin::OnUpdate()
           << " waited 1.0 s without contact messages\n";
     this->newMsgWait = 0;
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/MudPlugin.cc
+++ b/plugins/MudPlugin.cc
@@ -180,8 +180,8 @@ void MudPlugin::OnContact(ConstContactsPtr &_msg)
 /////////////////////////////////////////////////
 void MudPlugin::OnUpdate()
 {
-  IGN_PROFILE("MudPlugin");
-  IGN_PROFILE_BEGIN("MudPlugin::update");
+  IGN_PROFILE("MudPlugin:OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   double dt = this->physics->GetMaxStepSize();
   if (dt < 1e-6)
     dt = 1e-6;

--- a/plugins/PlaneDemoPlugin.cc
+++ b/plugins/PlaneDemoPlugin.cc
@@ -365,8 +365,8 @@ void PlaneDemoPlugin::Init()
 /////////////////////////////////////////////////
 void PlaneDemoPlugin::OnUpdate()
 {
-  IGN_PROFILE("PlaneDemoPlugin");
-  IGN_PROFILE_BEGIN("PlaneDemoPlugin::update");
+  IGN_PROFILE("PlaneDemoPlugin:OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   // gzdbg << "executing OnUpdate.\n";
   {
     std::lock_guard<std::mutex> lock(this->dataPtr->mutex);

--- a/plugins/PlaneDemoPlugin.cc
+++ b/plugins/PlaneDemoPlugin.cc
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <functional>
 #include <thread>
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Pose3.hh>
 
@@ -364,6 +365,8 @@ void PlaneDemoPlugin::Init()
 /////////////////////////////////////////////////
 void PlaneDemoPlugin::OnUpdate()
 {
+  IGN_PROFILE("PlaneDemoPlugin");
+  IGN_PROFILE_BEGIN("PlaneDemoPlugin::update");
   // gzdbg << "executing OnUpdate.\n";
   {
     std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
@@ -398,6 +401,7 @@ void PlaneDemoPlugin::OnUpdate()
     }
     this->dataPtr->lastUpdateTime = curTime;
   }
+  IGN_PROFILE_END();
 }
 
 /////////////////////////////////////////////////

--- a/plugins/PressurePlugin.cc
+++ b/plugins/PressurePlugin.cc
@@ -127,8 +127,8 @@ void PressurePlugin::Init()
 /////////////////////////////////////////////////
 void PressurePlugin::OnUpdate()
 {
-  IGN_PROFILE("PressurePlugin");
-  IGN_PROFILE_BEGIN("PressurePlugin::update");
+  IGN_PROFILE("PressurePlugin:OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
 
   msgs::Tactile tactileMsg;
 

--- a/plugins/PressurePlugin.cc
+++ b/plugins/PressurePlugin.cc
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <boost/algorithm/string.hpp>
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Vector3.hh>
 #include <gazebo/physics/Base.hh>
 #include "PressurePlugin.hh"
@@ -126,6 +127,9 @@ void PressurePlugin::Init()
 /////////////////////////////////////////////////
 void PressurePlugin::OnUpdate()
 {
+  IGN_PROFILE("PressurePlugin");
+  IGN_PROFILE_BEGIN("PressurePlugin::update");
+
   msgs::Tactile tactileMsg;
 
   // For each collision attached to this sensor
@@ -171,4 +175,5 @@ void PressurePlugin::OnUpdate()
     if (this->tactilePub && tactileMsg.pressure_size() > 0)
       this->tactilePub->Publish(tactileMsg);
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/RandomVelocityPlugin.cc
+++ b/plugins/RandomVelocityPlugin.cc
@@ -145,8 +145,8 @@ void RandomVelocityPlugin::Reset()
 /////////////////////////////////////////////////
 void RandomVelocityPlugin::Update(const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("RandomVelocityPlugin");
-  IGN_PROFILE_BEGIN("RandomVelocityPlugin::update");
+  IGN_PROFILE("RandomVelocityPlugin:Update");
+  IGN_PROFILE_BEGIN("Update");
   GZ_ASSERT(this->dataPtr->link, "<link> in RandomVelocity plugin is null");
 
   // Short-circuit in case the link is invalid.

--- a/plugins/RandomVelocityPlugin.cc
+++ b/plugins/RandomVelocityPlugin.cc
@@ -17,6 +17,7 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Rand.hh>
 #include <gazebo/common/Events.hh>
 #include <gazebo/common/Assert.hh>
@@ -144,6 +145,8 @@ void RandomVelocityPlugin::Reset()
 /////////////////////////////////////////////////
 void RandomVelocityPlugin::Update(const common::UpdateInfo &_info)
 {
+  IGN_PROFILE("RandomVelocityPlugin");
+  IGN_PROFILE_BEGIN("RandomVelocityPlugin::update");
   GZ_ASSERT(this->dataPtr->link, "<link> in RandomVelocity plugin is null");
 
   // Short-circuit in case the link is invalid.
@@ -180,4 +183,5 @@ void RandomVelocityPlugin::Update(const common::UpdateInfo &_info)
 
   // Apply velocity
   this->dataPtr->link->SetLinearVel(this->dataPtr->velocity);
+  IGN_PROFILE_END();
 }

--- a/plugins/SimpleTrackedVehiclePlugin.cc
+++ b/plugins/SimpleTrackedVehiclePlugin.cc
@@ -301,8 +301,8 @@ void SimpleTrackedVehiclePlugin::DriveTracks(
   if (this->contactManager->GetContactCount() == 0)
     return;
 
-  IGN_PROFILE("SimpleTrackedVehiclePlugin");
-  IGN_PROFILE_BEGIN("SimpleTrackedVehiclePlugin::update");
+  IGN_PROFILE("SimpleTrackedVehiclePlugin::DriveTracks");
+  IGN_PROFILE_BEGIN("Update");
 
   /////////////////////////////////////////////
   // Calculate the desired center of rotation

--- a/plugins/SimpleTrackedVehiclePlugin.cc
+++ b/plugins/SimpleTrackedVehiclePlugin.cc
@@ -18,6 +18,7 @@
 #include <functional>
 #include <vector>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Pose3.hh>
 
@@ -300,6 +301,9 @@ void SimpleTrackedVehiclePlugin::DriveTracks(
   if (this->contactManager->GetContactCount() == 0)
     return;
 
+  IGN_PROFILE("SimpleTrackedVehiclePlugin");
+  IGN_PROFILE_BEGIN("SimpleTrackedVehiclePlugin::update");
+
   /////////////////////////////////////////////
   // Calculate the desired center of rotation
   /////////////////////////////////////////////
@@ -476,6 +480,7 @@ void SimpleTrackedVehiclePlugin::DriveTracks(
       continue;
     }
   }
+  IGN_PROFILE_END();
 }
 
 ignition::math::Vector3d SimpleTrackedVehiclePlugin::ComputeFrictionDirection(

--- a/plugins/SkidSteerDrivePlugin.cc
+++ b/plugins/SkidSteerDrivePlugin.cc
@@ -117,8 +117,8 @@ void SkidSteerDrivePlugin::Load(physics::ModelPtr _model,
 /////////////////////////////////////////////////
 void SkidSteerDrivePlugin::OnVelMsg(ConstPosePtr &_msg)
 {
-  IGN_PROFILE("SkidSteerDrivePlugin");
-  IGN_PROFILE_BEGIN("SkidSteerDrivePlugin::update");
+  IGN_PROFILE("SkidSteerDrivePlugin::OnVelMsg");
+  IGN_PROFILE_BEGIN("Update");
   // gzmsg << "cmd_vel: " << msg->position().x() << ", "
   //       << msgs::Convert(msg->orientation()).GetAsEuler().z << std::endl;
 

--- a/plugins/SkidSteerDrivePlugin.cc
+++ b/plugins/SkidSteerDrivePlugin.cc
@@ -17,6 +17,8 @@
 
 #include <string>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/physics/physics.hh"
 #include "gazebo/transport/transport.hh"
 #include "plugins/SkidSteerDrivePlugin.hh"
@@ -115,6 +117,8 @@ void SkidSteerDrivePlugin::Load(physics::ModelPtr _model,
 /////////////////////////////////////////////////
 void SkidSteerDrivePlugin::OnVelMsg(ConstPosePtr &_msg)
 {
+  IGN_PROFILE("SkidSteerDrivePlugin");
+  IGN_PROFILE_BEGIN("SkidSteerDrivePlugin::update");
   // gzmsg << "cmd_vel: " << msg->position().x() << ", "
   //       << msgs::Convert(msg->orientation()).GetAsEuler().z << std::endl;
 
@@ -126,4 +130,6 @@ void SkidSteerDrivePlugin::OnVelMsg(ConstPosePtr &_msg)
   this->joints[RIGHT_REAR ]->SetVelocity(0, vel_lin - vel_rot);
   this->joints[LEFT_FRONT ]->SetVelocity(0, vel_lin + vel_rot);
   this->joints[LEFT_REAR  ]->SetVelocity(0, vel_lin + vel_rot);
+
+  IGN_PROFILE_END();
 }

--- a/plugins/TouchPlugin.cc
+++ b/plugins/TouchPlugin.cc
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <string>
+#include <ignition/common/Profiler.hh>
 #include <gazebo/common/Assert.hh>
 #include <gazebo/physics/Model.hh>
 #include <gazebo/sensors/SensorManager.hh>
@@ -146,6 +147,8 @@ void TouchPlugin::Enable(ConstIntPtr &_msg)
 /////////////////////////////////////////////////
 void TouchPlugin::OnUpdate(const common::UpdateInfo &_info)
 {
+  IGN_PROFILE("TouchPlugin");
+  IGN_PROFILE_BEGIN("TouchPlugin::update");
   // Get all contacts across all sensors
   msgs::Contacts contacts;
 
@@ -181,6 +184,7 @@ void TouchPlugin::OnUpdate(const common::UpdateInfo &_info)
               << std::endl;
       }
       this->touchStart = common::Time::Zero;
+      IGN_PROFILE_END();
       return;
     }
   }
@@ -200,6 +204,7 @@ void TouchPlugin::OnUpdate(const common::UpdateInfo &_info)
       gzmsg << "Not touching anything" << std::endl;
     }
     this->touchStart = common::Time::Zero;
+    IGN_PROFILE_END();
     return;
   }
 
@@ -231,5 +236,5 @@ void TouchPlugin::OnUpdate(const common::UpdateInfo &_info)
     m->set_data(0);
     this->Enable(m);
   }
+  IGN_PROFILE_END();
 }
-

--- a/plugins/TouchPlugin.cc
+++ b/plugins/TouchPlugin.cc
@@ -147,8 +147,8 @@ void TouchPlugin::Enable(ConstIntPtr &_msg)
 /////////////////////////////////////////////////
 void TouchPlugin::OnUpdate(const common::UpdateInfo &_info)
 {
-  IGN_PROFILE("TouchPlugin");
-  IGN_PROFILE_BEGIN("TouchPlugin::update");
+  IGN_PROFILE("TouchPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   // Get all contacts across all sensors
   msgs::Contacts contacts;
 

--- a/plugins/TransporterPlugin.cc
+++ b/plugins/TransporterPlugin.cc
@@ -149,8 +149,8 @@ void TransporterPlugin::OnActivation(ConstGzStringPtr &_msg)
 /////////////////////////////////////////////////
 void TransporterPlugin::Update()
 {
-  IGN_PROFILE("TransporterPlugin");
-  IGN_PROFILE_BEGIN("TransporterPlugin::update");
+  IGN_PROFILE("TransporterPlugin::Update");
+  IGN_PROFILE_BEGIN("Update");
   // Get all the models
   physics::Model_V models = this->dataPtr->world->Models();
 

--- a/plugins/TransporterPlugin.cc
+++ b/plugins/TransporterPlugin.cc
@@ -17,6 +17,8 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include <gazebo/common/Events.hh>
 #include <gazebo/common/Assert.hh>
 #include <gazebo/common/Console.hh>
@@ -147,6 +149,8 @@ void TransporterPlugin::OnActivation(ConstGzStringPtr &_msg)
 /////////////////////////////////////////////////
 void TransporterPlugin::Update()
 {
+  IGN_PROFILE("TransporterPlugin");
+  IGN_PROFILE_BEGIN("TransporterPlugin::update");
   // Get all the models
   physics::Model_V models = this->dataPtr->world->Models();
 
@@ -184,4 +188,5 @@ void TransporterPlugin::Update()
       }
     }
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/VehiclePlugin.cc
+++ b/plugins/VehiclePlugin.cc
@@ -17,6 +17,8 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/physics/physics.hh"
 #include "gazebo/transport/transport.hh"
 #include "plugins/VehiclePlugin.hh"
@@ -184,6 +186,8 @@ void VehiclePlugin::Init()
 /////////////////////////////////////////////////
 void VehiclePlugin::OnUpdate()
 {
+  IGN_PROFILE("VehiclePlugin");
+  IGN_PROFILE_BEGIN("VehiclePlugin::update");
   // Get the normalized gas and brake amount
   double gas = this->gasJoint->Position(0) / this->maxGas;
   double brake = this->brakeJoint->Position(0) / this->maxBrake;
@@ -266,6 +270,7 @@ void VehiclePlugin::OnUpdate()
       this->chassis->AddForceAtWorldPosition(axis * -amt, p.Pos());
     }
   }
+  IGN_PROFILE_END();
 }
 
 /////////////////////////////////////////////////

--- a/plugins/VehiclePlugin.cc
+++ b/plugins/VehiclePlugin.cc
@@ -186,8 +186,8 @@ void VehiclePlugin::Init()
 /////////////////////////////////////////////////
 void VehiclePlugin::OnUpdate()
 {
-  IGN_PROFILE("VehiclePlugin");
-  IGN_PROFILE_BEGIN("VehiclePlugin::update");
+  IGN_PROFILE("VehiclePlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   // Get the normalized gas and brake amount
   double gas = this->gasJoint->Position(0) / this->maxGas;
   double brake = this->brakeJoint->Position(0) / this->maxBrake;

--- a/plugins/WheelSlipPlugin.cc
+++ b/plugins/WheelSlipPlugin.cc
@@ -457,8 +457,8 @@ void WheelSlipPlugin::SetSlipComplianceLongitudinal(const double _compliance)
 /////////////////////////////////////////////////
 void WheelSlipPlugin::Update()
 {
-  IGN_PROFILE("WheelSlipPlugin");
-  IGN_PROFILE_BEGIN("WheelSlipPlugin::update");
+  IGN_PROFILE("WheelSlipPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   // Get slip data so it can be published later
   std::map<std::string, ignition::math::Vector3d> slips;
   this->GetSlips(slips);

--- a/plugins/WheelSlipPlugin.cc
+++ b/plugins/WheelSlipPlugin.cc
@@ -17,6 +17,8 @@
 #include <map>
 #include <mutex>
 
+#include <ignition/common/Profiler.hh>
+
 #include <gazebo/common/Assert.hh>
 #include <gazebo/common/CommonTypes.hh>
 #include <gazebo/common/Console.hh>
@@ -455,6 +457,8 @@ void WheelSlipPlugin::SetSlipComplianceLongitudinal(const double _compliance)
 /////////////////////////////////////////////////
 void WheelSlipPlugin::Update()
 {
+  IGN_PROFILE("WheelSlipPlugin");
+  IGN_PROFILE_BEGIN("WheelSlipPlugin::update");
   // Get slip data so it can be published later
   std::map<std::string, ignition::math::Vector3d> slips;
   this->GetSlips(slips);
@@ -515,4 +519,5 @@ void WheelSlipPlugin::Update()
         params.slipPub->Publish(msg);
     }
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/WheelTrackedVehiclePlugin.cc
+++ b/plugins/WheelTrackedVehiclePlugin.cc
@@ -17,6 +17,8 @@
 
 #include <boost/pointer_cast.hpp>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/Plugin.hh"
 #include "gazebo/physics/ode/ODEPhysics.hh"
 
@@ -210,6 +212,8 @@ void WheelTrackedVehiclePlugin::UpdateTrackSurface()
 
 void WheelTrackedVehiclePlugin::OnUpdate()
 {
+  IGN_PROFILE("WheelTrackedVehiclePlugin");
+  IGN_PROFILE_BEGIN("WheelTrackedVehiclePlugin::update");
   std::lock_guard<std::mutex> lock(this->mutex);
 
   for (auto trackPair : this->trackNames)
@@ -222,4 +226,5 @@ void WheelTrackedVehiclePlugin::OnUpdate()
       wheel->joint->SetVelocity(0, angularVelocity);
     }
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/WheelTrackedVehiclePlugin.cc
+++ b/plugins/WheelTrackedVehiclePlugin.cc
@@ -212,8 +212,8 @@ void WheelTrackedVehiclePlugin::UpdateTrackSurface()
 
 void WheelTrackedVehiclePlugin::OnUpdate()
 {
-  IGN_PROFILE("WheelTrackedVehiclePlugin");
-  IGN_PROFILE_BEGIN("WheelTrackedVehiclePlugin::update");
+  IGN_PROFILE("WheelTrackedVehiclePlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   std::lock_guard<std::mutex> lock(this->mutex);
 
   for (auto trackPair : this->trackNames)

--- a/plugins/WindPlugin.cc
+++ b/plugins/WindPlugin.cc
@@ -17,6 +17,8 @@
 
 #include <functional>
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/Assert.hh"
 #include "gazebo/common/Event.hh"
 #include "gazebo/common/Events.hh"
@@ -291,6 +293,8 @@ ignition::math::Vector3d WindPlugin::LinearVel(const physics::Wind *_wind,
 /////////////////////////////////////////////////
 void WindPlugin::OnUpdate()
 {
+  IGN_PROFILE("WindPlugin");
+  IGN_PROFILE_BEGIN("WindPlugin::update");
   // Update loop for using the force on mass approximation
   // This is not recommended. Please use the LiftDragPlugin instead.
 
@@ -316,4 +320,5 @@ void WindPlugin::OnUpdate()
           (link->RelativeWindLinearVel() - link->RelativeLinearVel()));
     }
   }
+  IGN_PROFILE_END();
 }

--- a/plugins/WindPlugin.cc
+++ b/plugins/WindPlugin.cc
@@ -293,8 +293,8 @@ ignition::math::Vector3d WindPlugin::LinearVel(const physics::Wind *_wind,
 /////////////////////////////////////////////////
 void WindPlugin::OnUpdate()
 {
-  IGN_PROFILE("WindPlugin");
-  IGN_PROFILE_BEGIN("WindPlugin::update");
+  IGN_PROFILE("WindPlugin::OnUpdate");
+  IGN_PROFILE_BEGIN("Update");
   // Update loop for using the force on mass approximation
   // This is not recommended. Please use the LiftDragPlugin instead.
 

--- a/worlds/profiler.world
+++ b/worlds/profiler.world
@@ -1,0 +1,474 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <model name="sphere">
+      <pose>2 0 0 0 0 0</pose>
+      <link name="body">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="geom">
+          <geometry>
+            <sphere>
+              <radius>1</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>1</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <static>true</static>
+    </model>
+    <model name="camera_model">
+      <pose>0 0 0 0 0 0</pose>
+      <link name="my_link">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <sensor name="camera" type="depth">
+          <camera>
+            <horizontal_fov>1.04719755</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>20</far>
+            </clip>
+          </camera>
+          <plugin filename="libDepthCameraPlugin.so" name="depth_camera_plugin" />
+          <always_on>true</always_on>
+          <update_rate>10</update_rate>
+        </sensor>
+      </link>
+      <static>true</static>
+    </model>
+    <model name="camera_model1">
+      <pose>0 1 0 0 0 0</pose>
+      <link name="my_link1">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <sensor name="camera" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+        </sensor>
+      </link>
+      <static>true</static>
+    </model>
+    <model name="camera_model2">
+      <pose>1 0 0 0 0 0</pose>
+      <link name="my_link2">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <sensor name="camera2" type="camera">
+          <camera>
+            <horizontal_fov>1.04719755</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>20</far>
+            </clip>
+          </camera>
+          <plugin filename="libCameraPlugin.so" name="camera_plugin" />
+          <always_on>true</always_on>
+          <update_rate>10</update_rate>
+        </sensor>
+      </link>
+      <static>true</static>
+    </model>
+    <model name="model_1">
+      <static>true</static>
+      <pose>0 0 0.035 0. 0 0</pose>
+      <link name="link_1">
+        <inertial>
+          <mass>0.1</mass>
+        </inertial>
+        <visual name="visual">
+          <geometry>
+            <mesh>
+              <uri>model://hokuyo/meshes/hokuyo.dae</uri>
+            </mesh>
+          </geometry>
+        </visual>
+        <collision name="collision-base">
+          <pose>0 0 -0.0145 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.05 0.041</size>
+            </box>
+          </geometry>
+        </collision>
+        <collision name="collision-top">
+          <pose>0 0 0.0205 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.021</radius>
+              <length>0.029</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <sensor name='gps' type='gps'>
+          <always_on>1</always_on>
+          <update_rate>10.000000</update_rate>
+          <gps>
+            <position_sensing>
+              <horizontal>
+                <noise type='gaussian_quantized'>
+                  <mean>0</mean>
+                  <stddev>1</stddev>
+                  <bias_mean>3</bias_mean>
+                  <bias_stddev>1</bias_stddev>
+                  <precision>0.5</precision>
+                </noise>
+              </horizontal>
+              <vertical>
+                <noise type='gaussian_quantized'>
+                  <mean>0</mean>
+                  <stddev>1</stddev>
+                  <bias_mean>3</bias_mean>
+                  <bias_stddev>1</bias_stddev>
+                  <precision>1.0</precision>
+                </noise>
+              </vertical>
+            </position_sensing>
+            <velocity_sensing>
+              <horizontal>
+                <noise type='gaussian_quantized'>
+                  <mean>0</mean>
+                  <stddev>0.1</stddev>
+                  <bias_mean>0.1</bias_mean>
+                  <bias_stddev>0.1</bias_stddev>
+                  <precision>0.1</precision>
+                </noise>
+              </horizontal>
+              <vertical>
+                <noise type='gaussian_quantized'>
+                  <mean>0</mean>
+                  <stddev>0.2</stddev>
+                  <bias_mean>0.2</bias_mean>
+                  <bias_stddev>0.2</bias_stddev>
+                  <precision>0.2</precision>
+                </noise>
+              </vertical>
+            </velocity_sensing>
+          </gps>
+        </sensor>
+        <sensor name="laser_sensor" type="gpu_ray">
+          <pose>0.1 0 0.0175 0 -0 0</pose>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>640</samples>
+                <resolution>1</resolution>
+                <min_angle>-1.396263</min_angle>
+                <max_angle>1.396263</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>1</samples>
+                <resolution>1</resolution>
+                <min_angle>0</min_angle>
+                <max_angle>0</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>0.08</min>
+              <max>10.0</max>
+              <resolution>0.01</resolution>
+            </range>
+          </ray>
+          <always_on>1</always_on>
+          <update_rate>100</update_rate>
+          <visualize>true</visualize>
+          <plugin filename="libGpuRayPlugin.so" name="gpuray_plugin" />
+        </sensor>
+        <sensor name="imu" type="imu">
+          <always_on>true</always_on>
+        </sensor>
+        <sensor name="magnetometer" type="magnetometer">
+          <always_on>1</always_on>
+          <update_rate>20.0</update_rate>
+          <magnetometer>
+          </magnetometer>
+        </sensor>
+        <sensor name='altimeter' type='altimeter'>
+          <always_on>1</always_on>
+          <update_rate>10.0</update_rate>
+          <altimeter>
+          </altimeter>
+        </sensor>
+        <sensor name='contact' type='contact'>
+          <always_on>1</always_on>
+          <update_rate>10.0</update_rate>
+          <altimeter>
+          </altimeter>
+        </sensor>
+        <sensor name='force_torque' type='force_torque'>
+          <update_rate>30</update_rate>
+          <always_on>true</always_on>
+        </sensor>
+      </link>
+    </model>
+
+
+        <actor name="actor1">
+          <pose>0 5 1.25 0 0 0</pose>
+          <skin>
+            <filename>walk.dae</filename>
+            <scale>1.0</scale>
+          </skin>
+          <animation name="walking">
+            <filename>walk.dae</filename>
+            <scale>1.000000</scale>
+            <interpolate_x>true</interpolate_x>
+          </animation>
+
+          <plugin name="actor1_plugin" filename="libActorPlugin.so">
+            <target>0 -5 1.2138</target>
+            <target_weight>1.15</target_weight>
+            <obstacle_weight>1.8</obstacle_weight>
+            <animation_factor>5.1</animation_factor>
+            <!-- Usage: Modify the set of models that the vector field should
+                 ignore when moving the actor -->
+            <ignore_obstacles>
+              <model>cafe</model>
+              <model>ground_plane</model>
+            </ignore_obstacles>
+          </plugin>
+        </actor>
+
+        <model name="test_vehicle">
+          <pose frame=''>2 2 0 0 0 0</pose>
+          <link name='base_link'>
+            <pose frame=''>0 0 0 0 0 0</pose>
+            <inertial>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <mass>2.0</mass>
+              <inertia>
+                <ixx>0.1</ixx>
+                <ixy>0</ixy>
+                <ixz>0</ixz>
+                <iyy>0.1</iyy>
+                <iyz>0</iyz>
+                <izz>0.1</izz>
+              </inertia>
+            </inertial>
+            <collision name='base_link_collision'>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <geometry>
+                <box>
+                  <size>0.5 0.5 0.2</size>
+                </box>
+              </geometry>
+            </collision>
+            <visual name='base_link_visual'>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <geometry>
+                <box>
+                  <size>0.5 0.5 0.2</size>
+                </box>
+              </geometry>
+            </visual>
+            <self_collide>0</self_collide>
+            <gravity>1</gravity>
+            <kinematic>0</kinematic>
+          </link>
+
+          <link name='left_track'>
+            <pose frame=''>0 0.55 0 1.5701 -0 0</pose>
+            <inertial>
+              <pose frame=''>0 0 0 0 -0 0</pose>
+              <mass>0.5</mass>
+              <inertia>
+                <ixx>0.001</ixx>
+                <ixy>0</ixy>
+                <ixz>0</ixz>
+                <iyy>0.0001</iyy>
+                <iyz>0</iyz>
+                <izz>0.001</izz>
+              </inertia>
+            </inertial>
+            <collision name='left_track_collision'>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <geometry>
+                <cylinder>
+                  <radius>0.5</radius>
+                  <length>0.1</length>
+                </cylinder>
+              </geometry>
+            </collision>
+            <visual name='left_track_visual'>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <geometry>
+                <cylinder>
+                  <radius>0.5</radius>
+                  <length>0.1</length>
+                </cylinder>
+              </geometry>
+            </visual>
+            <gravity>1</gravity>
+            <kinematic>0</kinematic>
+          </link>
+          <joint name='left_track_j' type='revolute'>
+            <child>left_track</child>
+            <parent>base_link</parent>
+            <axis>
+              <xyz>0 1 0</xyz>
+              <limit>
+              </limit>
+              <use_parent_model_frame>1</use_parent_model_frame>
+            </axis>
+          </joint>
+
+          <link name='right_track'>
+            <pose frame=''>0 -0.55 0 -1.5701 0 0</pose>
+            <inertial>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <mass>0.5</mass>
+              <inertia>
+                <ixx>0.001</ixx>
+                <ixy>0</ixy>
+                <ixz>0</ixz>
+                <iyy>0.0001</iyy>
+                <iyz>0</iyz>
+                <izz>0.001</izz>
+              </inertia>
+            </inertial>
+            <collision name='right_track_collision'>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <geometry>
+                <cylinder>
+                  <radius>0.5</radius>
+                  <length>0.1</length>
+                </cylinder>
+              </geometry>
+            </collision>
+            <visual name='right_track_visual'>
+              <pose frame=''>0 0 0 0 0 0</pose>
+              <geometry>
+                <cylinder>
+                  <radius>0.5</radius>
+                  <length>0.1</length>
+                </cylinder>
+              </geometry>
+            </visual>
+            <gravity>1</gravity>
+            <kinematic>0</kinematic>
+          </link>
+
+          <joint name='right_track_j' type='revolute'>
+            <child>right_track</child>
+            <parent>base_link</parent>
+            <axis>
+              <xyz>0 1 0</xyz>
+              <limit>
+              </limit>
+              <use_parent_model_frame>1</use_parent_model_frame>
+            </axis>
+          </joint>
+
+          <plugin filename="libDiffDrivePlugin.so" name="test_vehicle">
+            <body>base_link</body>
+            <left_joint>left_track_j</left_joint>
+            <right_joint>right_track_j</right_joint>
+          </plugin>
+
+          <plugin filename="libKeysToCmdVelPlugin.so" name="keyboard_control">
+            <cmd_vel_topic>~/test_vehicle/vel_cmd</cmd_vel_topic>
+            <linear_increment>0.25</linear_increment>
+            <angular_increment>0.2</angular_increment>
+          </plugin>
+        </model>
+  </world>
+</sdf>

--- a/worlds/profiler.world
+++ b/worlds/profiler.world
@@ -1,6 +1,44 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
   <world name="default">
+    <wind>
+      <linear_velocity>0 1 0</linear_velocity>
+    </wind>
+
+    <!-- Load the plugin for the wind -->
+    <plugin name="wind" filename="libWindPlugin.so">
+      <horizontal>
+        <magnitude>
+          <time_for_rise>10</time_for_rise>
+          <sin>
+            <amplitude_percent>0.05</amplitude_percent>
+            <period>60</period>
+          </sin>
+          <noise type="gaussian">
+           <mean>0</mean>
+           <stddev>0.0002</stddev>
+          </noise>
+        </magnitude>
+        <direction>
+          <time_for_rise>30</time_for_rise>
+          <sin>
+            <amplitude>5</amplitude>
+            <period>20</period>
+          </sin>
+          <noise type="gaussian">
+           <mean>0</mean>
+           <stddev>0.03</stddev>
+          </noise>
+        </direction>
+      </horizontal>
+      <vertical>
+        <noise type="gaussian">
+         <mean>0</mean>
+         <stddev>0.03</stddev>
+        </noise>
+      </vertical>
+    </plugin>
+
     <include>
       <uri>model://ground_plane</uri>
     </include>
@@ -300,175 +338,1053 @@
         </sensor>
       </link>
     </model>
+    <actor name="actor1">
+      <pose>0 5 1.25 0 0 0</pose>
+      <skin>
+        <filename>walk.dae</filename>
+        <scale>1.0</scale>
+      </skin>
+      <animation name="walking">
+        <filename>walk.dae</filename>
+        <scale>1.000000</scale>
+        <interpolate_x>true</interpolate_x>
+      </animation>
 
+      <plugin name="actor1_plugin" filename="libActorPlugin.so">
+        <target>0 -5 1.2138</target>
+        <target_weight>1.15</target_weight>
+        <obstacle_weight>1.8</obstacle_weight>
+        <animation_factor>5.1</animation_factor>
+        <!-- Usage: Modify the set of models that the vector field should
+             ignore when moving the actor -->
+        <ignore_obstacles>
+          <model>cafe</model>
+          <model>ground_plane</model>
+        </ignore_obstacles>
+      </plugin>
+    </actor>
 
-        <actor name="actor1">
-          <pose>0 5 1.25 0 0 0</pose>
-          <skin>
-            <filename>walk.dae</filename>
-            <scale>1.0</scale>
-          </skin>
-          <animation name="walking">
-            <filename>walk.dae</filename>
-            <scale>1.000000</scale>
-            <interpolate_x>true</interpolate_x>
-          </animation>
+    <model name="test_vehicle">
+      <pose frame=''>2 2 0 0 0 0</pose>
+      <link name='base_link'>
+        <pose frame=''>0 0 0 0 0 0</pose>
+        <inertial>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <mass>2.0</mass>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+        </inertial>
+        <collision name='base_link_collision'>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='base_link_visual'>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.2</size>
+            </box>
+          </geometry>
+        </visual>
+        <self_collide>0</self_collide>
+        <gravity>1</gravity>
+        <kinematic>0</kinematic>
+      </link>
 
-          <plugin name="actor1_plugin" filename="libActorPlugin.so">
-            <target>0 -5 1.2138</target>
-            <target_weight>1.15</target_weight>
-            <obstacle_weight>1.8</obstacle_weight>
-            <animation_factor>5.1</animation_factor>
-            <!-- Usage: Modify the set of models that the vector field should
-                 ignore when moving the actor -->
-            <ignore_obstacles>
-              <model>cafe</model>
-              <model>ground_plane</model>
-            </ignore_obstacles>
-          </plugin>
-        </actor>
+      <link name='left_track'>
+        <pose frame=''>0 0.55 0 1.5701 -0 0</pose>
+        <inertial>
+          <pose frame=''>0 0 0 0 -0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.001</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.0001</iyy>
+            <iyz>0</iyz>
+            <izz>0.001</izz>
+          </inertia>
+        </inertial>
+        <collision name='left_track_collision'>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name='left_track_visual'>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </visual>
+        <gravity>1</gravity>
+        <kinematic>0</kinematic>
+      </link>
+      <joint name='left_track_j' type='revolute'>
+        <child>left_track</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <limit>
+          </limit>
+          <use_parent_model_frame>1</use_parent_model_frame>
+        </axis>
+      </joint>
 
-        <model name="test_vehicle">
-          <pose frame=''>2 2 0 0 0 0</pose>
-          <link name='base_link'>
-            <pose frame=''>0 0 0 0 0 0</pose>
-            <inertial>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <mass>2.0</mass>
-              <inertia>
-                <ixx>0.1</ixx>
-                <ixy>0</ixy>
-                <ixz>0</ixz>
-                <iyy>0.1</iyy>
-                <iyz>0</iyz>
-                <izz>0.1</izz>
-              </inertia>
-            </inertial>
-            <collision name='base_link_collision'>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <geometry>
-                <box>
-                  <size>0.5 0.5 0.2</size>
-                </box>
-              </geometry>
-            </collision>
-            <visual name='base_link_visual'>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <geometry>
-                <box>
-                  <size>0.5 0.5 0.2</size>
-                </box>
-              </geometry>
-            </visual>
-            <self_collide>0</self_collide>
-            <gravity>1</gravity>
-            <kinematic>0</kinematic>
-          </link>
+      <link name='right_track'>
+        <pose frame=''>0 -0.55 0 -1.5701 0 0</pose>
+        <inertial>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <mass>0.5</mass>
+          <inertia>
+            <ixx>0.001</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.0001</iyy>
+            <iyz>0</iyz>
+            <izz>0.001</izz>
+          </inertia>
+        </inertial>
+        <collision name='right_track_collision'>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name='right_track_visual'>
+          <pose frame=''>0 0 0 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+        </visual>
+        <gravity>1</gravity>
+        <kinematic>0</kinematic>
+      </link>
 
-          <link name='left_track'>
-            <pose frame=''>0 0.55 0 1.5701 -0 0</pose>
-            <inertial>
-              <pose frame=''>0 0 0 0 -0 0</pose>
-              <mass>0.5</mass>
-              <inertia>
-                <ixx>0.001</ixx>
-                <ixy>0</ixy>
-                <ixz>0</ixz>
-                <iyy>0.0001</iyy>
-                <iyz>0</iyz>
-                <izz>0.001</izz>
-              </inertia>
-            </inertial>
-            <collision name='left_track_collision'>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <geometry>
-                <cylinder>
-                  <radius>0.5</radius>
-                  <length>0.1</length>
-                </cylinder>
-              </geometry>
-            </collision>
-            <visual name='left_track_visual'>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <geometry>
-                <cylinder>
-                  <radius>0.5</radius>
-                  <length>0.1</length>
-                </cylinder>
-              </geometry>
-            </visual>
-            <gravity>1</gravity>
-            <kinematic>0</kinematic>
-          </link>
-          <joint name='left_track_j' type='revolute'>
-            <child>left_track</child>
-            <parent>base_link</parent>
-            <axis>
-              <xyz>0 1 0</xyz>
-              <limit>
-              </limit>
-              <use_parent_model_frame>1</use_parent_model_frame>
-            </axis>
-          </joint>
+      <joint name='right_track_j' type='revolute'>
+        <child>right_track</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <limit>
+          </limit>
+          <use_parent_model_frame>1</use_parent_model_frame>
+        </axis>
+      </joint>
 
-          <link name='right_track'>
-            <pose frame=''>0 -0.55 0 -1.5701 0 0</pose>
-            <inertial>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <mass>0.5</mass>
-              <inertia>
-                <ixx>0.001</ixx>
-                <ixy>0</ixy>
-                <ixz>0</ixz>
-                <iyy>0.0001</iyy>
-                <iyz>0</iyz>
-                <izz>0.001</izz>
-              </inertia>
-            </inertial>
-            <collision name='right_track_collision'>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <geometry>
-                <cylinder>
-                  <radius>0.5</radius>
-                  <length>0.1</length>
-                </cylinder>
-              </geometry>
-            </collision>
-            <visual name='right_track_visual'>
-              <pose frame=''>0 0 0 0 0 0</pose>
-              <geometry>
-                <cylinder>
-                  <radius>0.5</radius>
-                  <length>0.1</length>
-                </cylinder>
-              </geometry>
-            </visual>
-            <gravity>1</gravity>
-            <kinematic>0</kinematic>
-          </link>
+      <plugin filename="libDiffDrivePlugin.so" name="test_vehicle">
+        <body>base_link</body>
+        <left_joint>left_track_j</left_joint>
+        <right_joint>right_track_j</right_joint>
+      </plugin>
 
-          <joint name='right_track_j' type='revolute'>
-            <child>right_track</child>
-            <parent>base_link</parent>
-            <axis>
-              <xyz>0 1 0</xyz>
-              <limit>
-              </limit>
-              <use_parent_model_frame>1</use_parent_model_frame>
-            </axis>
-          </joint>
+      <plugin filename="libKeysToCmdVelPlugin.so" name="keyboard_control">
+        <cmd_vel_topic>~/test_vehicle/vel_cmd</cmd_vel_topic>
+        <linear_increment>0.25</linear_increment>
+        <angular_increment>0.2</angular_increment>
+      </plugin>
+    </model>
 
-          <plugin filename="libDiffDrivePlugin.so" name="test_vehicle">
-            <body>base_link</body>
-            <left_joint>left_track_j</left_joint>
-            <right_joint>right_track_j</right_joint>
-          </plugin>
+    <model name='actuator_example'>
+      <pose frame=''>-5 0 0 0 0 0</pose>
+      <link name='top'>
+        <visual name='top_visual'>
+          <pose>0 0 1.5 0 -0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+         <collision name='top_collision'>
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <pose>0 0 1.5 0 0 0</pose>
+        </collision>
+        <gravity>1</gravity>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <link name='base'>
+        <visual name='base_visual'>
+          <pose>0 0 0.5 0 0 0</pose>
+          <geometry>
+            <cylinder>
+              <radius>1.5</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+         <collision name='base_collision'>
+          <geometry>
+            <cylinder>
+              <radius>1.5</radius>
+              <length>1</length>
+            </cylinder>
+          </geometry>
+          <pose>0 0 0.5 0 0 0</pose>
+        </collision>
+        <gravity>1</gravity>
+        <self_collide>0</self_collide>
+        <kinematic>0</kinematic>
+        <inertial>
+          <mass>1</mass>
+          <pose>0 0 0 0 -0 0</pose>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+        </inertial>
+      </link>
+      <joint name='JOINT_0' type='revolute'>
+        <parent>base</parent>
+        <child>top</child>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <use_parent_model_frame>0</use_parent_model_frame>
+          <limit>
+            <lower>1e-16</lower>
+            <upper>1e16</upper>
+          </limit>
+        </axis>
+        <pose>0 0 1 0 -0 0</pose>
+      </joint>
+      <static>0</static>
+      <allow_auto_disable>1</allow_auto_disable>
 
-          <plugin filename="libKeysToCmdVelPlugin.so" name="keyboard_control">
-            <cmd_vel_topic>~/test_vehicle/vel_cmd</cmd_vel_topic>
-            <linear_increment>0.25</linear_increment>
-            <angular_increment>0.2</angular_increment>
-          </plugin>
-        </model>
+      <plugin name="actuator_plugin" filename="libActuatorPlugin.so">
+        <actuator>
+          <name>actuator_0</name>
+          <joint>JOINT_0</joint>
+          <index>0</index>
+          <type>electric_motor</type>
+          <power>20</power>
+          <max_velocity>6</max_velocity>
+          <max_torque>10.0</max_torque>
+        </actuator>
+      </plugin>
+    </model>
+
+    <model name="test_model">
+      <pose>5 0 0.7 0 0 0</pose>
+      <link name="link">
+        <inertial>
+          <inertia>
+            <ixx>1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>1</iyy>
+            <iyz>0</iyz>
+            <izz>1</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <pose>0 0 -0.55 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1 1 0.1</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <pose>0 0 -0.55 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>1 1 0.1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+        <collision name="collision2">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual2">
+          <pose>0 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.5 0.5 0.5</size>
+            </box>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <link name="bar_1">
+        <pose>0.45 0 -0.5 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.001</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.001</iyy>
+            <iyz>0</iyz>
+            <izz>0.001</izz>
+          </inertia>
+          <mass>0.1</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0.02 1.0 0.02</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.02 1.0 0.02</size>
+            </box>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="bar_12_joint" type="revolute">
+        <parent>bar_2</parent>
+        <child>bar_1</child>
+        <pose>0 0.5 0 0 0 0</pose>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <joint name="bar_13_joint" type="revolute">
+        <parent>bar_3</parent>
+        <child>bar_1</child>
+        <pose>0 -0.5 0 0 0 0</pose>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="bar_2">
+        <pose>0.5 0.5 -0.5 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.001</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.001</iyy>
+            <iyz>0</iyz>
+            <izz>0.001</izz>
+          </inertia>
+          <mass>0.1</mass>
+        </inertial>
+        <collision name="collision">
+          <pose>-0.025 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.02 0.02</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <pose>-0.025 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.02 0.02</size>
+            </box>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="bar_2_joint" type="revolute">
+        <parent>link</parent>
+        <child>bar_2</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="bar_3">
+        <pose>0.5 -0.5 -0.5 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.001</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.001</iyy>
+            <iyz>0</iyz>
+            <izz>0.001</izz>
+          </inertia>
+          <mass>0.1</mass>
+        </inertial>
+        <collision name="collision">
+          <pose>-0.025 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.02 0.02</size>
+            </box>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <pose>-0.025 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.05 0.02 0.02</size>
+            </box>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="bar_3_joint" type="revolute">
+        <parent>link</parent>
+        <child>bar_3</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="wheel_1">
+        <pose>0.5 0.55 -0.5 1.57079633 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.01</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01</iyy>
+            <iyz>0</iyz>
+            <izz>0.01</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <fdir1>1 0 0</fdir1>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="wheel_1_joint" type="revolute">
+        <parent>bar_2</parent>
+        <child>wheel_1</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="wheel_2">
+        <pose>0.5 -0.55 -0.5 1.57079633 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.01</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01</iyy>
+            <iyz>0</iyz>
+            <izz>0.01</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <fdir1>1 0 0</fdir1>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="wheel_2_joint" type="revolute">
+        <parent>bar_3</parent>
+        <child>wheel_2</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <xyz>0 1 0</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="wheel_3">
+        <pose>-0.5 0.55 -0.5 1.57079633 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.01</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01</iyy>
+            <iyz>0</iyz>
+            <izz>0.01</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <fdir1>1 0 0</fdir1>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="wheel_3_joint" type="revolute">
+        <parent>link</parent>
+        <child>wheel_3</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <dynamics>
+            <damping>0.0</damping>
+            <friction>0.0</friction>
+          </dynamics>
+          <xyz>0 1 0</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="wheel_4">
+        <pose>-0.5 -0.55 -0.5 1.57079633 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.01</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01</iyy>
+            <iyz>0</iyz>
+            <izz>0.01</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <fdir1>1 0 0</fdir1>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>100</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.2</radius>
+              <length>0.1</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="wheel_4_joint" type="revolute">
+        <parent>link</parent>
+        <child>wheel_4</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <dynamics>
+            <damping>0.0</damping>
+            <friction>0.0</friction>
+          </dynamics>
+          <xyz>0 1 0</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="sphere_link">
+        <pose>0 0 0.5 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+          <mass>10.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+            </sphere>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <fdir1>1 0 0</fdir1>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>10</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.25</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="joint_sphere" type="revolute">
+        <parent>link</parent>
+        <child>sphere_link</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <link name="cylinder_link">
+        <pose>0 0 0.25 0 0 0</pose>
+        <inertial>
+          <inertia>
+            <ixx>0.1</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.1</iyy>
+            <iyz>0</iyz>
+            <izz>0.1</izz>
+          </inertia>
+          <mass>10.0</mass>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>0.5</length>
+            </cylinder>
+          </geometry>
+          <surface>
+            <friction>
+              <ode>
+                <mu>1</mu>
+                <mu2>1</mu2>
+              </ode>
+            </friction>
+            <contact>
+              <ode>
+                <max_vel>10</max_vel>
+              </ode>
+            </contact>
+          </surface>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>0.5</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+      <joint name="joint_cylinder" type="revolute">
+        <parent>sphere_link</parent>
+        <child>cylinder_link</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <use_parent_model_frame>true</use_parent_model_frame>
+        </axis>
+      </joint>
+      <plugin name="cart_test_plugin" filename="libCartDemoPlugin.so">
+        <steer>bar_2_joint</steer>
+        <steer_pid>10 0.1 0.5</steer_pid>
+        <steer_ilim>-10 10</steer_ilim>
+        <steer_pos>0.0</steer_pos>
+        <!-- steer -->
+        <steer_vel>0</steer_vel>
+        <!-- not used -->
+        <steer_eff>100.0</steer_eff>
+        <!-- max pos pid effort -->
+        <right>wheel_3_joint</right>
+        <right_pid>0.1 0.0 0.001</right_pid>
+        <right_ilim>-.1 .1</right_ilim>
+        <right_pos>0</right_pos>
+        <!-- final position pid -->
+        <right_vel>0</right_vel>
+        <!-- final velocity pid -->
+        <right_eff>0.1</right_eff>
+        <!-- drive torque -->
+        <left>wheel_4_joint</left>
+        <left_pid>0.1 0.0 0.001</left_pid>
+        <left_ilim>-.1 .1</left_ilim>
+        <left_pos>0</left_pos>
+        <!-- final position pid -->
+        <left_vel>0</left_vel>
+        <!-- final velocity pid -->
+        <left_eff>0.1</left_eff>
+        <!-- drive torque -->
+      </plugin>
+    </model>
+    <model name="cessna_c172">
+      <pose>-5 -5 0.7 0 0 0</pose>
+
+      <include>
+        <uri>model://cessna</uri>
+      </include>
+
+      <link name="blade_1_visual">
+        <pose>1.79 0 1.350 0 0 0</pose>
+        <gravity>0</gravity>
+      </link>
+
+      <link name="wing_body_debug_visuals">
+        <pose>0 0 0.495 0 0 0</pose>
+        <gravity>0</gravity>
+      </link>
+
+      <!-- Plugins for controlling the thrust and control surfaces -->
+      <plugin name="cessna_control" filename="libCessnaPlugin.so">
+        <propeller>cessna_c172::propeller_joint</propeller>
+        <propeller_max_rpm>2500</propeller_max_rpm>
+        <left_aileron>cessna_c172::left_aileron_joint</left_aileron>
+        <left_flap>cessna_c172::left_flap_joint</left_flap>
+        <right_aileron>cessna_c172::right_aileron_joint</right_aileron>
+        <right_flap>cessna_c172::right_flap_joint</right_flap>
+        <elevators>cessna_c172::elevators_joint</elevators>
+        <rudder>cessna_c172::rudder_joint</rudder>
+        <propeller_p_gain>10000</propeller_p_gain>
+        <propeller_i_gain>0</propeller_i_gain>
+        <propeller_d_gain>0</propeller_d_gain>
+        <surfaces_p_gain>2000</surfaces_p_gain>
+        <surfaces_i_gain>0</surfaces_i_gain>
+        <surfaces_d_gain>0</surfaces_d_gain>
+      </plugin>
+      <plugin name="propeller_top_blade" filename="libLiftDragPlugin.so">
+        <a0>0.4</a0>
+        <cla>4.752798721</cla>
+        <cda>0.6417112299</cda>
+        <cma>0</cma>
+        <alpha_stall>1.5</alpha_stall>
+        <cla_stall>-3.85</cla_stall>
+        <cda_stall>-0.9233984055</cda_stall>
+        <cma_stall>0</cma_stall>
+        <cp>-0.37 0 0.77</cp>
+        <area>0.1</area>
+        <air_density>1.2041</air_density>
+        <forward>0 -1 0</forward>
+        <upward>1 0 0</upward>
+        <link_name>cessna_c172::propeller</link_name>
+      </plugin>
+      <plugin name="propeller_bottom_blade" filename="libLiftDragPlugin.so">
+        <a0>0.4</a0>
+        <cla>4.752798721</cla>
+        <cda>0.6417112299</cda>
+        <cma>0</cma>
+        <alpha_stall>1.5</alpha_stall>
+        <cla_stall>-3.85</cla_stall>
+        <cda_stall>-0.9233984055</cda_stall>
+        <cma_stall>0</cma_stall>
+        <cp>-0.37 0 -0.77</cp>
+        <area>0.1</area>
+        <air_density>1.2041</air_density>
+        <forward>0 1 0</forward>
+        <upward>1 0 0</upward>
+        <link_name>cessna_c172::propeller</link_name>
+      </plugin>
+
+      <plugin name="left_wing" filename="libLiftDragPlugin.so">
+        <a0>0.05984281113</a0>
+        <cla>4.752798721</cla>
+        <cda>0.6417112299</cda>
+        <cma>-1.8</cma>
+        <alpha_stall>0.3391428111</alpha_stall>
+        <cla_stall>-3.85</cla_stall>
+        <cda_stall>-0.9233984055</cda_stall>
+        <cma_stall>0</cma_stall>
+        <cp>-1 2.205 1.5</cp>
+        <area>8.08255</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>cessna_c172::body</link_name>
+        <control_joint_name>cessna_c172::left_aileron_joint</control_joint_name>
+        <control_joint_rad_to_cl>-2.0</control_joint_rad_to_cl>
+      </plugin>
+
+      <plugin name="right_wing" filename="libLiftDragPlugin.so">
+        <a0>0.05984281113</a0>
+        <cla>4.752798721</cla>
+        <cda>0.6417112299</cda>
+        <cma>-1.8</cma>
+        <alpha_stall>0.3391428111</alpha_stall>
+        <cla_stall>-3.85</cla_stall>
+        <cda_stall>-0.9233984055</cda_stall>
+        <cma_stall>0</cma_stall>
+        <cp>-1 -2.205 1.5</cp>
+        <area>8.08255</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>cessna_c172::body</link_name>
+        <control_joint_name>
+          cessna_c172::right_aileron_joint
+        </control_joint_name>
+        <control_joint_rad_to_cl>-2.0</control_joint_rad_to_cl>
+      </plugin>
+
+      <plugin name="elevator" filename="libLiftDragPlugin.so">
+        <a0>-0.2</a0>
+        <cla>4.752798721</cla>
+        <cda>0.6417112299</cda>
+        <cma>-1.8</cma>
+        <alpha_stall>0.3391428111</alpha_stall>
+        <cla_stall>-3.85</cla_stall>
+        <cda_stall>-0.9233984055</cda_stall>
+        <cma_stall>0</cma_stall>
+        <cp>-5.45 0 0.55</cp>
+        <area>2.03458</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 0 1</upward>
+        <link_name>cessna_c172::body</link_name>
+        <control_joint_name>cessna_c172::elevators_joint</control_joint_name>
+        <control_joint_rad_to_cl>-4.0</control_joint_rad_to_cl>
+      </plugin>
+
+      <plugin name="rudder" filename="libLiftDragPlugin.so">
+        <a0>0</a0>
+        <cla>4.752798721</cla>
+        <cda>0.6417112299</cda>
+        <cma>-1.8</cma>
+        <alpha_stall>0.3391428111</alpha_stall>
+        <cla_stall>-3.85</cla_stall>
+        <cda_stall>-0.9233984055</cda_stall>
+        <cma_stall>0</cma_stall>
+        <cp>-6 0 1.55</cp>
+        <area>1.5329</area>
+        <air_density>1.2041</air_density>
+        <forward>1 0 0</forward>
+        <upward>0 1 0</upward>
+        <link_name>cessna_c172::body</link_name>
+        <control_joint_name>cessna_c172::rudder_joint</control_joint_name>
+        <control_joint_rad_to_cl>4.0</control_joint_rad_to_cl>
+      </plugin>
+    </model>
   </world>
 </sdf>


### PR DESCRIPTION
I added profile points in ODEPhysics, sensors and some plugins

Here some snapshots:

![Selección_044](https://user-images.githubusercontent.com/1933907/86485923-488b0c80-bd5a-11ea-8857-700f7bb03be0.png)
![Selección_042](https://user-images.githubusercontent.com/1933907/86485934-4e80ed80-bd5a-11ea-9cc4-ba208424045d.png)
![Selección_041](https://user-images.githubusercontent.com/1933907/86485938-52147480-bd5a-11ea-9c90-ea6caaf83da2.png)

there is a world called `profile.world` where you can reproduce these results.

I had to change this line in the CMakeLists.txt to avoid create a Profile Singleton in each library. I can provide more details about this if necessary.

from
```cmake
  filter_valid_compiler_flags(-fvisibility=hidden -fvisibility-inlines-hidden)
```
to
```cmake
  filter_valid_compiler_flags(-fvisibility-inlines-hidden)
```

is this change creating a conflict with something specific?

Signed-off-by: ahcorde <ahcorde@gmail.com>