### PR TITLE
Fix build on Linux with conda-forge dependencies 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,9 +285,8 @@ if (MSVC)
   set(UNFILTERED_FLAGS "/EHsc")
 endif()
 
-# Visual Studio enables c++11 support by default
 if (NOT MSVC)
-  set(UNFILTERED_FLAGS "-std=c++11")
+  set(UNFILTERED_FLAGS "")
 endif()
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VALID_CXX_FLAGS} ${UNFILTERED_FLAGS}")

--- a/plugins/rest_web/RestApi.cc
+++ b/plugins/rest_web/RestApi.cc
@@ -18,7 +18,7 @@
 #include <cstring>
 #include <stdlib.h>
 #include <curl/curl.h>
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "RestApi.hh"
 


### PR DESCRIPTION
These are the last two fixes that are required to build Gazebo with conda-forge provided dependencies on Linux without any further modification (verified in https://github.com/traversaro/gazebo-conda-forge-ci/pull/2/checks?check_run_id=2024424151, the test suite has some failures, but that's another story).

The fixes are: 
* Do not manually add -std=c++11 to CMAKE_CXX_FLAGS. This is not necessary as the `cxx_std_11` compile feature is set for all the libraries in https://github.com/osrf/gazebo/blob/67c43463c87685b7c9d485a9f8d2e6ac760815b9/cmake/GazeboUtils.cmake#L106 and https://github.com/osrf/gazebo/blob/67c43463c87685b7c9d485a9f8d2e6ac760815b9/cmake/GazeboUtils.cmake#L120 . Furthermore, it can create problems when external libraries export other compile features (such as ignition-math6 that export `cxx_std_17`).
* In `RestApi.cc` use  C++ style `cinttypes` instead of C style `inttypes.h`.