### PR TITLE
Backport to 9: fixes for gzserver shutdown and ogre log test

### DIFF
--- a/gazebo/transport/ConnectionManager.cc
+++ b/gazebo/transport/ConnectionManager.cc
@@ -215,6 +215,9 @@ void ConnectionManager::Fini()
     return;
 
   this->Stop();
+  if (this->initialized)
+    while (this->stopped == false)
+      common::Time::MSleep(100);
 
   if (this->masterConn)
   {
@@ -244,10 +247,6 @@ void ConnectionManager::Fini()
 void ConnectionManager::Stop()
 {
   this->stop = true;
-  this->updateCondition.notify_all();
-  if (this->initialized)
-    while (this->stopped == false)
-      common::Time::MSleep(100);
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/ogre_log.cc
+++ b/test/integration/ogre_log.cc
@@ -65,9 +65,20 @@ TEST_F(OgreLog, LogError)
     if (line.find(" GL_EXTENSIONS =") < 12)
       continue;
 
-    EXPECT_EQ(line.find("Error"), std::string::npos);
-    EXPECT_EQ(line.find("error"), std::string::npos);
-    EXPECT_EQ(line.find("ERROR"), std::string::npos);
+    // A GLX extension may have the word "error" in its name. For example:
+    // GLX_ARB_create_context_no_error.
+    // We will skip the line that lists all the extensions. This line starts
+    // with a date, so we just check that "Supported GLX extensions:" is
+    // toward the beginning.
+    // False positive cppcheck
+    // https://sourceforge.net/p/cppcheck/discussion/general/thread/0c113d65/
+    // cppcheck-suppress stlIfStrFind
+    if (line.find(" Supported GLX extensions: ") < 12)
+      continue;
+
+    EXPECT_EQ(line.find("Error"), std::string::npos) << line;
+    EXPECT_EQ(line.find("error"), std::string::npos) << line;
+    EXPECT_EQ(line.find("ERROR"), std::string::npos) << line;
   }
 }
 


### PR DESCRIPTION
This backports the following pull requests to gazebo9:

* ~~#2960: Specify wide angle camera cube map texture format~~ redacted because it doesn't work with libsdformat6
* #2949: improve gzserver shutdown by protecting DepthCameraPlugin globals with a mutex
* #2950: improve gzserver shutdown by avoiding deadlock in ConnectionManager::Stop
* #2954: fix ogre_log test

Use rebase and merge.