### PR TITLE
Fix reflectance values for objects without a reflectance map

### DIFF
--- a/gazebo/rendering/DepthCamera.cc
+++ b/gazebo/rendering/DepthCamera.cc
@@ -801,11 +801,11 @@ ReflectanceMaterialListener::ReflectanceMaterialListener(ScenePtr _scene)
   this->reflectanceMaterial =
       Ogre::MaterialManager::getSingleton().getByName(material);
 
-  material = "Gazebo/Black";
+  material = "Gazebo/BlackUnlit";
   Ogre::MaterialManager::getSingleton().load(material,
       Ogre::ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
   this->blackMaterial =
-      Ogre::MaterialManager::getSingleton().getByName("Gazebo/Black");
+      Ogre::MaterialManager::getSingleton().getByName("Gazebo/BlackUnlit");
 }
 
 /////////////////////////////////////////////////

--- a/media/materials/scripts/gazebo.material
+++ b/media/materials/scripts/gazebo.material
@@ -240,6 +240,19 @@ material Gazebo/Black
   }
 }
 
+material Gazebo/BlackUnlit
+{
+  technique
+  {
+    lighting off
+    pass
+    {
+      ambient 0 0 0 1
+      diffuse 0 0 0 1
+      specular 0 0 0 1
+    }
+  }
+}
 
 material Gazebo/Red
 {


### PR DESCRIPTION
When generating reflectance values for depth cameras, visuals in the scene without a reflectance map is assigned a black material so they show up as 0s in the image output. However, it was found that the material used [Gazebo/Black](https://github.com/osrf/gazebo/blob/e4f20675ef2fbdc8f102adab48365532ff82934f/media/materials/scripts/gazebo.material#L230) is not a pure black color as it has a small amount specular component and the final color is also affected by lighting. So the resulting reflectance output is non-zero. This PR creates a new `Gazebo/BlackUnlit` material that is true black and updates the reflectance generation code to use this material instead.  

Signed-off-by: Ian Chen <ichen@osrfoundation.org>