### PR TITLE
Add support for frame semantics with nested models in SDFormat 1.7

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -606,7 +606,7 @@ endif ()
 
 ########################################
 # Find SDFormat
-set(SDF_MIN_REQUIRED_VERSION 9.1)
+set(SDF_MIN_REQUIRED_VERSION 9.3)
 find_package(sdformat9 ${SDF_MIN_REQUIRED_VERSION} REQUIRED)
 if (sdformat9_FOUND)
   message (STATUS "Looking for SDFormat9  - found")

--- a/gazebo/common/SdfFrameSemantics.cc
+++ b/gazebo/common/SdfFrameSemantics.cc
@@ -28,7 +28,6 @@
 #include "sdf/JointAxis.hh"
 #include "sdf/SemanticPose.hh"
 
-
 namespace gazebo
 {
 namespace common
@@ -173,9 +172,15 @@ void convertPosesToSdf16(const sdf::ElementPtr &_modelElem)
       }
     }
   }
-  // TODO (addisu) Revisit when composition with frame semantics is
-  // supported in sdformat
-  // Models
+
+  for (std::size_t modelInd = 0; modelInd < modelSDFDom.ModelCount();
+       ++modelInd)
+  {
+    auto *nestedModelDom = modelSDFDom.ModelByIndex(modelInd);
+    updateIfRelativeTo(nestedModelDom->Element(),
+                       nestedModelDom->SemanticPose());
+    convertPosesToSdf16(nestedModelDom->Element());
+  }
 }
 }
 }

--- a/gazebo/common/SdfFrameSemantics.cc
+++ b/gazebo/common/SdfFrameSemantics.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <ignition/math/SemanticVersion.hh>
+
 #include "gazebo/common/SdfFrameSemantics.hh"
 #include "gazebo/common/Console.hh"
 
@@ -25,6 +27,7 @@
 #include "sdf/Joint.hh"
 #include "sdf/JointAxis.hh"
 #include "sdf/SemanticPose.hh"
+
 
 namespace gazebo
 {
@@ -84,11 +87,18 @@ void convertPosesToSdf16(const sdf::ElementPtr &_modelElem)
   sdf::Model modelSDFDom;
   sdf::Errors errors = modelSDFDom.Load(_modelElem);
 
-  for (const auto &error : errors)
+  auto sdfVersion =
+      ignition::math::SemanticVersion(_modelElem->OriginalVersion());
+  // Only print out errors if the original SDFormat version does not support
+  // frame semantics
+  if (sdfVersion >= ignition::math::SemanticVersion(1, 7))
   {
-    if (isSdfFrameSemanticsError(error))
+    for (const auto &error : errors)
     {
-      gzerr << error << "\n";
+      if (isSdfFrameSemanticsError(error))
+      {
+        gzerr << error << "\n";
+      }
     }
   }
 

--- a/gazebo/gui/ModelMaker_TEST.hh
+++ b/gazebo/gui/ModelMaker_TEST.hh
@@ -42,6 +42,10 @@ class ModelMaker_TEST : public QTestFixture
 
   /// \brief Test creating a nested model by copying another nested model.
   private slots: void FromNestedModel();
+
+  /// \brief Test creating a nested model with frame semantics (SDFormat 1.7)
+  /// from a file
+  private slots: void FromNestedModelFileWithFrameSemantics();
 };
 
 #endif

