### PR TITLE
Add support to compile the gazebo executable on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+if(WIN32)
+  cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
+else()
+  cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+endif()
 
 if(COMMAND CMAKE_POLICY)
   CMAKE_POLICY(SET CMP0003 NEW)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -865,3 +865,18 @@ else()
   message (STATUS "Looking for qwt >= 6.1.0 - not found")
   BUILD_ERROR ("Missing: libqwt-dev. Required for plotting.")
 endif ()
+
+########################################
+# On Windows, find tiny-process-library
+if (WIN32)
+  option(USE_EXTERNAL_TINY_PROCESS_LIBRARY "Use external tiny-process-library." OFF)
+  if (USE_EXTERNAL_TINY_PROCESS_LIBRARY)
+    find_package(tiny-process-library QUIET)
+    if (NOT tiny-process-library_FOUND)
+      message (STATUS "Looking for tiny-process-library - not found")
+      BUILD_ERROR ("Missing: tiny-process-library, even if USE_EXTERNAL_TINY_PROCESS_LIBRARY was enabled.")
+    else()
+      message (STATUS "Looking for tiny-process-library - found")
+    endif()
+  endif()
+endif()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -4,4 +4,8 @@ if (NOT CCD_FOUND)
   add_subdirectory(libccd)
 endif()
 # add_subdirectory(ann)
-# add_subdirectory(fcl)
+# add_subdirectory(fcl
+
+if (WIN32 AND NOT USE_EXTERNAL_TINY_PROCESS_LIBRARY)
+  add_subdirectory(tiny-process-library)
+endif()

--- a/deps/tiny-process-library/CMakeLists.txt
+++ b/deps/tiny-process-library/CMakeLists.txt
@@ -1,0 +1,52 @@
+include(FetchContent)
+FetchContent_Declare(
+  tinyprocesslibrary
+  GIT_REPOSITORY https://gitlab.com/eidheim/tiny-process-library.git
+  GIT_TAG v2.0.2)
+
+FetchContent_GetProperties(tinyprocesslibrary)
+
+if(NOT tinyprocesslibrary_POPULATED)
+  FetchContent_Populate(tinyprocesslibrary)
+
+  # We don't want to install this library in the system, we instead
+  # compile it as an OBJECT library and embed in either the shared or
+  # static libraries that need it.
+  # From https://gitlab.kitware.com/cmake/cmake/-/issues/18935 it seems
+  # that OBJECT libraries that are not installed become INTERFACE when
+  # part of an EXPORT set.
+  # This behaviour allows setting transitively tiny-process-library infos
+  # to the consuming targets while not breaking the EXPORT process. In fact,
+  # the conversion to INTERFACE allows to add tiny-process-library to the
+  # targets of the EXPORT that contains targets linking against it.
+  # See also https://cmake.org/pipermail/cmake/2018-September/068250.html.
+
+  if(WIN32)
+    add_library(tiny-process-library OBJECT
+      ${tinyprocesslibrary_SOURCE_DIR}/process.cpp
+      ${tinyprocesslibrary_SOURCE_DIR}/process_win.cpp)
+    #If compiled using MSYS2, use sh to run commands
+    if(MSYS)
+      target_compile_definitions(tiny-process-library
+        PUBLIC MSYS_PROCESS_USE_SH)
+    endif()
+  else()
+    add_library(tiny-process-library OBJECT
+      ${tinyprocesslibrary_SOURCE_DIR}/process.cpp
+      ${tinyprocesslibrary_SOURCE_DIR}/process_unix.cpp)
+  endif()
+  add_library(tiny-process-library::tiny-process-library ALIAS tiny-process-library)
+
+  if(MSVC)
+    target_compile_definitions(tiny-process-library
+      PRIVATE /D_CRT_SECURE_NO_WARNINGS)
+  endif()
+
+  find_package(Threads REQUIRED)
+
+  target_link_libraries(tiny-process-library PRIVATE
+    ${CMAKE_THREAD_LIBS_INIT})
+  target_include_directories(tiny-process-library PUBLIC
+    $<BUILD_INTERFACE:${tinyprocesslibrary_SOURCE_DIR}>)
+
+endif()

--- a/gazebo/CMakeLists.txt
+++ b/gazebo/CMakeLists.txt
@@ -82,28 +82,35 @@ endif()
 gz_install_executable(gzserver)
 manpage(gzserver 1)
 
-# gazebo executable doesn't yet work on Windows
-if (NOT WIN32)
-  gz_add_executable(gazebo gazebo_main.cc)
-  target_link_libraries(gazebo
-    libgazebo
-    libgazebo_client
-    gazebo_common
-    gazebo_util
-    gazebo_transport
-    gazebo_physics
-    gazebo_sensors
-    gazebo_rendering
-    gazebo_msgs
-    gazebo_gui
-  )
 
-  gz_install_executable(gazebo)
-  manpage(gazebo 1)
+gz_add_executable(gazebo gazebo_main.cc)
+target_link_libraries(gazebo
+  libgazebo
+  libgazebo_client
+  gazebo_common
+  gazebo_util
+  gazebo_transport
+  gazebo_physics
+  gazebo_sensors
+  gazebo_rendering
+  gazebo_msgs
+  gazebo_gui
+)
+
+if(WIN32)
+  target_link_libraries(gazebo tiny-process-library::tiny-process-library)
 endif()
 
+gz_install_executable(gazebo)
+manpage(gazebo 1)
+
+
 gz_add_library(libgazebo Server.cc Master.cc gazebo.cc gazebo_shared.cc)
-set_target_properties(libgazebo PROPERTIES OUTPUT_NAME "gazebo")
+
+# On Windows calling libgazebo "gazebo" will conflict with the Gazebo executable
+if (NOT WIN32)
+  set_target_properties(libgazebo PROPERTIES OUTPUT_NAME "gazebo")
+endif()
 
 target_link_libraries(libgazebo
   gazebo_common


### PR DESCRIPTION
All the versions of Gazebo available on Windows provide the two separate binaries `gzserver` and `gzclient`, but do not provide the unified command `gazebo` that is commonly used by users and in documentation, examples and ROS launch files. This PR add supports for compiling the `gazebo` command also on Windows.

![gazebo_command_windows](https://user-images.githubusercontent.com/1857049/97082362-4c90b200-1609-11eb-9ea4-79a331ba4638.gif)

To do so, to avoid meddling with the low level Windows [`CreateProcess` API](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/), we used the MIT licensed [`tiny-process-library`](https://gitlab.com/eidheim/tiny-process-library). However, this additional dependency is added only on Windows, and by default on Windows is automatically downloaded and compiled using the [CMake's FetchContent module](https://cmake.org/cmake/help/v3.11/module/FetchContent.html), to ensure that all existing Windows documentation and build script will continue to work. To use `FetchContent`, the minimum required version of CMake on Windows is increment to CMake 3.11, but this should not be on Windows were there is no system-provided CMake and the CMake version installed is quite recent. However, if it is necessary to avoid the use of FetchContent I can vendor `tiny-process-library` in a more old-style way by simply adding its files in the `deps/tiny-process-library` directory.

However, a `USE_EXTERNAL_TINY_PROCESS_LIBRARY` CMake option is added to permit to use a system-provided `tiny-process-library`, to simplify the life of package maintainers on Windows. 

To clarify further, this PR should not influence in any way the behavior of Gazebo on non-Windows platforms. 
