### PR TITLE
Remove warning message in verbose mode when using GPU rays or depth cameras

### DIFF
--- a/gazebo/msgs/msgs.cc
+++ b/gazebo/msgs/msgs.cc
@@ -1817,12 +1817,12 @@ namespace gazebo
       if (_sdf->HasElement("topic"))
         result.set_topic(_sdf->Get<std::string>("topic"));
 
-      if (type == "camera")
+      if (type == "camera" || type == "depth")
       {
         result.mutable_camera()->CopyFrom(
             msgs::CameraSensorFromSDF(_sdf->GetElement("camera")));
       }
-      else if (type == "ray")
+      else if (type == "ray" || type == "gpu_ray")
       {
         result.mutable_ray()->CopyFrom(msgs::RaySensorFromSDF(
             _sdf->GetElement("ray")));


### PR DESCRIPTION
Backported PR #2963.

- In #2963, the fix for the depth camera was not introduced so another PR will be created later.

### Testing

```bash
gazebo --verbose test/worlds/gpu_laser2.world

gazebo --verbose worlds/depth_camera2.world
```

Path are relative to Gazebo.