### PR TITLE
[Gazebo 9] Added test to check collisions equal to zero

### DIFF
--- a/gazebo/rendering/Visual_TEST.cc
+++ b/gazebo/rendering/Visual_TEST.cc
@@ -1588,10 +1588,11 @@ TEST_F(Visual_TEST, ConvertVisualType)
       rendering::Visual::ConvertVisualType(msgs::Visual::PHYSICS));
 }
 
-TEST_F(Visual_TEST, collisionZero)
+TEST_F(Visual_TEST, CollisionZero)
 {
-  // This test checks that there isn't a segmentation fault when inserting zero collision geometries
-  // Load a world containing 3 simple shapes with collision geometry equals to zero
+  // This test checks that there isn't a segmentation fault when inserting zero collision
+  // geometries.
+  // Load a world containing 3 simple shapes with collision geometry equals to zero.
   Load("worlds/collision_zero.world");
 
   // Get the scene
@@ -1614,6 +1615,14 @@ TEST_F(Visual_TEST, collisionZero)
     common::Time::MSleep(1000);
     sleep++;
   }
+  scene->ShowCollisions(true);
+  
+  // box
+  ASSERT_NE(box, nullptr);
+  // cylinder
+  ASSERT_NE(cylinder, nullptr);
+  // sphere
+  ASSERT_NE(sphere, nullptr);
 }
 /////////////////////////////////////////////////
 TEST_F(Visual_TEST, Scale)

--- a/gazebo/rendering/Visual_TEST.cc
+++ b/gazebo/rendering/Visual_TEST.cc
@@ -1617,7 +1617,6 @@ TEST_F(Visual_TEST, CollisionZero)
     sleep++;
   }
   scene->ShowCollisions(true);
-
   // box
   ASSERT_NE(box, nullptr);
   // cylinder

--- a/gazebo/rendering/Visual_TEST.cc
+++ b/gazebo/rendering/Visual_TEST.cc
@@ -1590,9 +1590,10 @@ TEST_F(Visual_TEST, ConvertVisualType)
 
 TEST_F(Visual_TEST, CollisionZero)
 {
-  // This test checks that there isn't a segmentation fault when inserting zero collision
-  // geometries.
-  // Load a world containing 3 simple shapes with collision geometry equals to zero.
+  // This test checks that there isn't a segmentation fault when inserting
+  // zero collision geometries.
+  // Load a world containing 3 simple shapes with collision geometry equals
+  // to zero.
   Load("worlds/collision_zero.world");
 
   // Get the scene
@@ -1616,7 +1617,7 @@ TEST_F(Visual_TEST, CollisionZero)
     sleep++;
   }
   scene->ShowCollisions(true);
-  
+
   // box
   ASSERT_NE(box, nullptr);
   // cylinder

--- a/gazebo/rendering/Visual_TEST.cc
+++ b/gazebo/rendering/Visual_TEST.cc
@@ -1588,6 +1588,33 @@ TEST_F(Visual_TEST, ConvertVisualType)
       rendering::Visual::ConvertVisualType(msgs::Visual::PHYSICS));
 }
 
+TEST_F(Visual_TEST, collisionZero)
+{
+  // This test checks that there isn't a segmentation fault when inserting zero collision geometries
+  // Load a world containing 3 simple shapes with collision geometry equals to zero
+  Load("worlds/collision_zero.world");
+
+  // Get the scene
+  gazebo::rendering::ScenePtr scene = gazebo::rendering::get_scene();
+  ASSERT_NE(scene, nullptr);
+
+  // Wait until all models are inserted
+  int sleep = 0;
+  int maxSleep = 10;
+  rendering::VisualPtr box, sphere, cylinder;
+  while ((!box || !sphere || !cylinder) && sleep < maxSleep)
+  {
+    event::Events::preRender();
+    event::Events::render();
+    event::Events::postRender();
+
+    box = scene->GetVisual("box");
+    cylinder = scene->GetVisual("cylinder");
+    sphere = scene->GetVisual("sphere");
+    common::Time::MSleep(1000);
+    sleep++;
+  }
+}
 /////////////////////////////////////////////////
 TEST_F(Visual_TEST, Scale)
 {

--- a/worlds/collision_zero.world
+++ b/worlds/collision_zero.world
@@ -1,0 +1,79 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <model name="box">
+      <pose>0 0 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>0 0 0</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="sphere">
+      <pose>0 1.5 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.5</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+    </model>
+    <model name="cylinder">
+      <pose>0 -1.5 0.5 0 1.5707 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0</radius>
+              <length>0</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.5</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>Gazebo/WoodPallet</script>
+          </material>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
I missed to add tests in this PR https://github.com/osrf/gazebo/pull/2768. 

I added a world with a box, sphere and cylinder with collisions equal to zero. The test will try to load the world, no segmentation fault should happens

Signed-off-by: ahcorde <ahcorde@gmail.com>