### PR TITLE
DARTHeightmapShape: correctly load asymmetric terrains

### DIFF
--- a/gazebo/physics/dart/DARTHeightmapShape.cc
+++ b/gazebo/physics/dart/DARTHeightmapShape.cc
@@ -30,6 +30,7 @@ DARTHeightmapShape::DARTHeightmapShape(DARTCollisionPtr _parent)
   : HeightmapShape(_parent),
     dataPtr(new DARTHeightmapShapePrivate<HeightmapShape::HeightType>())
 {
+  this->flipY = false;
 }
 
 //////////////////////////////////////////////////

--- a/worlds/heightmap.world
+++ b/worlds/heightmap.world
@@ -1,6 +1,11 @@
 <?xml version="1.0" ?>
 <sdf version="1.5">
   <world name="default">
+    <physics type="ode">
+      <dart>
+        <collision_detector>bullet</collision_detector>
+      </dart>
+    </physics>
     <!-- A global light source -->
     <include>
       <uri>model://sun</uri>


### PR DESCRIPTION
Support for heightmaps in DART was added in [bitbucket pull request 2956](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/2956) and [bitbucket pull request 3066](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/3066) with tests using the [heightmap_valley.png](https://github.com/osrf/gazebo/blob/gazebo11/media/materials/textures/heightmap_valley.png) image, which happens to be symmetric in both x and y directions. I recently noticed a bug in DARTHeightmapShape when using asymmetric terrains, so I added a test using [worlds/heightmap.world](https://github.com/osrf/gazebo/blob/gazebo11/worlds/heightmap.world), which uses the asymmetric [heightmap_bowl.png](https://github.com/osrf/gazebo/blob/gazebo11/media/materials/textures/heightmap_bowl.png) with a box at each of the 4 corners. The boxes all start at the same height, and based on the shape of the heightmap, 3 of the boxes should already be in contact with the heightmap, but one of them (`box2`) should fall. I've added a test that illlustrates the failure with dart:

~~~
[Dbg] [DARTPhysics.cc:734] Using BULLET collision detector
Dbg DART Bullet heightfield AABB: min = {-64.249, -64.249, -5}, max = {64.249, 64.249, 5} (will be translated by z=5)
AL lib: (EE) ALCpulsePlayback_streamStateCallback: Received stream failure!
[Dbg] [ServerFixture.cc:203] ServerFixture load in 0.8 seconds, timeout after 600 seconds
/data_fast/scpeters/ws/gazebo8/src/gazebo/test/integration/heightmap.cc:952: Failure
Expected: (box1->WorldPose().Pos().Z()) >= (9.9), actual: 5.0951 vs 9.9
/data_fast/scpeters/ws/gazebo8/src/gazebo/test/integration/heightmap.cc:956: Failure
Expected: (box2->WorldPose().Pos().Z()) < (5.5), actual: 9.98575 vs 5.5
[Dbg] [ServerFixture.cc:129] ServerFixture::Unload
~~~

The fix is to set an uninitialized variable `DARTHeightmapShape::flipY` to false.

Use `gazebo --verbose worlds/heightmap.world -e dart` to see the failure in gzclient.