### PR TITLE
Do not force the value of HAVE_OPENAL

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -74,9 +74,9 @@ endif ()
 include (FindOpenAL)
 if (NOT OPENAL_FOUND)
   BUILD_WARNING ("OpenAL not found, audio support will be disabled.")
-  set (HAVE_OPENAL OFF CACHE BOOL "HAVE OpenAL" FORCE)
+  set (HAVE_OPENAL OFF CACHE BOOL "HAVE OpenAL")
 else ()
-  set (HAVE_OPENAL ON CACHE BOOL "HAVE OpenAL" FORCE)
+  set (HAVE_OPENAL ON CACHE BOOL "HAVE OpenAL")
 endif ()
 
 ########################################


### PR DESCRIPTION
In some cases, it may be convenient to build Gazebo without OpenAL even if it is available in the system. To do so, it is necessary to avoid to **force** the cache value `HAVE_OPENAL`, permitting to the user to set it. If the user does not set it, the behaviour remains the standard one. 