### PR TITLE
SearchForStuff: On Apple platforms do not search for uuid library

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -700,9 +700,10 @@ endif()
 
 ########################################
 # Find uuid
-#  - In UNIX we use uuid library.
+#  - In UNIX if not APPLE we use uuid library.
+#  - On APPLE we use the uuid library provided by the OS's SDK.
 #  - In Windows the native RPC call, no dependency needed.
-if (UNIX)
+if (UNIX AND NOT APPLE)
   pkg_check_modules(uuid uuid)
   if (uuid_FOUND)
     message (STATUS "Looking for uuid - found")
@@ -711,6 +712,9 @@ if (UNIX)
     set (HAVE_UUID FALSE)
     BUILD_WARNING ("uuid-dev library not found - Gazebo will not have uuid support.")
   endif ()
+elseif(APPLE)
+  message (STATUS "Using macOS-provided uuid library")
+  set (HAVE_UUID TRUE)
 else()
   message (STATUS "Using Windows RPC UuidCreate function")
   set (HAVE_UUID TRUE)


### PR DESCRIPTION
Fix https://github.com/ignitionrobotics/ign-cmake/issues/127 w.r.t. to the Gazebo Classic codebase.