### PR TITLE
Restore HeightmapShape::SetHeight implementation

### DIFF
--- a/gazebo/physics/HeightmapShape.cc
+++ b/gazebo/physics/HeightmapShape.cc
@@ -338,6 +338,20 @@ HeightmapShape::HeightType HeightmapShape::GetHeight(int _x, int _y) const
 }
 
 /////////////////////////////////////////////////
+void HeightmapShape::SetHeight(int _x, int _y, HeightmapShape::HeightType _h)
+{
+  int index =  _y * this->vertSize + _x;
+  if (_x < 0 || _y < 0 || index >= static_cast<int>(this->heights.size()))
+  {
+    gzerr << "SetHeight position (" << _x << ", " << _y << ")"
+          << " is out of bounds" << std::endl;
+    return;
+  }
+
+  this->heights[index] = _h;
+}
+
+/////////////////////////////////////////////////
 HeightmapShape::HeightType HeightmapShape::GetMaxHeight() const
 {
   HeightType max = -std::numeric_limits<HeightType>::max();

--- a/gazebo/physics/HeightmapShape.hh
+++ b/gazebo/physics/HeightmapShape.hh
@@ -92,7 +92,8 @@ namespace gazebo
       /// \brief Sets a height value at a position.
       /// \param[in] _x X position.
       /// \param[in] _y Y position.
-      public: void SetHeight(int _x, int _y, float _value);
+      /// \param[in] _h Height to set.
+      public: void SetHeight(int _x, int _y, HeightType _h);
 
       /// \brief Fill a geometry message with this shape's data. Raw height
       /// data are not packed in this message to minimize packet size.


### PR DESCRIPTION
The HeightmapShape::SetHeight function was added in [bitbucket PR 3210](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/3210/page/1) (c7ecafa3980f) but was lost in a merge forward. This restores it and updates the API to use the `HeightType` typedef.

cc @Samahu