### PR TITLE
Profile gzclient

### DIFF
--- a/gazebo/gui/GLWidget.cc
+++ b/gazebo/gui/GLWidget.cc
@@ -19,6 +19,7 @@
 #include <boost/lexical_cast.hpp>
 #include <math.h>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Matrix4.hh>
 #include <ignition/math/Pose3.hh>
 
@@ -279,16 +280,28 @@ void GLWidget::paintEvent(QPaintEvent *_e)
   rendering::UserCameraPtr cam = gui::get_active_camera();
   if (cam && cam->Initialized())
   {
-    event::Events::preRender();
+    {
+      IGN_PROFILE("gui::GLWidget::paintEvent pre-render");
+      event::Events::preRender();
+    }
 
     // Tell all the cameras to render
-    event::Events::render();
+    {
+      IGN_PROFILE("gui::GLWidget::paintEvent render");
+      event::Events::render();
+    }
 
-    event::Events::postRender();
+    {
+      IGN_PROFILE("gui::GLWidget::paintEvent post-render");
+      event::Events::postRender();
+    }
   }
   else
   {
-    event::Events::preRender();
+    {
+      IGN_PROFILE("gui::GLWidget::paintEvent pre-render");
+      event::Events::preRender();
+    }
   }
 
   _e->accept();

--- a/gazebo/gui/GuiIface.cc
+++ b/gazebo/gui/GuiIface.cc
@@ -25,6 +25,7 @@
 #include <boost/program_options.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/SemanticVersion.hh>
 
 #include "gazebo/gui/qt.h"
@@ -382,7 +383,7 @@ unsigned int gui::get_entity_id(const std::string &_name)
 /////////////////////////////////////////////////
 bool gui::run(int _argc, char **_argv)
 {
-  IGN_PROFILE_THREAD_NAME("gzclient")
+  IGN_PROFILE_THREAD_NAME("gzclient");
 
   // Initialize the informational logger. This will log warnings, and errors.
   gzLogInit("client-", "gzclient.log");

--- a/gazebo/gui/GuiIface.cc
+++ b/gazebo/gui/GuiIface.cc
@@ -382,6 +382,8 @@ unsigned int gui::get_entity_id(const std::string &_name)
 /////////////////////////////////////////////////
 bool gui::run(int _argc, char **_argv)
 {
+  IGN_PROFILE_THREAD_NAME("gzclient")
+
   // Initialize the informational logger. This will log warnings, and errors.
   gzLogInit("client-", "gzclient.log");
 

--- a/gazebo/gui/main.cc
+++ b/gazebo/gui/main.cc
@@ -22,6 +22,9 @@
 //////////////////////////////////////////////////
 int main(int _argc, char **_argv)
 {
+#ifndef _WIN32
+  ::setenv("RMT_PORT", "1501", true);
+#endif
   Q_INIT_RESOURCE(resources);
   int result = 0;
   try

--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -569,9 +569,18 @@ void Camera::RenderImpl()
 {
   if (this->renderTarget)
   {
-    Events::cameraPreRender(this->Name());
-    this->renderTarget->update();
-    Events::cameraPostRender(this->Name());
+    {
+      IGN_PROFILE("rendering::Camera::RenderImpl pre-render");
+      Events::cameraPreRender(this->Name());
+    }
+    {
+      IGN_PROFILE("rendering::Camera::RenderImpl update");
+      this->renderTarget->update();
+    }
+    {
+      IGN_PROFILE("rendering::Camera::RenderImpl post-render");
+      Events::cameraPostRender(this->Name());
+    }
   }
 }
 
@@ -654,6 +663,7 @@ common::Time Camera::LastRenderWallTime() const
 //////////////////////////////////////////////////
 void Camera::PostRender()
 {
+  IGN_PROFILE("rendering::Camera::PostRender");
   this->ReadPixelBuffer();
 
   // Only record last render time if data was actually generated

--- a/gazebo/rendering/RenderEngine.cc
+++ b/gazebo/rendering/RenderEngine.cc
@@ -35,6 +35,8 @@
 
 #include "gazebo/gazebo_config.h"
 
+#include <ignition/common/Profiler.hh>
+
 #include "gazebo/common/CommonIface.hh"
 #include "gazebo/common/Events.hh"
 #include "gazebo/common/Exception.hh"
@@ -261,17 +263,20 @@ unsigned int RenderEngine::SceneCount() const
 //////////////////////////////////////////////////
 void RenderEngine::PreRender()
 {
+  IGN_PROFILE("rendering::RenderEngine::PreRender");
   this->dataPtr->root->_fireFrameStarted();
 }
 
 //////////////////////////////////////////////////
 void RenderEngine::Render()
 {
+  IGN_PROFILE("rendering::RenderEngine::Render");
 }
 
 //////////////////////////////////////////////////
 void RenderEngine::PostRender()
 {
+  IGN_PROFILE("rendering::RenderEngine::PostRender");
   // _fireFrameRenderingQueued was here for CEGUI to work. Leaving because
   // it shouldn't harm anything, and we don't want to introduce
   // a regression.

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -19,6 +19,7 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
+#include <ignition/common/Profiler.hh>
 #include <ignition/math/Color.hh>
 #include <ignition/math/Helpers.hh>
 
@@ -1761,6 +1762,7 @@ void Scene::OnVisualMsg(ConstVisualPtr &_msg)
 //////////////////////////////////////////////////
 void Scene::PreRender()
 {
+  IGN_PROFILE("rendering::Scene::PreRender");
   /* Deferred shading debug code. Delete me soon (July 17, 2012)
   static bool first = true;
 

--- a/gazebo/rendering/UserCamera.cc
+++ b/gazebo/rendering/UserCamera.cc
@@ -250,6 +250,7 @@ void UserCamera::AnimationComplete()
 //////////////////////////////////////////////////
 void UserCamera::Render(const bool /*_force*/)
 {
+  IGN_PROFILE("rendering::UserCamera::Render");
   if (this->initialized)
   {
     this->newData = true;
@@ -260,6 +261,7 @@ void UserCamera::Render(const bool /*_force*/)
 //////////////////////////////////////////////////
 void UserCamera::PostRender()
 {
+  IGN_PROFILE("rendering::UserCamera::PostRender");
   Camera::PostRender();
 }
 

--- a/gazebo/server_main.cc
+++ b/gazebo/server_main.cc
@@ -24,6 +24,9 @@
 //////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
+#ifndef _WIN32
+  ::setenv("RMT_PORT", "1500", true);
+#endif
   std::unique_ptr<gazebo::Server> server;
 
   try


### PR DESCRIPTION
Add profiling for `gzclient`, builds on top of #2837 

Set the `RMT_PORT` variable so the `gzserver` and `gzclient` processes go to different ports. I'm using the [same numbers](https://github.com/ignitionrobotics/ign-gazebo/blob/fac36a4b06c3ba45b14c72163f9b390721edbda6/src/cmd/cmdgazebo.rb.in#L400-L418) as `ign-gazebo`, which are 1500 for the server and 1501 for the client. The tutorial needs to be updated if this goes in.

I also added some more profiling points. Here's a run with a camera, a lidar and contact visualization on.

![gzclient_profiling](https://user-images.githubusercontent.com/5751272/94635250-17ea3e80-0287-11eb-9732-ac5441466500.png)
