### PR TITLE
Fix sensor update rate throttling when new sensors are spawned

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## Gazebo 9.xx.x (202x-xx-xx)
 
 1. Fix sensor update rate throttling when new sensors are spawned
-    * [Pull request #](https://github.com/osrf/gazebo/pull/)
+    * [Pull request #2784](https://github.com/osrf/gazebo/pull/2784)
 
 1. LensFlare: initialize OGRE compositors during plugin initialization
     * [Pull request #2762](https://github.com/osrf/gazebo/pull/2762)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Gazebo 9.xx.x (202x-xx-xx)
 
+1. Fix sensor update rate throttling when new sensors are spawned
+    * [Pull request #](https://github.com/osrf/gazebo/pull/)
+
 1. LensFlare: initialize OGRE compositors during plugin initialization
     * [Pull request #2762](https://github.com/osrf/gazebo/pull/2762)
 

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -818,10 +818,9 @@ void Visual::SetScale(const ignition::math::Vector3d &_scale)
     this->dataPtr->sceneNode->setScale(
         Conversions::Convert(this->dataPtr->scale));
   }
-  else
-  {
-    gzerr << Name() << ": Size of the collision contains one or several zeros."
-      << " Collisions may not visualize properly." << std::endl;
+  else {
+    gzerr << Name() << ": Size of the collision contains one or several zeros." <<
+      " Collisions may not visualize properly." << std::endl;
   }
   // Scale selection object in case we have one attached. Other children were
   // scaled from UpdateGeomSize

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -817,9 +817,11 @@ void Visual::SetScale(const ignition::math::Vector3d &_scale)
   {
     this->dataPtr->sceneNode->setScale(
         Conversions::Convert(this->dataPtr->scale));
-  } else {
-    gzerr << Name() << ": Size of the collision contains one or several zeros." <<
-      " Collisions may not visualize properly." << std::endl;
+  }
+  else
+  {
+    gzerr << Name() << ": Size of the collision contains one or several zeros."
+      << " Collisions may not visualize properly." << std::endl;
   }
   // Scale selection object in case we have one attached. Other children were
   // scaled from UpdateGeomSize

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -817,8 +817,7 @@ void Visual::SetScale(const ignition::math::Vector3d &_scale)
   {
     this->dataPtr->sceneNode->setScale(
         Conversions::Convert(this->dataPtr->scale));
-  }
-  else {
+  } else {
     gzerr << Name() << ": Size of the collision contains one or several zeros." <<
       " Collisions may not visualize properly." << std::endl;
   }

--- a/test/integration/sensor.cc
+++ b/test/integration/sensor.cc
@@ -22,6 +22,16 @@ class SensorTest : public ServerFixture
 {
 };
 
+std::mutex g_mutex;
+unsigned int g_messageCount = 0;
+
+////////////////////////////////////////////////////////////////////////
+void SensorCallback(const ConstIMUSensorPtr &/*_msg*/)
+{
+  std::lock_guard<std::mutex> lock(g_mutex);
+  g_messageCount++;
+}
+
 /////////////////////////////////////////////////
 // This tests getting links from a model.
 TEST_F(SensorTest, GetScopedName)
@@ -46,6 +56,101 @@ TEST_F(SensorTest, FastSensor)
 
   // This test will cause an assertion if maxSensorUpdate in
   // SensorManager::SensorContainer::RunLoop() is set improperly
+}
+
+/////////////////////////////////////////////////
+// Make sure sensors update rates are respected
+// Spawn two sensors, one after another, with different update rates and
+// verify the rates are correctly throttled
+TEST_F(SensorTest, MaxUpdateRate)
+{
+  Load("worlds/empty.world");
+
+  physics::WorldPtr world = physics::get_world("default");
+  ASSERT_NE(nullptr, world);
+
+  auto spawnSensorWithUpdateRate = [&](const std::string &_name,
+      const ignition::math::Pose3d &_pose, double _rate)
+  {
+    std::ostringstream newModelStr;
+    newModelStr << "<sdf version='" << SDF_VERSION << "'>"
+      << "<model name ='" << _name << "'>\n"
+      << "<static>true</static>\n"
+      << "<pose>" << _pose << "</pose>\n"
+      << "<link name ='body'>\n"
+      << "<inertial>\n"
+      << "<mass>0.1</mass>\n"
+      << "</inertial>\n"
+      << "<collision name='parent_collision'>\n"
+      << "  <pose>0 0 0.0205 0 0 0</pose>\n"
+      << "  <geometry>\n"
+      << "    <cylinder>\n"
+      << "      <radius>0.021</radius>\n"
+      << "      <length>0.029</length>\n"
+      << "    </cylinder>\n"
+      << "  </geometry>\n"
+      << "</collision>\n"
+      << "  <sensor name ='" << _name << "' type ='imu'>\n"
+      << "    <update_rate>" << _rate << "</update_rate>\n"
+      << "    <topic>" << _name << "</topic>\n"
+      << "    <imu>\n"
+      << "    </imu>\n"
+      << "  </sensor>\n"
+      << "</link>\n"
+      << "</model>\n"
+      << "</sdf>\n";
+
+    SpawnSDF(newModelStr.str());
+  };
+
+  transport::NodePtr node = transport::NodePtr(new transport::Node());
+  node->Init();
+
+  g_messageCount = 0;
+
+  // spawn first sensor with low update rate
+  spawnSensorWithUpdateRate("sensor1", ignition::math::Pose3d::Zero, 5);
+
+  transport::SubscriberPtr sub = node->Subscribe("~/sensor1/body/sensor1/imu",
+      SensorCallback);
+
+  // wait for messages
+  int sleep = 0;
+  int maxSleep = 1000;
+  double t0 = 0.0;
+  while (g_messageCount < 30 && sleep++ < maxSleep)
+  {
+    if (g_messageCount == 0)
+      t0 = world->SimTime().Double();
+    common::Time::MSleep(10);
+  }
+
+  // verify update rate by checking the time it takes to receive n msgs
+  double elapsed = world->SimTime().Double() - t0;
+  EXPECT_NEAR(6.0, elapsed, 0.5);
+
+  // disconnect first sensor
+  sub.reset();
+
+  g_messageCount = 0;
+
+  // spawn another sensor with higher update rate
+  spawnSensorWithUpdateRate("sensor2", ignition::math::Pose3d::Zero, 10);
+  sub = node->Subscribe("~/sensor2/body/sensor2/imu", SensorCallback);
+
+  // wait for more msgs
+  sleep = 0;
+  t0 = 0.0;
+  while (g_messageCount < 30 && sleep++ < maxSleep)
+  {
+    if (g_messageCount == 0)
+      t0 = world->SimTime().Double();
+    common::Time::MSleep(10);
+  }
+
+  // verify update rate by checking the time it takes to receive n msgs
+  elapsed = world->SimTime().Double() - t0;
+  EXPECT_NEAR(3.0, elapsed, 0.5);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
There is an issue with sensor manager's update loop throttling. When a world is loaded, the sensor manager figures out the max update rate from all the sensors in the world. However, when a new sensor is spawned after the world is loaded, this max update rate is never updated. This causes a problem for example when later spawning a sensor with an update rate higher than all the existing sensors in the world, this new sensor would never hit its target update rate.

This PR adds a flag (global variable, `g_sensorsDirty`, to avoid breaking ABI) to detect when sensors are added or removed, and recalcuates the sensor manager's max update rate when the flag is dirty.

The bug only affects non-rendering sensors, e.g. imu, ray sensor, etc

To manually test this, you can:
1. download the `hokuyo` model from gazebo model database, e.g. by inserting it from gazebo's Insert tab on the left
1. create a copy with higher update rate, e.g. copy the model `~/.gazebo/models/hokuyo` to `~/.gazebo/models/hokuyo_new` and change the update rate in `model.sdf` and also remember to give it a new name in `model.config`
1. launch gazebo and insert the original hokuyo model -> check update rate, e.g. Ctrl + T and select the corresponding laser scan topic under `LaserStamped` msg type
1. insert the new hokuyo model with higher update rate -> check update rate using the same way as before. Verify that the new model is able to reach the target update rate with the changes in this PR.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>