### PR TITLE
Fix usage of relative paths with environment variables

### DIFF
--- a/examples/plugins/actor_collisions/actor_collisions.world
+++ b/examples/plugins/actor_collisions/actor_collisions.world
@@ -117,11 +117,11 @@
       "/>
     </plugin>
     <skin>
-      <filename>walk.dae</filename>
+      <filename>file://media/models/walk.dae</filename>
       <scale>1.0</scale>
     </skin>
     <animation name="walking">
-      <filename>walk.dae</filename>
+      <filename>file://media/models/walk.dae</filename>
       <scale>1.000000</scale>
       <interpolate_x>true</interpolate_x>
     </animation>

--- a/examples/plugins/actor_collisions/actor_collisions.world.erb
+++ b/examples/plugins/actor_collisions/actor_collisions.world.erb
@@ -238,11 +238,11 @@
       "/>
     </plugin>
     <skin>
-      <filename>walk.dae</filename>
+      <filename>file://media/models/walk.dae</filename>
       <scale>1.0</scale>
     </skin>
     <animation name="walking">
-      <filename>walk.dae</filename>
+      <filename>file://media/models/walk.dae</filename>
       <scale>1.000000</scale>
       <interpolate_x>true</interpolate_x>
     </animation>

--- a/gazebo/common/CommonIface.cc
+++ b/gazebo/common/CommonIface.cc
@@ -513,7 +513,13 @@ std::string common::asFullPath(const std::string &_uri,
 #endif
 
   // Use platform-specific separator
-  return ignition::common::joinPaths(path,  uri);
+  auto result = ignition::common::joinPaths(path,  uri);
+
+  // If result doesn't exist, return it unchanged
+  if (!exists(result))
+    return _uri;
+
+  return result;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/common/CommonIface.hh
+++ b/gazebo/common/CommonIface.hh
@@ -188,6 +188,7 @@ namespace gazebo
     /// If the URI is already a full path or contains a scheme, it won't be
     /// modified.
     /// If the URI is a relative path, the file path will be prepended.
+    /// If the URI and path combination doesn't exist, the URI won't be changed.
     /// \param[in] _uri URI, which can have a scheme, or be full or relative
     /// paths.
     /// \param[in] _filePath The path to a file in disk.

--- a/test/worlds/actor_collisions.world
+++ b/test/worlds/actor_collisions.world
@@ -12,11 +12,11 @@
 
   <actor name="actor">
     <skin>
-      <filename>walk.dae</filename>
+      <filename>file://media/models/walk.dae</filename>
       <scale>1.0</scale>
     </skin>
     <animation name="walking">
-      <filename>walk.dae</filename>
+      <filename>file://media/models/walk.dae</filename>
       <scale>1.000000</scale>
       <interpolate_x>true</interpolate_x>
     </animation>

--- a/worlds/actor.world
+++ b/worlds/actor.world
@@ -10,12 +10,12 @@
       </include>
       <actor name="actor">
          <skin>
-            <filename>walk.dae</filename>
+            <filename>file://media/models/walk.dae</filename>
             <scale>1.0</scale>
          </skin>
          <pose>0 0 0 0 0 0</pose>
          <animation name="walking">
-            <filename>walk.dae</filename>
+            <filename>file://media/models/walk.dae</filename>
             <scale>1.000000</scale>
             <interpolate_x>true</interpolate_x>
          </animation>

--- a/worlds/actor_bvh.world
+++ b/worlds/actor_bvh.world
@@ -14,7 +14,7 @@
     <actor name="actor">
       <pose>2 2 2 0 0 0</pose>
       <skin>
-        <filename>walk.dae</filename>
+        <filename>file://media/models/walk.dae</filename>
       </skin>
       <animation name="anim">
         <filename>cmu-13_26.bvh</filename>

--- a/worlds/cafe.world
+++ b/worlds/cafe.world
@@ -80,11 +80,11 @@
     <actor name="actor1">
       <pose>0 1 1.25 0 0 0</pose>
       <skin>
-        <filename>walk.dae</filename>
+        <filename>file://media/models/walk.dae</filename>
         <scale>1.0</scale>
       </skin>
       <animation name="walking">
-        <filename>walk.dae</filename>
+        <filename>file://media/models/walk.dae</filename>
         <scale>1.000000</scale>
         <interpolate_x>true</interpolate_x>
       </animation>
@@ -106,11 +106,11 @@
     <actor name="actor2">
       <pose>-2 -2 1.25 0 0 0</pose>
       <skin>
-        <filename>walk.dae</filename>
+        <filename>file://media/models/walk.dae</filename>
         <scale>1.0</scale>
       </skin>
       <animation name="walking">
-        <filename>walk.dae</filename>
+        <filename>file://media/models/walk.dae</filename>
         <scale>1.000000</scale>
         <interpolate_x>true</interpolate_x>
       </animation>

--- a/worlds/profiler.world
+++ b/worlds/profiler.world
@@ -341,11 +341,11 @@
     <actor name="actor1">
       <pose>0 5 1.25 0 0 0</pose>
       <skin>
-        <filename>walk.dae</filename>
+        <filename>file://media/models/walk.dae</filename>
         <scale>1.0</scale>
       </skin>
       <animation name="walking">
-        <filename>walk.dae</filename>
+        <filename>file://media/models/walk.dae</filename>
         <scale>1.000000</scale>
         <interpolate_x>true</interpolate_x>
       </animation>


### PR DESCRIPTION
I noticed that some tests started failing since #2765, such as [UNIT_Actor_TEST](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/38/consoleFull):

<details><summary>UNIT_Actor_TEST failure</summary>
<p>

```
251: [ RUN      ] ActorTest.Load
251: [Msg] Waiting for master.
251: [Msg] Connected to gazebo master @ http://127.0.0.1:11345
251: [Msg] Publicized address: 172.17.0.2
251: [Wrn] [SystemPaths.cc:459] File or path does not exist ["/var/lib/jenkins/workspace/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/gazebo/worlds/walk.dae"] [/var/lib/jenkins/workspace/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/gazebo/worlds/walk.dae]
251: [Err] [MeshManager.cc:211] Unable to find file[/var/lib/jenkins/workspace/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/gazebo/worlds/walk.dae]
251: [Wrn] [Actor.cc:177] Couldn't find mesh [/var/lib/jenkins/workspace/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/gazebo/worlds/walk.dae]. Not loading skin.
251: [Dbg] [ServerFixture.cc:203] ServerFixture load in 0.7 seconds, timeout after 600 seconds
251: /var/lib/jenkins/workspace/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/gazebo/gazebo/physics/Actor_TEST.cc:56: Failure
251: Value of: skelAnims.empty()
251:   Actual: true
251: Expected: false
251: /var/lib/jenkins/workspace/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/gazebo/gazebo/physics/Actor_TEST.cc:57: Failure
251: Expected equality of these values:
251:   skelAnims.size()
251:     Which is: 0
251:   1u
251:     Which is: 1
251: /var/lib/jenkins/workspace/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/gazebo/gazebo/physics/Actor_TEST.cc:58: Failure
251: Value of: skelAnims["walking"] != nullptr
251:   Actual: false
251: Expected: true
251: [Dbg] [ServerFixture.cc:129] ServerFixture::Unload
251: [Wrn] [Publisher.cc:136] Queue limit reached for topic /gazebo/default/pose/local/info, deleting message. This warning is printed only once.
251: [  FAILED  ] ActorTest.Load (836 ms)
```

</p>
</details>

That's a use case for relative paths that I overlooked on the other pull request. Resources could be found with paths relative to environment variables like `GAZEBO_RESOURCE_PATH` and `GAZEBO_MODEL_PATH`. But when I added the conversion to full paths relative to the SDF file, I didn't give Gazebo a chance to also look for the files relative to those environment variables.

This PR changes the `asFullPath` function to only return the full path in case it exists on disk. This allows the search to continue using the environment variable in case there's no matching file relative to the SDF.

I changed some worlds to more robust URIs, but left some others to make sure those use cases still work.