### PR TITLE
⬆️  11.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 11)
-set (GAZEBO_MINOR_VERSION 2)
+set (GAZEBO_MINOR_VERSION 3)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,39 +2,69 @@
 
 ## Gazebo 11.x.x (202x-xx-xx)
 
+## Gazebo 11.3.0 (2020-11-26)
+
+1. Added profiler to gazebo::rendering and gzclient
+    * [Pull request #2837](https://github.com/osrf/gazebo/pull/2837)
+
+1. SimpleTrackedVehiclePlugin: fix for boost 1.74
+    * [Pull request #2862](https://github.com/osrf/gazebo/pull/2862)
+
+1. Add support to compile the gazebo executable on Windows
+    * [Pull request #2864](https://github.com/osrf/gazebo/pull/2864)
+
+1. Support platforms in which qwt headers are not installed in a qwt directory
+    * [Issue #2886](https://github.com/osrf/gazebo/issues/2886)
+    * [Pull request #2887](https://github.com/osrf/gazebo/pull/2887)
+
+1. Warn instead of fail for non-Earth Dem's on 20.04
+    * [Pull request #2882](https://github.com/osrf/gazebo/pull/2882)
+
+1. SearchForStuff: On Apple platforms do not search for uuid library
+    * [Pull request #2878](https://github.com/osrf/gazebo/pull/2878)
+
+1. Fix usage of relative paths with environment variables
+    * [Pull request #2890](https://github.com/osrf/gazebo/pull/2890)
+
+1. Support resource files with spaces
+    * [Pull request #2877](https://github.com/osrf/gazebo/pull/2877)
+
+1. Update TinyOBJLoader to v2.0.0rc8
+    * [Pull request #2885](https://github.com/osrf/gazebo/pull/2885)
+
 ## Gazebo 11.2.0 (2020-09-30)
 
 1. Fix assumptions that CMAKE\_INSTALL\_\*DIR paths are relative
-    * [Issue #2778](https://github.com/osrf/gazebo/issues/2778)
+    * [Pull request #2778](https://github.com/osrf/gazebo/pull/2778)
 
 1. Accept relative paths in SDF files
-    * [Issue #2765](https://github.com/osrf/gazebo/issues/2765)
-    * [Issue #2839](https://github.com/osrf/gazebo/issues/2839)
+    * [Pull request #2765](https://github.com/osrf/gazebo/pull/2765)
+    * [Pull request #2839](https://github.com/osrf/gazebo/pull/2839)
 
 1. Add support for frame semantics with nested models in SDFormat 1.7
-    * [Issue #2824](https://github.com/osrf/gazebo/issues/2824)
+    * [Pull request #2824](https://github.com/osrf/gazebo/pull/2824)
 
 1. Fix Actor collision if loop / auto_start false
-    * [Issue #2773](https://github.com/osrf/gazebo/issues/2773)
+    * [Pull request #2773](https://github.com/osrf/gazebo/pull/2773)
 
 1. Allow gazebo to download models from Fuel in the sdf files, and worlds from command line
-    * [Issue #2822](https://github.com/osrf/gazebo/issues/2822)
+    * [Pull request #2822](https://github.com/osrf/gazebo/pull/2822)
 
 1. Publish performance metrics
-    * [Issue #2819](https://github.com/osrf/gazebo/issues/2819)
+    * [Pull request #2819](https://github.com/osrf/gazebo/pull/2819)
 
 1. Find OGRE correctly in a system with pkg-config but without OGRE .pc files
-    * [Issue #2719](https://github.com/osrf/gazebo/issues/2719)
+    * [Pull request #2719](https://github.com/osrf/gazebo/pull/2719)
 
 ## Gazebo 11.1.0 (2020-08-12)
 
 1. Synchronize time stepping of physics and sensors with `--lockstep`
     * [Issue #2736](https://github.com/osrf/gazebo/issues/2736)
-    * [Pull request #2791](https://github.com/osrf/gazebo/issues/2791)
-    * [Pull request #2799](https://github.com/osrf/gazebo/issues/2799)
-    * [Pull request #2802](https://github.com/osrf/gazebo/issues/2802)
-    * [Pull request #2761](https://github.com/osrf/gazebo/issues/2761)
-    * [Pull request #2746](https://github.com/osrf/gazebo/issues/2746)
+    * [Pull request #2791](https://github.com/osrf/gazebo/pull/2791)
+    * [Pull request #2799](https://github.com/osrf/gazebo/pull/2799)
+    * [Pull request #2802](https://github.com/osrf/gazebo/pull/2802)
+    * [Pull request #2761](https://github.com/osrf/gazebo/pull/2761)
+    * [Pull request #2746](https://github.com/osrf/gazebo/pull/2746)
 
 1. Enable DART support in gazebo11 .deb packages
     * [Issue #2752](https://github.com/osrf/gazebo/issues/2752)

--- a/Migration.md
+++ b/Migration.md
@@ -5,7 +5,16 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo 11.2 to 11.3
+
+### Modifications
+
+Updated the version of TinyOBJLoader from 1.0.0 to 2.0.0rc8.
+See the changelog at https://github.com/osrf/gazebo/blob/gazebo11/deps/tinyobjloader/tiny_obj_loader.h
+
 ## Gazebo 11.1 to 11.3
+
+### Modifications
 
 The way Gazebo handles relative paths in SDF files has changed:
 


### PR DESCRIPTION
Preparing for a 11.3.0 release.

Comparison to 11.2.0: https://github.com/osrf/gazebo/compare/gazebo11_11.2.0...gazebo11

There are 3 PRs currently open against `gazebo11`:

* #2879 shouldn't affect debs, so there's no rush to get it in
* #2853 is waiting for an update from the author, it will probably need to go in the next release
* #2827 is still under discussion

