### PR TITLE
Add mutex to make Sensor::SetActive threadsafe

### DIFF
--- a/gazebo/sensors/ContactSensor.cc
+++ b/gazebo/sensors/ContactSensor.cc
@@ -323,7 +323,7 @@ void ContactSensor::OnContacts(ConstContactsPtr &_msg)
 //////////////////////////////////////////////////
 bool ContactSensor::IsActive() const
 {
-  return this->active ||
+  return Sensor::IsActive() ||
     (this->dataPtr->contactsPub &&
      this->dataPtr->contactsPub->HasConnections());
 }

--- a/gazebo/sensors/ImuSensor.cc
+++ b/gazebo/sensors/ImuSensor.cc
@@ -448,6 +448,6 @@ bool ImuSensor::UpdateImpl(const bool /*_force*/)
 //////////////////////////////////////////////////
 bool ImuSensor::IsActive() const
 {
-  return this->active ||
+  return Sensor::IsActive() ||
          (this->dataPtr->pub && this->dataPtr->pub->HasConnections());
 }

--- a/gazebo/sensors/Sensor.cc
+++ b/gazebo/sensors/Sensor.cc
@@ -304,6 +304,7 @@ void Sensor::SetActive(const bool _value)
 //////////////////////////////////////////////////
 bool Sensor::IsActive() const
 {
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutexActive);
   return this->active;
 }
 
@@ -497,6 +498,7 @@ SensorExt::SensorExt(Sensor *_sensor)
 //////////////////////////////////////////////////
 void SensorExt::SetActive(bool _value)
 {
+  std::lock_guard<std::mutex> lock(this->sensor->dataPtr->mutexActive);
   this->sensor->active = _value;
 }
 

--- a/gazebo/sensors/Sensor.cc
+++ b/gazebo/sensors/Sensor.cc
@@ -244,7 +244,11 @@ void Sensor::Fini()
     it.second->Fini();
   this->noises.clear();
 
-  this->active = false;
+  {
+    std::lock_guard<std::mutex> lock(this->dataPtr->mutexActive);
+    this->active = false;
+  }
+
   this->plugins.clear();
 
   if (this->sdf)

--- a/gazebo/sensors/SensorPrivate.hh
+++ b/gazebo/sensors/SensorPrivate.hh
@@ -41,6 +41,9 @@ namespace gazebo
       /// \brief Mutex to protect resetting lastUpdateTime.
       public: std::mutex mutexLastUpdateTime;
 
+      /// \brief Mutex to protect active variable
+      public: std::mutex mutexActive;
+
       /// \brief Event triggered when a sensor is updated.
       public: event::EventT<void()> updated;
 


### PR DESCRIPTION
The `IsActive` function in the Sensor class is being called from various threads, e.g. [rendering](https://github.com/osrf/gazebo/blob/gazebo9/gazebo/sensors/CameraSensor.cc#L254), [physics](https://github.com/osrf/gazebo/blob/gazebo11/gazebo/sensors/SensorManager.cc#L402) (event callback from physics), and [transport](https://github.com/osrf/gazebo/blob/gazebo9/gazebo/sensors/SonarSensor.cc#L344) threads. So a mutex is added to protects calls for setting the `active` variable in `Sensor` class so that it is safe to call `SetActive` from gazebo plugins, e.g. various plugins in gazebo_ros_pkgs calls [SetActive](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/kinetic-devel/gazebo_plugins/src/gazebo_ros_block_laser.cpp#L195) to enable / disable the sensors when subscriber count changes. 

Signed-off-by: Ian Chen <ichen@osrfoundation.org>