### PR TITLE
⬆️  9.16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 9)
-set (GAZEBO_MINOR_VERSION 15)
+set (GAZEBO_MINOR_VERSION 16)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Gazebo 9.xx.x (202x-xx-xx)
 
+## Gazebo 9.16.0 (2020-11-24)
+
 1. Updated the version of TinyOBJLoader from 1.0.0 to 2.0.0rc8.
     * [Pull request #2885](https://github.com/osrf/gazebo/pull/2885)
 
@@ -10,6 +12,18 @@
 
 1. Fix physics based sensor update rate in lockstep mode
     * [Pull request #2863](https://github.com/osrf/gazebo/pull/2863)
+
+1. Added Profiler to gazebo::rendering and gzclient
+    * [Pull request #2836](https://github.com/osrf/gazebo/pull/2836)
+
+1. Fix segfault when deleting an model that's being manipulated
+    * [Pull request #2856](https://github.com/osrf/gazebo/pull/2856)
+
+1. SimpleTrackedVehiclePlugin: fix for boost 1.74
+    * [Pull request #2865](https://github.com/osrf/gazebo/pull/2865)
+
+1. Add mutex to make Sensor::SetActive threadsafe
+    * [Pull request #2871](https://github.com/osrf/gazebo/pull/2871)
 
 ## Gazebo 9.15.0 (2020-09-30)
 


### PR DESCRIPTION
Prepare for 9.16.0 release.

Changes since 9.15.0: https://github.com/osrf/gazebo/compare/gazebo9_9.15.0...gazebo9

Technically, this release will contain mainly bug fixes. But I think that the bump on TinyOBJLoader prompts a minor release.