### PR TITLE
Fix warning message when using depth cameras in verbose mode

### DIFF
--- a/gazebo/msgs/msgs.cc
+++ b/gazebo/msgs/msgs.cc
@@ -1807,7 +1807,7 @@ namespace gazebo
       if (_sdf->HasElement("topic"))
         result.set_topic(_sdf->Get<std::string>("topic"));
 
-      if (type == "camera")
+      if (type == "camera" || type == "depth")
       {
         result.mutable_camera()->CopyFrom(
             msgs::CameraSensorFromSDF(_sdf->GetElement("camera")));


### PR DESCRIPTION
Partially fixes #2355 and get rid of an annoying message when the verbose flag is enabled.

It's a continuation of #2963 and similar to the Gazebo 9 version of #2972.

### Testing

```bash
gazebo --verbose worlds/depth_camera2.world
```

Path is relative to Gazebo.