### PR TITLE
Prepare for 11.5.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 11)
-set (GAZEBO_MINOR_VERSION 4)
+set (GAZEBO_MINOR_VERSION 5)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,31 @@
 ## Gazebo 11
 
+## Gazebo 11.5.0 (2021-04-20)
+
+1. Specify wide angle camera cube map texture format
+    * [Pull request #2960](https://github.com/osrf/gazebo/pull/2960)
+    * [Issue #2928](https://github.com/osrf/gazebo/issues/2928)
+
+1. Protect DepthCameraPlugin globals with a mutex
+    * [Pull request #2949](https://github.com/osrf/gazebo/pull/2949)
+
+1. Avoid deadlock in ConnectionManager::Stop
+    * [Pull request #2950](https://github.com/osrf/gazebo/pull/2950)
+
+1. Optimize collision checking in ODE
+    * [Pull request #2945](https://github.com/osrf/gazebo/pull/2945)
+
+1. Fix color channel of point clouds from DepthCamera
+    * [Pull request #2853](https://github.com/osrf/gazebo/pull/2853)
+
+1. GpuRaySensor: validate scene existence
+    * [Pull request #2937](https://github.com/osrf/gazebo/pull/2937)
+
+1. Silence message conversion warning messages
+    * [Pull request #2963](https://github.com/osrf/gazebo/pull/2963)
+    * [Pull request #2973](https://github.com/osrf/gazebo/pull/2973)
+
+
 ## Gazebo 11.4.0 (2021-04-01)
 
 1. Restore HeightmapShape::SetHeight implementation (#2955)


### PR DESCRIPTION
This bumps to 11.5.0 to prepare for a release. I've opened this in a pull request that includes the content of #2974 so that CI will be realistic. It should be quick to make the release from this state once both are approved.

Wait for #2974 to land and then use squash and merge.