### PR TITLE
Respect joint axes' initial_position

### DIFF
--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -1350,14 +1350,14 @@ void Model::SetState(const ModelState &_state)
       gzerr << "Unable to find model[" << ms.first << "]\n";
   }
 
-  // For now we don't use the joint state values to set the state of
-  // simulation.
-  // for (unsigned int i = 0; i < _state.GetJointStateCount(); ++i)
-  // {
-  //   JointState jointState = _state.GetJointState(i);
-  //   this->SetJointPosition(this->GetName() + "::" + jointState.GetName(),
-  //                          jointState.GetAngle(0).Radian());
-  // }
+  for (unsigned int i = 0; i < _state.GetJointStateCount(); ++i)
+  {
+    JointState const jointState = _state.GetJointState(i);
+    for (unsigned int k = 0; k < jointState.GetAngleCount(); ++k) {
+      this->SetJointPosition(this->GetName() + "::" + jointState.GetName(),
+                            jointState.Position(k), k);
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/gazebo/physics/ModelState.cc
+++ b/gazebo/physics/ModelState.cc
@@ -204,7 +204,7 @@ void ModelState::Load(const sdf::ElementPtr _elem)
   }
 
   // Set all the joints
-  /*this->jointStates.clear();
+  this->jointStates.clear();
   if (_elem->HasElement("joint"))
   {
     sdf::ElementPtr childElem = _elem->GetElement("joint");
@@ -215,7 +215,7 @@ void ModelState::Load(const sdf::ElementPtr _elem)
             JointState(childElem)));
       childElem = childElem->GetNextElement("joint");
     }
-  }*/
+  }
 }
 
 /////////////////////////////////////////////////

--- a/gazebo/physics/ModelState_TEST.cc
+++ b/gazebo/physics/ModelState_TEST.cc
@@ -165,6 +165,41 @@ TEST_F(ModelStateTest, Nested)
   }
 }
 
+TEST_F(ModelStateTest, JointState)
+{
+  std::ostringstream sdfStr;
+  sdfStr << "<sdf version ='" << SDF_VERSION << "'>"
+    << "<world name='default'>"
+    << "<state world_name='default'>"
+    << "<model name='model_00'>"
+    << "  <joint name='joint_00'>"
+    << "    <angle axis='0'>1.57</angle>"
+    << "  </joint>"
+    << "</model>"
+    << "</state>"
+    << "</world>"
+    << "</sdf>";
+  sdf::SDFPtr worldSDF(new sdf::SDF);
+  worldSDF->SetFromString(sdfStr.str());
+  EXPECT_TRUE(worldSDF->Root()->HasElement("world"));
+  sdf::ElementPtr worldElem = worldSDF->Root()->GetElement("world");
+  EXPECT_TRUE(worldElem->HasElement("state"));
+  sdf::ElementPtr stateElem = worldElem->GetElement("state");
+  EXPECT_TRUE(stateElem->HasElement("model"));
+  sdf::ElementPtr modelElem = stateElem->GetElement("model");
+  EXPECT_TRUE(modelElem != nullptr);
+
+  physics::ModelState const modelState(modelElem);
+
+  ASSERT_EQ(modelState.GetJointStateCount(), 1u);
+
+  physics::JointState const jointState = modelState.GetJointState(0);
+  EXPECT_EQ(1u, jointState.GetAngleCount());
+  EXPECT_EQ(1u, jointState.Positions().size());
+  EXPECT_DOUBLE_EQ(1.57, jointState.Position(0));
+  EXPECT_TRUE(ignition::math::isnan(jointState.Position(1)));
+}
+
 int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/integration/model.cc
+++ b/test/integration/model.cc
@@ -51,6 +51,20 @@ TEST_F(ModelTest, GetLinksV)
   EXPECT_EQ(model->GetLinks().size(), 1u);
 }
 
+TEST_F(ModelTest, LoadJointState)
+{
+  Load("worlds/joint_state_test.world");
+  physics::ModelPtr const model = GetModel("model_3");
+
+  ASSERT_EQ(model->GetJointCount(), 2u);
+
+  physics::JointPtr const joint_1 = model->GetJoint("joint_1");
+  EXPECT_NEAR(joint_1->Position(), 0.7854, 0.0001);
+
+  physics::JointPtr const joint_2 = model->GetJoint("joint_2");
+  EXPECT_NEAR(joint_2->Position(), 0.7854, 0.0001);
+}
+
 /////////////////////////////////////////////////
 // This tests getting the scoped name of a model.
 TEST_F(ModelTest, GetScopedName)

