### PR TITLE
Fix lockstep world

### DIFF
--- a/test/worlds/camera_strict_rate.world
+++ b/test/worlds/camera_strict_rate.world
@@ -34,19 +34,6 @@
           <update_rate>500</update_rate>
           <visualize>true</visualize>
         </sensor>
-      </link>
-    </model>
-
-    <model name="box">
-      <pose>13 0 0.5 0 0 0</pose>
-      <link name="link">
-        <visual name="visual">
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-        </visual>
         <!-- Regular camera, to make sure strict rate is only applied to the sensor intended -->
         <sensor name="camera_sensor_regular" type="camera">
           <camera>


### PR DESCRIPTION
I found a bug in the camera sensor world file for lockstep while writing the tutorial. It came from an earlier commit, what I thought was a "correction" to the file, but actually made the low-frame-rate camera looking into blank space. It doesn't affect the lockstep tests - INTEGRATION_camera_sensor still passes. The bug was just in a side camera for comparison to the one that matters.