### PR TITLE
Lockstep small compiler warning fix

### DIFF
--- a/test/integration/laser.cc
+++ b/test/integration/laser.cc
@@ -616,7 +616,7 @@ TEST_P(LaserTest, LaserNoise)
   LaserUnitNoise(GetParam());
 }
 
-void LaserTest::LaserStrictUpdateRate(const std::string &_physicsEngine)
+void LaserTest::LaserStrictUpdateRate(const std::string &)
 {
   LoadArgs(" --lockstep worlds/laser_hit_strict_rate_test.world");
 


### PR DESCRIPTION
Fixes a compiler warning from changes in #2791

Related: #2793 