### PR TITLE
👩‍🌾 Fixed fails for OSX: Added using namespace boost::placeholders

### DIFF
--- a/examples/stand_alone/custom_main_pkgconfig/CMakeLists.txt
+++ b/examples/stand_alone/custom_main_pkgconfig/CMakeLists.txt
@@ -12,3 +12,9 @@ link_directories(${GAZEBO_LIBRARY_DIRS})
 
 add_executable(custom_main custom_main.cc)
 target_link_libraries(custom_main ${GAZEBO_LIBRARIES})
+
+if(${CMAKE_VERSION} VERSION_LESS "3.13.0") 
+  link_directories(${Boost_LIBRARY_DIRS})
+else()
+  target_link_directories(custom_main PUBLIC ${Boost_LIBRARY_DIRS})
+endif()

--- a/gazebo/gui/model/ModelTreeWidget.cc
+++ b/gazebo/gui/model/ModelTreeWidget.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <boost/version.hpp>
+
 #include "gazebo/common/Events.hh"
 
 #include "gazebo/gui/GuiEvents.hh"
@@ -160,6 +162,10 @@ ModelTreeWidget::ModelTreeWidget(QWidget *_parent)
   this->layout()->setContentsMargins(0, 0, 0, 0);
 
   // Connections
+  #if BOOST_VERSION >= 107300
+  using namespace boost::placeholders;
+  #endif
+
   this->connections.push_back(
       gui::model::Events::ConnectSaveModel(
       boost::bind(&ModelTreeWidget::OnSaveModel, this, _1)));

--- a/gazebo/gui/model/SchematicViewWidget.cc
+++ b/gazebo/gui/model/SchematicViewWidget.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <boost/version.hpp>
+
 #include <ignition/math/Color.hh>
 
 #include "gazebo/rendering/Material.hh"
@@ -82,6 +84,10 @@ void SchematicViewWidget::Reset()
 /////////////////////////////////////////////////
 void SchematicViewWidget::Init()
 {
+  #if BOOST_VERSION >= 107300
+  using namespace boost::placeholders;
+  #endif
+
   this->connections.push_back(gui::model::Events::ConnectLinkInserted(
       boost::bind(&SchematicViewWidget::AddNode, this, _1)));
 

--- a/test/plugins/ForceTorqueModelRemovalTestPlugin.cc
+++ b/test/plugins/ForceTorqueModelRemovalTestPlugin.cc
@@ -15,6 +15,8 @@
  *
  */
 
+#include <functional>
+
 #include "plugins/ForceTorqueModelRemovalTestPlugin.hh"
 
 #include "gazebo/sensors/ForceTorqueSensor.hh"
@@ -53,7 +55,8 @@ void ForceTorqueModelRemovalTestPlugin::Load(sensors::SensorPtr _sensor,
 
   // Create connection
   this->updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(
-       boost::bind(&ForceTorqueModelRemovalTestPlugin::onUpdate, this, _1));
+       std::bind(&ForceTorqueModelRemovalTestPlugin::onUpdate, this,
+                 std::placeholders::_1));
 }
 
 void ForceTorqueModelRemovalTestPlugin::onUpdate(


### PR DESCRIPTION
Forward-port #2680 

That fixed the Gazebo 9 build on macOS, so I hope it has the same effect for Gazebo 10.