### PR TITLE
LensFlare: rename SetCameraSensor to SetCameraImpl

### DIFF
--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -525,7 +525,7 @@ void LensFlare::OnRequest(ConstRequestPtr &_msg)
 }
 
 //////////////////////////////////////////////////
-void LensFlare::SetCameraSensor(CameraPtr _camera)
+void LensFlare::SetCameraImpl(CameraPtr _camera)
 {
   this->dataPtr->camera = _camera;
 }

--- a/gazebo/rendering/LensFlare.hh
+++ b/gazebo/rendering/LensFlare.hh
@@ -128,7 +128,7 @@ namespace gazebo
 
       /// \brief Set camera stored in LensFlarePrivate
       /// \param[in] _camera Camera to use in sensor.
-      protected: void SetCameraSensor(CameraPtr _camera);
+      protected: void SetCameraImpl(CameraPtr _camera);
 
       /// \brief Set lensFlareCompositorListener stored in LensFlarePrivate
       /// \param[in] _listener Shared pointer to object to be set.


### PR DESCRIPTION
This is an adjustment to API added in #2965 in response to https://github.com/osrf/gazebo/pull/2965#discussion_r615210697, which is allowed because the API has not yet been released.