### PR TITLE
[Gazebo9] More enhancement for Windows build

### DIFF
--- a/cmake/GazeboUtils.cmake
+++ b/cmake/GazeboUtils.cmake
@@ -131,7 +131,11 @@ endmacro()
 #################################################
 macro (gz_install_library _name)
   set_target_properties(${_name} PROPERTIES SOVERSION ${GAZEBO_MAJOR_VERSION} VERSION ${GAZEBO_VERSION_FULL})
-  install (TARGETS ${_name} DESTINATION ${LIB_INSTALL_DIR} COMPONENT shlib)
+  install (TARGETS ${_name}
+    ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+    LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+    COMPONENT shlib)
 endmacro ()
 
 #################################################

--- a/gazebo/common/Material.cc
+++ b/gazebo/common/Material.cc
@@ -98,6 +98,10 @@ void Material::SetTextureImage(const std::string &_tex,
       }
     }
   }
+
+  // normalize the path
+  this->texImage = boost::filesystem::path(this->texImage)
+    .make_preferred().string();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/common/ModelDatabase.cc
+++ b/gazebo/common/ModelDatabase.cc
@@ -503,19 +503,28 @@ std::string ModelDatabase::GetModelPath(const std::string &_uri,
         continue;
       }
 
+      std::string outputPath = getenv("HOME");
+      outputPath += "/.gazebo/models";
+
 #ifndef _WIN32
       TAR *tar;
       tar_open(&tar, const_cast<char*>(tarfilename.c_str()),
           nullptr, O_RDONLY, 0644, TAR_GNU);
 
-      std::string outputPath = getenv("HOME");
-      outputPath += "/.gazebo/models";
-
       tar_extract_all(tar, const_cast<char*>(outputPath.c_str()));
-      path = outputPath + "/" + modelName;
-
-      ModelDatabase::DownloadDependencies(path);
+#else
+      // Tar now is a built-in tool since Windows 10 build 17063.
+      std::string cmdline = "tar xzf \"";
+      cmdline += tarfilename + "\" -C \"";
+      cmdline += outputPath + "\"";
+      auto ret = system(cmdline.c_str());
+      if (ret != 0)
+      {
+        gzerr << "tar extract ret = " << ret << ", cmdline = " << cmdline << std::endl;
+      }
 #endif
+      path = outputPath + "/" + modelName;
+      ModelDatabase::DownloadDependencies(path);
     }
 
     curl_easy_cleanup(curl);

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -626,7 +626,6 @@ void Visual::DetachVisual(const std::string &_name)
 //////////////////////////////////////////////////
 void Visual::AttachObject(Ogre::MovableObject *_obj)
 {
-  static std::atomic_uint64_t id = 0;
   // This code makes plane render before grids. This allows grids to overlay
   // planes, and then other elements to overlay both planes and grids.
   // if (this->dataPtr->sdf->HasElement("geometry"))
@@ -648,7 +647,7 @@ void Visual::AttachObject(Ogre::MovableObject *_obj)
         {
           std::string newMaterialName;
           newMaterialName = this->dataPtr->sceneNode->getName() +
-              "_MATERIAL_" + material->getName() + "_" + boost::lexical_cast<std::string>(id++);
+              "_MATERIAL_" + material->getName();
 
           // keep a pointer to the original submesh material so it can be used
           // to restore material state when setting transparency

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -626,6 +626,7 @@ void Visual::DetachVisual(const std::string &_name)
 //////////////////////////////////////////////////
 void Visual::AttachObject(Ogre::MovableObject *_obj)
 {
+  static std::atomic_uint64_t id = 0;
   // This code makes plane render before grids. This allows grids to overlay
   // planes, and then other elements to overlay both planes and grids.
   // if (this->dataPtr->sdf->HasElement("geometry"))
@@ -647,7 +648,7 @@ void Visual::AttachObject(Ogre::MovableObject *_obj)
         {
           std::string newMaterialName;
           newMaterialName = this->dataPtr->sceneNode->getName() +
-              "_MATERIAL_" + material->getName();
+              "_MATERIAL_" + material->getName() + "_" + boost::lexical_cast<std::string>(id++);
 
           // keep a pointer to the original submesh material so it can be used
           // to restore material state when setting transparency


### PR DESCRIPTION
* Installing the DLLs (shared libraries) into the `bin` folder by convention.
* Normalize the material paths into native paths so OGRE can discover them later. (Mixing the forward/backward slashes really confuses OGRE when looking up the resources.)
* Use the built-in `tar.exe` in Windows 10 (yes, there is a [`tar.exe`](https://techcommunity.microsoft.com/t5/containers/tar-and-curl-come-to-windows/ba-p/382409) with Windows) to unpack the downloaded asset. This could be a way to resolve this gap: #2611