### PR TITLE
⬆️  9.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 9)
-set (GAZEBO_MINOR_VERSION 13)
+set (GAZEBO_MINOR_VERSION 14)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.
-set (GAZEBO_PATCH_VERSION 2)
+set (GAZEBO_PATCH_VERSION 0)
 
 set (GAZEBO_VERSION ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION})
 set (GAZEBO_VERSION_FULL ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION}.${GAZEBO_PATCH_VERSION})

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,10 @@
 
 ## Gazebo 9.xx.x (202x-xx-xx)
 
-## Gazebo 9.13.2 (202x-xx-xx)
+## Gazebo 9.14.0 (2020-08-06)
+
+1. Lockstep between sensors and physics
+    * [Pull request #2793](https://github.com/osrf/gazebo/pull/2793)
 
 1. Fix sensor update rate throttling when new sensors are spawned
     * [Pull request #2784](https://github.com/osrf/gazebo/pull/2784)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,10 +2,13 @@
 
 ## Gazebo 9.xx.x (202x-xx-xx)
 
-## Gazebo 9.14.0 (2020-08-06)
+## Gazebo 9.14.0 (2020-08-07)
 
 1. Lockstep between sensors and physics
     * [Pull request #2793](https://github.com/osrf/gazebo/pull/2793)
+
+1. Fix race condition on Publisher shutdown
+    * [Pull request #2812](https://github.com/osrf/gazebo/pull/2812)
 
 ## Gazebo 9.13.2 (2020-07-20)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@
 1. Lockstep between sensors and physics
     * [Pull request #2793](https://github.com/osrf/gazebo/pull/2793)
 
+## Gazebo 9.14.0 (2020-07-20)
+
 1. Fix sensor update rate throttling when new sensors are spawned
     * [Pull request #2784](https://github.com/osrf/gazebo/pull/2784)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 1. Lockstep between sensors and physics
     * [Pull request #2793](https://github.com/osrf/gazebo/pull/2793)
 
-## Gazebo 9.14.0 (2020-07-20)
+## Gazebo 9.13.2 (2020-07-20)
 
 1. Fix sensor update rate throttling when new sensors are spawned
     * [Pull request #2784](https://github.com/osrf/gazebo/pull/2784)


### PR DESCRIPTION
Comparison to 9.13.1: https://github.com/osrf/gazebo/compare/gazebo9_9.13.1...gazebo9

As far as I could tell, a 9.13.2 was never released.