### PR TITLE
Support platforms in which qwt headers are not installed in a qwt directory

### DIFF
--- a/gazebo/gui/plot/qwt_gazebo.h
+++ b/gazebo/gui/plot/qwt_gazebo.h
@@ -23,24 +23,51 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal"
 
-#include <qwt/qwt_curve_fitter.h>
-#include <qwt/qwt_legend.h>
-#include <qwt/qwt_painter.h>
-#include <qwt/qwt_picker_machine.h>
-#include <qwt/qwt_plot.h>
-#include <qwt/qwt_plot_canvas.h>
-#include <qwt/qwt_plot_curve.h>
-#include <qwt/qwt_plot_directpainter.h>
-#include <qwt/qwt_plot_grid.h>
-#include <qwt/qwt_plot_layout.h>
-#include <qwt/qwt_plot_magnifier.h>
-#include <qwt/qwt_plot_marker.h>
-#include <qwt/qwt_plot_panner.h>
-#include <qwt/qwt_plot_zoomer.h>
-#include <qwt/qwt_scale_engine.h>
-#include <qwt/qwt_scale_widget.h>
-#include <qwt/qwt_symbol.h>
-#include <qwt/qwt_plot_renderer.h>
+#if defined __has_include
+  #if __has_include (<qwt.h>)
+    #include <qwt_curve_fitter.h>
+    #include <qwt_legend.h>
+    #include <qwt_painter.h>
+    #include <qwt_picker_machine.h>
+    #include <qwt_plot.h>
+    #include <qwt_plot_canvas.h>
+    #include <qwt_plot_curve.h>
+    #include <qwt_plot_directpainter.h>
+    #include <qwt_plot_grid.h>
+    #include <qwt_plot_layout.h>
+    #include <qwt_plot_magnifier.h>
+    #include <qwt_plot_marker.h>
+    #include <qwt_plot_panner.h>
+    #include <qwt_plot_zoomer.h>
+    #include <qwt_scale_engine.h>
+    #include <qwt_scale_widget.h>
+    #include <qwt_symbol.h>
+    #include <qwt_plot_renderer.h>
+    #define GAZEBO_GUI_QWT_IS_INCLUDED
+  #endif
+#endif
+
+#ifndef GAZEBO_GUI_QWT_IS_INCLUDED
+  #include <qwt/qwt_curve_fitter.h>
+  #include <qwt/qwt_legend.h>
+  #include <qwt/qwt_painter.h>
+  #include <qwt/qwt_picker_machine.h>
+  #include <qwt/qwt_plot.h>
+  #include <qwt/qwt_plot_canvas.h>
+  #include <qwt/qwt_plot_curve.h>
+  #include <qwt/qwt_plot_directpainter.h>
+  #include <qwt/qwt_plot_grid.h>
+  #include <qwt/qwt_plot_layout.h>
+  #include <qwt/qwt_plot_magnifier.h>
+  #include <qwt/qwt_plot_marker.h>
+  #include <qwt/qwt_plot_panner.h>
+  #include <qwt/qwt_plot_zoomer.h>
+  #include <qwt/qwt_scale_engine.h>
+  #include <qwt/qwt_scale_widget.h>
+  #include <qwt/qwt_symbol.h>
+  #include <qwt/qwt_plot_renderer.h>
+  #define GAZEBO_GUI_QWT_IS_INCLUDED
+#endif
 
 #pragma clang diagnostic pop
 


### PR DESCRIPTION
This change permits to fix https://github.com/osrf/gazebo/issues/2886 without touching at all the CMake code related to QWT (that may be error prone in my experience), and automatically falling back to the usual qwt include style if either the `__has_include` functionality is not available, or `qwt.h` is not available. The `__has_include` code has been added in line with what described in https://gcc.gnu.org/onlinedocs/gcc-10.1.0/cpp/_005f_005fhas_005finclude.html, to ensure that it works fine on any < C++17 compiler, even if the use of C++17 should be enforces by the use of the ignition libraries that use C++17 . 

With this change, it is possible to build Gazebo `gazebo11` branch on conda (starting from a minimal conda distro such as [Miniconda](https://docs.conda.io/en/latest/miniconda.html) or [Miniforge](https://github.com/conda-forge/miniforge)) on Windows by simply running: 
~~~sh
# Create a new environment to avoid polluting the base one
conda create -n gazebo-env
conda activate gazebo-env 
# Install Gazebo dependencies 
conda install -c conda-forge --only-deps gazebo 
# Install build dependencies
conda install  -c conda-forge pkg-config cmake
git clone https://github.com/osrf/gazebo
cd gazebo
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=Release ..
cmake --build . --config Release
~~~

