### PR TITLE
Optimize ODE collision detection for models with no collisions

### DIFF
--- a/deps/opende/src/collision_space.cpp
+++ b/deps/opende/src/collision_space.cpp
@@ -452,6 +452,13 @@ void dxHashSpace::collide (void *_data, dNearCallback *callback)
     if (!GEOM_ENABLED(geom)){
       continue;
     }
+
+    // skip geoms that have zero or negative/invalid aabb
+    if (geom->aabb[1] - geom->aabb[0] <= 0.0 &&
+        geom->aabb[3] - geom->aabb[2] <= 0.0 &&
+        geom->aabb[5] - geom->aabb[4] <= 0.0)
+      continue;
+
     dxAABB *aabb3 = (dxAABB*) ALLOCA (sizeof(dxAABB));
     aabb3->geom = geom;
     // compute level, but prevent cells from getting too small


### PR DESCRIPTION
It was found that removing all the collisions in a world with large number of models and links reduced performance / RTF. The problem is in ODE's collision checker. Models without collisions have a zero size bounding box. The collision checker seems to treat them all as overlapping collisions and hence results in extra unneeded computations. The "fix" is to skip collision checking for ODE geoms that have zero size AABB.

To reproduce this issue, you can run the following two worlds below. In both cases, go to Physics on the left panel and set `real_time_update_rate` to 0 for gazebo to run unbounded:

[dp.world](https://gist.github.com/iche033/02ad57d866b4e6783c83fa26d3b44f02): 100 static double pendulums with collisions. **RTF: 24.0**
[dp_no_collisions.world](https://gist.github.com/iche033/931efa8678ea8e9ba3ff2f2a638a7b4e): 100 static double pendulums with no collisions. Before fix: **RTF: 1.5**. After fix: **28.0**

Here're timings from the Remotery profiler 

dp.world. `dSpaceCollide`: 0.034ms
![dp](https://user-images.githubusercontent.com/4000684/110194765-16511380-7def-11eb-9657-c8ff4cf47443.png)

dp_no_collisions.world - Before fix. `dSpaceCollide`: 0.635
![dp_no_collision_before](https://user-images.githubusercontent.com/4000684/110194771-236e0280-7def-11eb-96a8-77e256fc3049.png)

dp_no_collisions.world - After fix. `dSpaceCollide`: 0.007ms
![dp_no_collision_after](https://user-images.githubusercontent.com/4000684/110194766-1b15c780-7def-11eb-8192-823065b7eca4.png)


