### PR TITLE
Prepare for gazebo11 11.1.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,14 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 11)
-set (GAZEBO_MINOR_VERSION 0)
+set (GAZEBO_MINOR_VERSION 1)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.
 set (GAZEBO_PATCH_VERSION 0)
 
-set (GAZEBO_VERSION ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION})
-set (GAZEBO_VERSION_FULL ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION}.${GAZEBO_PATCH_VERSION})
+set (GAZEBO_VERSION ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION}~pre1)
+set (GAZEBO_VERSION_FULL ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION}.${GAZEBO_PATCH_VERSION}~pre1)
 
 message (STATUS "${PROJECT_NAME} version ${GAZEBO_VERSION_FULL}")
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,10 +2,13 @@
 
 ## Gazebo 11.1.0 (202x-xx-xx)
 
-1. Platform fixes for arm and Windows: FindSSE, Tracked Plugins, io.h header
-    * https://github.com/osrf/gazebo/pull/2753
-    * https://github.com/osrf/gazebo/pull/2748
-    * https://github.com/osrf/gazebo/pull/2745
+1. DART support for deb packages at packages.osrfoundation.org
+    * [GitHub issue 2752](htttps://github.com/osrf/gazebo/issues/2752)
+
+1. Platform fixes for ARM and Windows: FindSSE, Tracked Plugins, io.h header
+    * [GitHub pull request 2753](https://github.com/osrf/gazebo/pull/2753)
+    * [GitHub pull request 2748](https://github.com/osrf/gazebo/pull/2748)
+    * [GitHub pull request 2745](https://github.com/osrf/gazebo/pull/2745)
 
 1. Fixed crash when collision size is zero
     * [GitHub pull request 2770](https://github.com/osrf/gazebo/pull/2770)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,14 @@
 ## Gazebo 11
 
-## Gazebo 11.x.x (202x-xx-xx)
+## Gazebo 11.1.0 (202x-xx-xx)
+
+1. Platform fixes for arm and Windows: FindSSE, Tracked Plugins, io.h header
+    * https://github.com/osrf/gazebo/pull/2753
+    * https://github.com/osrf/gazebo/pull/2748
+    * https://github.com/osrf/gazebo/pull/2745
+
+1. Fixed crash when collision size is zero
+    * [GitHub pull request 2770](https://github.com/osrf/gazebo/pull/2770)
 
 1. Fix corruption when a URDF file is included from a SDFormat 1.6 model #2734
     * [Pull request 2734](https://github.com/osrf/gazebo/pull/2734)


### PR DESCRIPTION
Missing entries in Changelog and bump version. Part of the works to solve https://github.com/osrf/gazebo/issues/2752. Needs to go in combination with https://github.com/ignition-release/gazebo11-release/pull/3