--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -85,10 +85,10 @@ void Model::Load(sdf::ElementPtr _sdf)
     BasePtr parentEntity = this->GetParent();
     if (nullptr != parentEntity && !modelName.empty())
     {
-      if (boost::dynamic_pointer_cast<Model>(parentEntity))
+      auto parentModelPtr = boost::dynamic_pointer_cast<Model>(parentEntity);
+      if (parentModelPtr)
       {
-        auto parentDom =
-            boost::dynamic_pointer_cast<Model>(parentEntity)->GetSDFDom();
+        auto parentDom = parentModelPtr->GetSDFDom();
         if (nullptr != parentDom)
         {
           this->modelSDFDom = parentDom->ModelByName(modelName);

--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -91,12 +91,19 @@ void Model::Load(sdf::ElementPtr _sdf)
     {
       this->modelSDFDomIsolated = std::make_unique<sdf::Model>();
       sdf::Errors errors = this->modelSDFDomIsolated->Load(_sdf);
-      // Print errors and load the parts that worked.
-      for (const auto &error : errors)
+      auto sdfVersion =
+        ignition::math::SemanticVersion(_sdf->OriginalVersion());
+      // Only print out errors if the original SDFormat version does not support
+      // frame semantics
+      if (sdfVersion >= ignition::math::SemanticVersion(1, 7))
       {
-        if (common::isSdfFrameSemanticsError(error))
+        // Print errors and load the parts that worked.
+        for (const auto &error : errors)
         {
-          gzerr << error << "\n";
+          if (common::isSdfFrameSemanticsError(error))
+          {
+            gzerr << error << "\n";
+          }
         }
       }
       this->modelSDFDom = this->modelSDFDomIsolated.get();

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -30,6 +30,7 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <ignition/math/Rand.hh>
+#include <ignition/math/SemanticVersion.hh>
 
 #include <gazebo/gazebo_config.h>
 
@@ -186,11 +187,18 @@ void World::Load(sdf::ElementPtr _sdf)
   sdf::Errors errors = this->dataPtr->worldSDFDom->Load(_sdf);
 
   // Print errors and load the parts that worked.
-  for (const auto &error : errors)
+  auto sdfVersion =
+    ignition::math::SemanticVersion(_sdf->OriginalVersion());
+  // Only print out errors if the original SDFormat version does not support
+  // frame semantics
+  if (sdfVersion >= ignition::math::SemanticVersion(1, 7))
   {
-    if (common::isSdfFrameSemanticsError(error))
+    for (const auto &error : errors)
     {
-      gzerr << error << "\n";
+      if (common::isSdfFrameSemanticsError(error))
+      {
+        gzerr << error << "\n";
+      }
     }
   }
 

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -38,7 +38,7 @@
 #include <ignition/msgs/stringmsg.pb.h>
 
 #include "ignition/common/Profiler.hh"
-#include <ignition/common/URI.hh>
+#include "ignition/common/URI.hh"
 #include "gazebo/common/FuelModelDatabase.hh"
 
 #include "gazebo/transport/Node.hh"

--- a/gazebo/sensors/SensorManager.cc
+++ b/gazebo/sensors/SensorManager.cc
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
 */
-#include "ignition/common/Profiler.hh"
 
 #include <functional>
 #include <boost/bind.hpp>
@@ -29,6 +28,8 @@
 #include "gazebo/sensors/SensorFactory.hh"
 #include "gazebo/sensors/SensorManager.hh"
 #include "gazebo/util/LogPlay.hh"
+
+#include "ignition/common/Profiler.hh"
 
 using namespace gazebo;
 using namespace sensors;

--- a/test/integration/nested_model.cc
+++ b/test/integration/nested_model.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <string.h>
+#include <string>
 
 #include <ignition/math/Pose3.hh>
 
@@ -27,7 +27,7 @@
 #define PHYSICS_TOL 1e-2
 using namespace gazebo;
 
-class PhysicsMsgsTest : public ServerFixture,
+class NestedModelTest : public ServerFixture,
                         public testing::WithParamInterface<const char*>
 {
   /// \brief Test loading a world with nested model.
@@ -41,7 +41,7 @@ class PhysicsMsgsTest : public ServerFixture,
 
 
 ////////////////////////////////////////////////////////////////////////
-void PhysicsMsgsTest::LoadNestedModel(const std::string &_physicsEngine)
+void NestedModelTest::LoadNestedModel(const std::string &_physicsEngine)
 {
   // load a world with a nested model
   Load("worlds/nested_model.world", true, _physicsEngine);
@@ -147,7 +147,7 @@ void PhysicsMsgsTest::LoadNestedModel(const std::string &_physicsEngine)
 }
 
 ////////////////////////////////////////////////////////////////////////
-void PhysicsMsgsTest::SpawnNestedModel(const std::string &_physicsEngine)
+void NestedModelTest::SpawnNestedModel(const std::string &_physicsEngine)
 {
   if (_physicsEngine == "simbody")
   {
@@ -173,7 +173,7 @@ void PhysicsMsgsTest::SpawnNestedModel(const std::string &_physicsEngine)
   EXPECT_EQ(physics->GetType(), _physicsEngine);
 
   std::ostringstream sdfStream;
-  sdfStream << "<sdf version='" << SDF_VERSION << "'>"
+  sdfStream << "<sdf version='1.6'>"
     << "<model name ='model_00'>"
     << "  <pose>0 0 1 0 0 0</pose>"
     << "  <model name ='model_01'>"
@@ -344,18 +344,18 @@ void PhysicsMsgsTest::SpawnNestedModel(const std::string &_physicsEngine)
 }
 
 /////////////////////////////////////////////////
-TEST_P(PhysicsMsgsTest, LoadNestedModel)
+TEST_P(NestedModelTest, LoadNestedModel)
 {
   LoadNestedModel(GetParam());
 }
 
 /////////////////////////////////////////////////
-TEST_P(PhysicsMsgsTest, SpawnNestedModel)
+TEST_P(NestedModelTest, SpawnNestedModel)
 {
   SpawnNestedModel(GetParam());
 }
 
-INSTANTIATE_TEST_CASE_P(PhysicsEngines, PhysicsMsgsTest,
+INSTANTIATE_TEST_CASE_P(PhysicsEngines, NestedModelTest,
                         PHYSICS_ENGINE_VALUES,);  // NOLINT
 
 /////////////////////////////////////////////////

--- a/test/models/testdb/deeply_nested_model_with_frame_semantics/model.config
+++ b/test/models/testdb/deeply_nested_model_with_frame_semantics/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Nested Model Test With Frame Semantics</name>
+  <version>1.0</version>
+  <sdf version="1.7">model.sdf</sdf>
+
+  <description>
+    Nested model for testing purposes.
+  </description>
+</model>

--- a/test/models/testdb/deeply_nested_model_with_frame_semantics/model.sdf
+++ b/test/models/testdb/deeply_nested_model_with_frame_semantics/model.sdf
@@ -1,0 +1,140 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="model_00">
+    <pose>0 0 0.5 0 0 0</pose>
+    <link name="link_00">
+      <pose>0.25 0 1 0 0 0</pose>
+      <collision name="collision_00">
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+      </collision>
+      <visual name="visual_00">
+        <geometry>
+          <sphere>
+            <radius>0.5</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+
+    <model name="model_01">
+      <pose relative_to="link_00">1.0 0 0 0 0 0</pose>
+      <link name="link_01">
+        <pose>0.25 0 1.0 0 0 0</pose>
+        <collision name="collision_01">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual_01">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Red</name>
+            </script>
+          </material>
+        </visual>
+      </link>
+      <model name="model_02">
+        <pose relative_to="link_01">0 2 0 0 0 0</pose>
+        <link name="link_02">
+          <pose>0.25 0 1.0 0 0 0</pose>
+          <collision name="collision_02">
+            <geometry>
+              <cylinder>
+                <radius>0.5</radius>
+                <length>1</length>
+              </cylinder>
+            </geometry>
+          </collision>
+          <visual name="visual_02">
+            <geometry>
+              <cylinder>
+                <radius>0.5</radius>
+                <length>1</length>
+              </cylinder>
+            </geometry>
+            <material>
+              <script>
+                <uri>file://media/materials/scripts/gazebo.material</uri>
+                <name>Gazebo/Green</name>
+              </script>
+            </material>
+          </visual>
+        </link>
+        <model name="model_03">
+          <pose relative_to="link_02">0 0 3 0 0 0</pose>
+          <link name="link_03">
+            <pose>0.25 0 1.0 0 0 0</pose>
+            <collision name="collision_03">
+              <geometry>
+                <box>
+                  <size>1 1 1</size>
+                </box>
+              </geometry>
+            </collision>
+            <visual name="visual_03">
+              <geometry>
+                <box>
+                  <size>1 1 1</size>
+                </box>
+              </geometry>
+              <material>
+                <script>
+                  <uri>file://media/materials/scripts/gazebo.material</uri>
+                  <name>Gazebo/Blue</name>
+                </script>
+              </material>
+            </visual>
+          </link>
+        </model>
+      </model>
+    </model>
+
+    <!-- Joints that reference entities in nested models are not compatible 
+      with frame semantics in SDFormat 1.7 -->
+
+    <!-- <joint name="joint_00" type="revolute"> -->
+    <!--   <parent>link_00</parent> -->
+    <!--   <child>model_01::link_01</child> -->
+    <!--   <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose> -->
+    <!--   <axis> -->
+    <!--     <xyz>1.0 0.0 0.0</xyz> -->
+    <!--   </axis> -->
+    <!-- </joint> -->
+
+    <!-- <joint name="joint_01" type="revolute"> -->
+    <!--   <parent>model_01::link_01</parent> -->
+    <!--   <child>model_01::model_02::link_02</child> -->
+    <!--   <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose> -->
+    <!--   <axis> -->
+    <!--     <xyz>1.0 0.0 0.0</xyz> -->
+    <!--   </axis> -->
+    <!-- </joint> -->
+
+    <!-- <joint name="joint_02" type="revolute"> -->
+    <!--   <parent>model_01::model_02::link_02</parent> -->
+    <!--   <child>model_01::model_02::model_03::link_03</child> -->
+    <!--   <pose>0.0 0.0 0.0 0.0 0.0 0.0</pose> -->
+    <!--   <axis> -->
+    <!--     <xyz>1.0 0.0 0.0</xyz> -->
+    <!--   </axis> -->
+    <!-- </joint> -->
+  </model>
+</sdf>

--- a/test/worlds/nested_model_with_frame_semantics.sdf
+++ b/test/worlds/nested_model_with_frame_semantics.sdf
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+  <world name="default">
+    <model name="parent_model">
+      <link name="L1"/>
+      <link name="L2">
+        <pose>0 1 0 0 0 0</pose>
+      </link>
+      <model name="M1">
+        <pose>1 0 0 0 1.5707963267948966 0</pose>
+        <link name="L">
+          <pose>0 0 1 0 0 0</pose>
+        </link>
+      </model>
+      <model name="M2">
+        <pose relative_to="">2 0 0 0 0 0</pose>
+        <link name="L">
+          <pose>0 0 1 0 0 0</pose>
+        </link>
+      </model>
+      <model name="M3">
+        <pose relative_to="M1">3 0 0 0 0 0</pose>
+        <link name="L">
+          <pose>0 0 1 0 0 0</pose>
+        </link>
+      </model>
+
+      <frame name="F1">
+        <pose relative_to="M3">0 1 0 0 0 0</pose>
+      </frame>
+
+      <joint name="J1" type="revolute">
+        <pose relative_to="F1">1 0 0 0 0 0</pose>
+        <parent>L1</parent>
+        <child>L2</child>
+        <axis>
+          <xyz>1 0 0</xyz>
+        </axis>
+      </joint>
+    </model>
+  </world>
+</sdf>
+


### PR DESCRIPTION
Support for nested models is going to be added to SDFormat 1.7 in https://github.com/osrf/sdformat/pull/316. This PR adds support in Gazebo for using nested models that utilize the frame semantics features of SDFormat 1.7. Note, however, that since SDFormat 1.7 does not support referencing entities inside nested models, SDFormat 1.7 files that use frame semantics as well as nested references will not be supported.
For example, the following SDFormat file will emit an error because joint `J1` references `M2::L2`.
```xml
<sdf version="1.7">
  <model name="M1">
    <link name="L1">
      <pose>0.1 0 0 0 0 0</pose>
    </link>
    <model name="M2">
      <pose>0 0 0.1 0 0 0</pose>
      <link name="L2"/>
    </model>
    <joint name="J1" type="revolute">
      <pose relative_to="L1">0 0 0.1 0 0 0</pose>
      <parent>L1</parent>
      <child>M2::L2</child>
      <axis><xyz>0 0 1</xyz></axis>
    </joint>
  </model>
</sdf>
```
If such a model is loaded, Gazebo will resolve poses with frame semantics wherever it can and revert to the semantics of SDFormat 1.6 where it can't. In the above example, all the poses except `J1`'s will be resolved with SDFormat 1.7 semantics. 
