### PR TITLE
Fix size of light visual

### DIFF
--- a/gazebo/rendering/Light.cc
+++ b/gazebo/rendering/Light.cc
@@ -318,8 +318,8 @@ void Light::CreateVisual()
 
     double angles[2];
     double range = 0.2;
-    angles[0] = range * tan(outerAngle);
-    angles[1] = range * tan(innerAngle);
+    angles[0] = range * tan(outerAngle / 2);
+    angles[1] = range * tan(innerAngle / 2);
 
     unsigned int i = 0;
     this->dataPtr->line->AddPoint(ignition::math::Vector3d(0, 0, 0));


### PR DESCRIPTION
Light visual is displayed wrong - it shows a cone corresponding to a light with double the angle than it should represent.

Example light:

```XML
<sdf version='1.6'>
  <world name='default'>
    <model name='lights'>
      <link name='link'>
        <light name='light_up' type='spot'>
          <attenuation>
            <range>60</range>
            <linear>0</linear>
            <constant>0.1</constant>
            <quadratic>0.0025</quadratic>
          </attenuation>
          <diffuse>0.8 0.8 0.5 1</diffuse>
          <specular>0.8 0.8 0.5 1</specular>
          <spot>
            <inner_angle>0.7</inner_angle> <!-- about 40 degrees -->
            <outer_angle>0.7</outer_angle>
            <falloff>1</falloff>
          </spot>
          <direction>0 0 -1</direction>
        </light>
        <kinematic>1</kinematic>
      </link>
    </model>
    <model name='unit_box'>
      <pose frame=''>0 0 -0.7 0 -0 0</pose>
      <link name='link'>
        <visual name='visual'>
          <geometry>
            <box>
              <size>1 1 1</size>
            </box>
          </geometry>
          <material>
            <script>
              <name>Gazebo/Grey</name>
              <uri>file://media/materials/scripts/gazebo.material</uri>
            </script>
          </material>
        </visual>
        <kinematic>1</kinematic>
      </link>
    </model>
  </world>
</sdf>
```

![default_gzclient_camera(1)-2021-03-11T23_12_09 882825](https://user-images.githubusercontent.com/182533/110862295-9b409f00-82bf-11eb-9738-16f0cafac9ea.jpg)

![default_gzclient_camera(1)-2021-03-11T23_12_26 360157](https://user-images.githubusercontent.com/182533/110862313-a09de980-82bf-11eb-9f20-6da0113a2b0a.jpg)

It seems the math is just wrong in https://github.com/osrf/gazebo/blob/db40ad5e02f21e68e9924d725a49b3e107fecb45/gazebo/rendering/Light.cc#L314-L327

If we denote `inner_angle` by α, then the computation done in code to determine the corners of the pyramid is:

    (±r*tan(α), ±r*tan(α), r)

Looking from a side, the situation is drawn here:

![obrazek](https://user-images.githubusercontent.com/182533/110860394-02108900-82bd-11eb-9d5b-b8276822a779.png)

It follows from the top half-triangle that `tan(α) = (r*tan(α))/r = (angles[i]/r)` and thus `α = atan(angles[i]/r)`... But as `angles[i]` is just a multiple of `tan(α)`, it is apparent that the angle at the apex of the upper half-triangle is `inner_angle`. Then sum it up with the lower half-triangle, and you get angle at the apex of the light visual `2*inner_angle`.

If I add a light with halved `inner_angle`, the borders of the visual match the circle of the light exactly:

![default_gzclient_camera(1)-2021-03-11T23_22_54 013417](https://user-images.githubusercontent.com/182533/110863512-148cc180-82c1-11eb-883a-8131860ca207.jpg)

This PR just applies the halving of the angle to fix the visuals.