### PR TITLE
Remove warning in message conversion using gpu_ray sensor

### DIFF
--- a/gazebo/msgs/msgs.cc
+++ b/gazebo/msgs/msgs.cc
@@ -1812,7 +1812,7 @@ namespace gazebo
         result.mutable_camera()->CopyFrom(
             msgs::CameraSensorFromSDF(_sdf->GetElement("camera")));
       }
-      else if (type == "ray")
+      else if (type == "ray" || type == "gpu_ray")
       {
         result.mutable_ray()->CopyFrom(msgs::RaySensorFromSDF(
             _sdf->GetElement("ray")));


### PR DESCRIPTION
This PR attempts to fix #2355 and get rid of an annoying message when the `verbose` flag is enabled.