### PR TITLE
Fix physics based sensor update rate in lockstep mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Gazebo 9.xx.x (202x-xx-xx)
 
+1. Fix physics based sensor update rate in lockstep mode
+    * [Pull request #2863](https://github.com/osrf/gazebo/pull/2863)
+
 ## Gazebo 9.15.0 (2020-09-30)
 
 1. More enhancement for Windows build

--- a/gazebo/sensors/Sensor.cc
+++ b/gazebo/sensors/Sensor.cc
@@ -174,8 +174,18 @@ void Sensor::Update(const bool _force)
   {
     if (this->useStrictRate)
     {
+      // rendering sensors (IMAGE category) has it's own mechanism
+      // for throttling and lockstepping with physics. So throttle just
+      // physics sensors
+      if (this->dataPtr->category != IMAGE && !this->NeedsUpdate() && !_force)
+        return;
+
       if (this->UpdateImpl(_force))
+      {
+        common::Time simTime = this->world->SimTime();
+        this->lastUpdateTime = simTime;
         this->dataPtr->updated();
+      }
     }
     else
     {

--- a/gazebo/sensors/Sensor.cc
+++ b/gazebo/sensors/Sensor.cc
@@ -174,7 +174,7 @@ void Sensor::Update(const bool _force)
   {
     if (this->useStrictRate)
     {
-      // rendering sensors (IMAGE category) has it's own mechanism
+      // rendering sensors (IMAGE category) has its own mechanism
       // for throttling and lockstepping with physics. So throttle just
       // physics sensors
       if (this->dataPtr->category != IMAGE && !this->NeedsUpdate() && !_force)
@@ -182,8 +182,7 @@ void Sensor::Update(const bool _force)
 
       if (this->UpdateImpl(_force))
       {
-        common::Time simTime = this->world->SimTime();
-        this->lastUpdateTime = simTime;
+        this->lastUpdateTime = this->world->SimTime();;
         this->dataPtr->updated();
       }
     }

--- a/gazebo/sensors/SensorManager.cc
+++ b/gazebo/sensors/SensorManager.cc
@@ -762,7 +762,7 @@ void SensorManager::SensorContainer::RunLoop()
       if (!g_sensorsDirty)
         return;
 
-      // Get the minimum update rate from the sensors.
+      // Get the maximum update rate from the sensors.
       for (Sensor_V::iterator iter = this->sensors.begin();
           iter != this->sensors.end() && !this->stop; ++iter)
       {

--- a/test/worlds/laser_hit_strict_rate_test.world
+++ b/test/worlds/laser_hit_strict_rate_test.world
@@ -48,10 +48,37 @@
             </range>
           </ray>
           <always_on>1</always_on>
+          <update_rate>250</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <model name="ray_model2">
+      <static>true</static>
+      <link name="link2">
+        <sensor name="laser2" type="ray">
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>4</samples>
+                <resolution>1</resolution>
+                <min_angle>-2.26889</min_angle>
+                <max_angle>2.268899</max_angle>
+              </horizontal>
+            </scan>
+            <range>
+              <min>0.0</min>
+              <max>20</max>
+              <resolution>0.01</resolution>
+            </range>
+          </ray>
+          <always_on>1</always_on>
           <update_rate>500</update_rate>
           <visualize>true</visualize>
         </sensor>
       </link>
     </model>
+
   </world>
 </sdf>


### PR DESCRIPTION
closes issue #2861 - see issue on how to reproduce the problem

Problem was that the physics based sensors were all throttled by the max update rate of all sensors in lockstep mode. This PR applies proper throttling to the sensors.

I was also able to reproduce the problem by adding an additional ray sensor with different update rate to the laser strict rate integration test world file and that caused `INTEGRATION_laser` test to fail. Test should be fixed with these changes.