--- a/test/integration/model.cc
+++ b/test/integration/model.cc
@@ -65,6 +65,20 @@ TEST_F(ModelTest, LoadJointState)
   EXPECT_NEAR(joint_2->Position(), 0.7854, 0.0001);
 }
 
+TEST_F(ModelTest, JointInitialPosition)
+{
+  Load("worlds/joint_test.world");
+  physics::ModelPtr const model = GetModel("model_3");
+
+  ASSERT_EQ(model->GetJointCount(), 2u);
+
+  physics::JointPtr const joint_1 = model->GetJoint("joint_1");
+  EXPECT_NEAR(joint_1->Position(), 0.7854, 0.0001);
+
+  physics::JointPtr const joint_2 = model->GetJoint("joint_2");
+  EXPECT_NEAR(joint_2->Position(), 1.5707, 0.0001);
+}
+
 /////////////////////////////////////////////////
 // This tests getting the scoped name of a model.
 TEST_F(ModelTest, GetScopedName)

--- a/test/worlds/joint_state_test.world
+++ b/test/worlds/joint_state_test.world
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<sdf version="1.7">
+    <world name="default">
+        <!-- A global light source -->
+        <include>
+            <uri>model://sun</uri>
+        </include>
+        <model name="model_3">
+            <pose>0 0 0 0 0 0</pose>
+            <link name="link_1">
+                <visual name="link_1_box">
+                    <pose>0 0.5 0 0 0 0</pose>
+                    <geometry>
+                        <box>
+                            <size>0.125 0.95 0.125</size>
+                        </box>
+                    </geometry>
+                </visual>
+            </link>
+            <link name="link_2">
+                <visual name="link_2_visual">
+                    <pose>0 1.5 0 0 0 0</pose>
+                    <geometry>
+                        <box>
+                            <size>0.125 0.95 0.125</size>
+                        </box>
+                    </geometry>
+                </visual>
+            </link>
+            <joint name="joint_1" type="revolute">
+                <parent>world</parent>
+                <child>link_1</child>
+                <axis>
+                    <xyz>0 0 1</xyz>
+                </axis>
+            </joint>
+            <joint name="joint_2" type="revolute">
+                <parent>link_1</parent>
+                <child>link_2</child>
+                <axis>
+                    <xyz>0 0 1</xyz>
+                </axis>
+                <pose>0 1 0 0 0 0</pose>
+            </joint>
+        </model>
+        <state world_name="default">
+            <model name="model_3">
+                <joint name="joint_1">
+                    <angle axis=0>0.7854</angle>
+                </joint>
+                <joint name="joint_2">
+                    <angle axis=0>0.7854</angle>
+                </joint>
+            </model>
+        </state>
+    </world>
+</sdf>

--- a/test/worlds/joint_test.world
+++ b/test/worlds/joint_test.world
@@ -141,5 +141,45 @@
             </joint>
             <static>0</static>
         </model>
+        <model name="model_3">
+            <pose>0 2 0 0 0 0</pose>
+            <link name="link_1">
+                <visual name="link_1_box">
+                    <pose>0 0.5 0 0 0 0</pose>
+                    <geometry>
+                        <box>
+                            <size>0.125 0.95 0.125</size>
+                        </box>
+                    </geometry>
+                </visual>
+            </link>
+            <link name="link_2">
+                <visual name="link_2_visual">
+                    <pose>0 1.5 0 0 0 0</pose>
+                    <geometry>
+                        <box>
+                            <size>0.125 0.95 0.125</size>
+                        </box>
+                    </geometry>
+                </visual>
+            </link>
+            <joint name="joint_1" type="revolute">
+                <parent>world</parent>
+                <child>link_1</child>
+                <axis>
+                    <xyz>0 0 1</xyz>
+                    <initial_position>0.7854</initial_position>
+                </axis>
+            </joint>
+            <joint name="joint_2" type="revolute">
+                <parent>link_1</parent>
+                <child>link_2</child>
+                <axis>
+                    <xyz>0 0 1</xyz>
+                    <initial_position>1.5707</initial_position>
+                </axis>
+                <pose>0 1 0 0 0 0</pose>
+            </joint>
+        </model>
     </world>
 </sdf>


### PR DESCRIPTION
SDF version 1.6 introduced an initial_position for joint axes. This is useful for loading models in a collision free pose. For example, Universal Robot's UR5e is penetrating the ground with the default initial configuration of all axes set to 0.0.

Fixes #2694 