### PR TITLE
Fix pkg-config boost entries for Ubuntu Focal (gazebo11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,8 @@ else (build_errors)
     endif()
     # Remove the prefix lib (not always present, like in pthread)
     string (REPLACE "lib" "" bname "${bname}")
+    # Some boost versions add the Boost:: component to cmake, need to change that to boost_ prefix
+    string (REPLACE "Boost::" "boost_" bname "${bname}")
     set (Boost_PKGCONFIG_LIBS "${Boost_PKGCONFIG_LIBS} ${bname}")
   endforeach(b)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Gazebo 11.x.x (202x-xx-xx)
 
+1. Fix pkg-config boost entries for Ubuntu Focal
+    * [Pull request #](https://github.com/osrf/gazebo/pull/)
+
 1. Fix corruption when a URDF file is included from a SDFormat 1.6 model #2734
     * [Pull request 2734](https://github.com/osrf/gazebo/pull/2734)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## Gazebo 11.x.x (202x-xx-xx)
 
 1. Fix pkg-config boost entries for Ubuntu Focal
-    * [Pull request #](https://github.com/osrf/gazebo/pull/)
+    * [Pull request #2797](https://github.com/osrf/gazebo/pull/2797)
 
 1. Fix corruption when a URDF file is included from a SDFormat 1.6 model #2734
     * [Pull request 2734](https://github.com/osrf/gazebo/pull/2734)


### PR DESCRIPTION
Forward port of #2751, closes #2735 