### PR TITLE
SimpleTrackedVehiclePlugin: fix for boost 1.74

### DIFF
--- a/plugins/SimpleTrackedVehiclePlugin.cc
+++ b/plugins/SimpleTrackedVehiclePlugin.cc
@@ -18,6 +18,8 @@
 #include <functional>
 #include <vector>
 
+#include <boost/version.hpp>
+
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Pose3.hh>
@@ -30,6 +32,7 @@
 
 #include "plugins/SimpleTrackedVehiclePlugin.hh"
 
+#if BOOST_VERSION < 107400
 namespace std {
 template<class T>
 class hash<boost::shared_ptr<T>> {
@@ -38,6 +41,7 @@ class hash<boost::shared_ptr<T>> {
   }
 };
 }
+#endif
 
 namespace gazebo
 {


### PR DESCRIPTION
Our macOS builds are failing since homebrew updated to boost 1.74 in https://github.com/Homebrew/homebrew-core/pull/62549:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo11-homebrew-amd64&build=39)](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-homebrew-amd64/39/) https://build.osrfoundation.org/job/gazebo-ci-gazebo11-homebrew-amd64/39/

~~~
plugins/SimpleTrackedVehiclePlugin.cc:35:7: error: redefinition of 'hash<boost::shared_ptr<T> >'
class hash<boost::shared_ptr<T>> {
      ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/smart_ptr/shared_ptr.hpp:1174:26: note: previous definition is here
template<class T> struct hash< ::boost::shared_ptr<T> >
                         ^
~~~

It looks like `shared_ptr.hpp` has changed in 1.74.0. I've disabled some code in SimpleTrackedVehiclePlugin for boost 1.74 or greater, which seems to fix this.

