### PR TITLE
Fix namespace usage in console macros

### DIFF
--- a/gazebo/common/Console.hh
+++ b/gazebo/common/Console.hh
@@ -38,19 +38,19 @@ namespace gazebo
     /// \{
 
     /// \brief Output a message
-    #define gzmsg (gazebo::common::Console::msg())
+    #define gzmsg (::gazebo::common::Console::msg())
 
     /// \brief Output a debug message
-    #define gzdbg (gazebo::common::Console::dbg(__FILE__, __LINE__))
+    #define gzdbg (::gazebo::common::Console::dbg(__FILE__, __LINE__))
 
     /// \brief Output a warning message
-    #define gzwarn (gazebo::common::Console::warn(__FILE__, __LINE__))
+    #define gzwarn (::gazebo::common::Console::warn(__FILE__, __LINE__))
 
     /// \brief Output an error message
-    #define gzerr (gazebo::common::Console::err(__FILE__, __LINE__))
+    #define gzerr (::gazebo::common::Console::err(__FILE__, __LINE__))
 
     /// \brief Output a message to a log file
-    #define gzlog (gazebo::common::Console::log())
+    #define gzlog (::gazebo::common::Console::log())
 
     /// \brief Initialize log file with filename given by _str.
     /// If called twice, it will close currently in use and open a new
@@ -59,11 +59,11 @@ namespace gazebo
     /// will be created.
     /// \param[in] _str Name of log file for gzlog messages.
     #define gzLogInit(_prefix, _str) \
-        (gazebo::common::Console::log.Init(_prefix, _str))
+        (::gazebo::common::Console::log.Init(_prefix, _str))
 
     /// \brief Get the full path of the directory where the log files are stored
     /// \return Full path of the directory
-    #define gzLogDirectory() (gazebo::common::Console::log.GetLogDirectory())
+    #define gzLogDirectory() (::gazebo::common::Console::log.GetLogDirectory())
 
     /// \class FileLogger FileLogger.hh common/common.hh
     /// \brief A logger that outputs messages to a file.

--- a/test/regression/2896_gazebo_subnamespace.cc
+++ b/test/regression/2896_gazebo_subnamespace.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "gazebo/test/ServerFixture.hh"
+
+
+namespace rhabarber::barbera::gazebo
+{
+    class bar
+    {
+    public:
+        void print_something() const 
+        {
+            gzmsg << "something" << std::endl;
+        }
+    };
+}
+
+
+/////////////////////////////////////////////////
+class Issue2896Test : public ::gazebo::ServerFixture
+{
+};
+
+/////////////////////////////////////////////////
+TEST_F(Issue2896Test, CompilationTest)
+{
+    rhabarber::barbera::gazebo::bar bar;
+    // Suppress unused variable warning
+    bar = bar;
+}
+
+
+/////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -44,6 +44,7 @@ set(tests
   2430_revolute_joint_SetPosition.cc
   2505_revolute_joint_SetAxis.cc
   2728_nested_urdf.cc
+  2896_gazebo_subnamespace.cc
 )
 gz_build_tests(${tests} EXTRA_LIBS gazebo_test_fixture)
 


### PR DESCRIPTION
Hey there,

This code did not work
```cpp
namespace foo::gazebo
{

class bar
{
public:
    void doSomething() {
        gzmsg << "doSomething" << std::endl;
    }
};

}  // foo::gazebo
```

because gzmsg resolves to (gazebo::common::Console::msg()) which
resolves in this error:
```
error: ‘foo::gazebo::common’ has not been declared
     #define gzmsg (gazebo::common::Console::msg())
```

Should this also be fixed in older gazebo version?

This solves #2896 

Cheers,
Stefan

cc @Pro