### PR TITLE
⬆️  9.15.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 9)
-set (GAZEBO_MINOR_VERSION 14)
+set (GAZEBO_MINOR_VERSION 15)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,35 @@
 
 ## Gazebo 9.xx.x (202x-xx-xx)
 
+## Gazebo 9.15.0 (2020-09-30)
+
+1. More enhancement for Windows build
+    * [Pull request #2789](https://github.com/osrf/gazebo/pull/2789)
+
+1. Fixed fails for OSX: Added using namespace boost::placeholders
+    * [Pull request #2809](https://github.com/osrf/gazebo/pull/2809)
+
+1. Add profiler
+    * [Pull request #2813](https://github.com/osrf/gazebo/pull/2813)
+
+1. ColladaLoader: fix cases where VERTEX and NORMAL share same polylist <p>
+    * [Pull request #2825](https://github.com/osrf/gazebo/pull/2825)
+
+1. Fix assumptions that CMAKE\_INSTALL\_\*DIR paths are relative
+    * [Pull request #2779](https://github.com/osrf/gazebo/pull/2779)
+
+1. Fix reflectance values for objects without a reflectance map
+    * [Pull request #2833](https://github.com/osrf/gazebo/pull/2833)
+
+1. Remove lighting param
+    * [Pull request #2840](https://github.com/osrf/gazebo/pull/2840)
+
+1. Publish performance metrics
+    * [Pull request #2819](https://github.com/osrf/gazebo/pull/2819)
+
+1. Improve transport::Publisher reliability
+    * [Pull request #2725](https://github.com/osrf/gazebo/pull/2725)
+
 ## Gazebo 9.14.0 (2020-08-07)
 
 1. Lockstep between sensors and physics


### PR DESCRIPTION
Prepare for a minor release.

Diff from 9.14.0:

https://github.com/osrf/gazebo/compare/gazebo9_9.14.0...gazebo9