### PR TITLE
Fix ogre log test

### DIFF
--- a/media/materials/scripts/gazebo.material
+++ b/media/materials/scripts/gazebo.material
@@ -244,7 +244,6 @@ material Gazebo/BlackUnlit
 {
   technique
   {
-    lighting off
     pass
     {
       ambient 0 0 0 1


### PR DESCRIPTION
`lighting` is specified in the wrong place but turns out the reflectance data generated are correct without this flag so it's removed.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>