### PR TITLE
Fix race condition on Publisher shutdown

### DIFF
--- a/gazebo/transport/Publisher.cc
+++ b/gazebo/transport/Publisher.cc
@@ -52,6 +52,11 @@ class PublisherPrivate
 static std::mutex pubMapMutex;
 
 /// \brief A map of Publisher id and its shared pointer
+/// The PublisherPrivate object has to be stored in a global static map
+/// and not within the Publisher class. This is because we need to keep the
+/// PublisherPrivate object alive for the caller of the OnPublisherComplete,
+/// otherwise we run into a situation in which the caller invokes a
+/// function of a destroyed object
 static std::map<uint32_t, std::shared_ptr<PublisherPrivate>> publisherMap;
 
 //////////////////////////////////////////////////

--- a/gazebo/transport/Publisher.hh
+++ b/gazebo/transport/Publisher.hh
@@ -131,10 +131,6 @@ namespace gazebo
       private: void PublishImpl(const google::protobuf::Message &_message,
                                 bool _block);
 
-      /// \brief Callback when a publish is completed
-      /// \param[in] _id ID associated with the publication.
-      private: void OnPublishComplete(uint32_t _id);
-
       /// \brief Topic on which messages are published.
       private: std::string topic;
 
@@ -173,6 +169,7 @@ namespace gazebo
       private: uint32_t pubId;
 
       /// \brief Current publication ids.
+      /// This variable is no longer used. Kept here for ABI compatibility.
       private: std::map<uint32_t, int> pubIds;
 
       /// \brief Unique ID for this publisher.


### PR DESCRIPTION
The race condition problem occurs when the `Publisher::OnPublishComplete` callback is invoked from a different thread after the `Publisher` object is destroyed, causing a crash. There's been a few attempts to fixing this race condition, see this [commit](https://github.com/osrf/gazebo/commit/e87d6cd82cede31b62025b367571bea2424ca602) and this [PR](https://bitbucket.org/osrf-migrated/gazebo/pull-requests/3103/fix-race-conditions-in-master/diff), but the issue persists and it is just harder to reproduce. When successfully reproduced, I get a assertion error in this [line](https://github.com/osrf/gazebo/blob/gazebo9/gazebo/transport/Publisher.cc#L242) when locking the mutex.

The fix is to bind the callback function along with a shared pointer instead of raw pointer `this` so that the object is kept alive for a little longer until after the callback is complete. In the case of Publisher, this should be safe to do as the `OnPublishComplete` function is mainly just doing some bookkeeping work. Note that I added a `PublisherPrivate` class and stored instances of this class in a static variable to avoid breaking ABI.

To reproduce this issue:

1. Save this model as `box.sdf` file:

```
<?xml version="1.0" ?>
<sdf version="1.6">
  <model name="box">
    <pose>0 0 0.5 0 0 0</pose>
    <link name="link">
      <collision name="collision">
        <geometry>
          <box>
            <size>1 1 1</size>
          </box>
        </geometry>
      </collision>
      <visual name="visual">
        <geometry>
          <box>
            <size>1 1 1</size>
          </box>
        </geometry>
      </visual>
    </link>
  </model>
</sdf>
```

2. launch gazebo using roslaunch: 

```
roslaunch gazebo_ros empty_world.launch verbose:=true
```

3. Run the following script that spawns and deletes the box model 500 times:

```
#!/bin/bash
for i in {0..500}; do
    echo "$i"
    rosparam set pizza --textfile box.sdf
    rosrun gazebo_ros spawn_model -param pizza -sdf -model box -x 0 -y 0.5 -z 0
    sleep 0.5
    rosservice call gazebo/delete_model '{model_name: box}'
done
```

4. Without changes in this PR, the crash occurs on spawn after a couple hundred iterations for me


Signed-off-by: Ian Chen <ichen@osrfoundation.org>