### PR TITLE
Use new policy for CMP0057 to fix finding DART

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -161,6 +161,7 @@ if (PKG_CONFIG_FOUND)
 
   #################################################
   # Find DART
+  cmake_policy(SET CMP0057 NEW)
   set(DART_MIN_REQUIRED_VERSION 6.6)
   find_package(DART ${DART_MIN_REQUIRED_VERSION} CONFIG OPTIONAL_COMPONENTS collision-bullet collision-ode utils-urdf)
   if (DART_FOUND)


### PR DESCRIPTION
As of DART 6.9.3, the DARTFindBullet.cmake module uses the `IN_LIST` keyword with new behavior, which requires setting CMP0057 to new. Without this change, the gazebo10 CI is failing:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo10-xenial-amd64-gpu-nvidia&build=44)](https://build.osrfoundation.org/job/gazebo-ci-gazebo10-xenial-amd64-gpu-nvidia/44/) https://build.osrfoundation.org/job/gazebo-ci-gazebo10-xenial-amd64-gpu-nvidia/44/