### PR TITLE
Fix missing link to OpenAL in gazebo_util library

### DIFF
--- a/gazebo/util/CMakeLists.txt
+++ b/gazebo/util/CMakeLists.txt
@@ -85,6 +85,10 @@ target_link_libraries(gazebo_util
   ${IGNITION-MSGS_LIBRARIES}
 )
 
+if (HAVE_OPENAL)
+  target_link_libraries(gazebo_util PRIVATE ${OPENAL_LIBRARY})
+endif()
+
 # define if tinxml2 major version >= 6
 # https://github.com/ignitionrobotics/ign-common/issues/28
 if (NOT tinyxml2_VERSION VERSION_LESS "6.0.0")

--- a/gazebo/util/CMakeLists.txt
+++ b/gazebo/util/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_libraries(gazebo_util
 )
 
 if (HAVE_OPENAL)
-  target_link_libraries(gazebo_util PRIVATE ${OPENAL_LIBRARY})
+  target_link_libraries(gazebo_util ${OPENAL_LIBRARY})
 endif()
 
 # define if tinxml2 major version >= 6


### PR DESCRIPTION
By inspecting the CMakeLists.txt of gazebo_util due to debugging the problem in https://github.com/RoboStack/ros-noetic/issues/55, I noticed that the if `HAVE_OPENAL` is defined, the OpenAL library is used in `gazebo_util`, but it is never linked to it, while `gazebo_util` is linked to it but just with `PRIVATE` visibility. 

Even if this is not the problem that is causing https://github.com/RoboStack/ros-noetic/issues/55 (as I never saw the same problem on Gazebo with Homebrew) in any case this missing link is wrong, so it make sense to fix it.