### PR TITLE
Check for nullptr in TopicManager::ConnectPubToSub

### DIFF
--- a/gazebo/transport/TopicManager.cc
+++ b/gazebo/transport/TopicManager.cc
@@ -271,7 +271,9 @@ void TopicManager::ConnectPubToSub(const std::string &_topic,
                                    const SubscriptionTransportPtr _sublink)
 {
   PublicationPtr publication = this->FindPublication(_topic);
-  publication->AddSubscription(_sublink);
+  if (publication) {
+    publication->AddSubscription(_sublink);
+  }
 }
 
 //////////////////////////////////////////////////
@@ -279,7 +281,9 @@ void TopicManager::DisconnectPubFromSub(const std::string &topic,
     const std::string &host, unsigned int port)
 {
   PublicationPtr publication = this->FindPublication(topic);
-  publication->RemoveSubscription(host, port);
+  if (publication) {
+    publication->RemoveSubscription(host, port);
+  }
 }
 
 //////////////////////////////////////////////////

--- a/test/regression/2875_connect_pub_to_sub_crash.cc
+++ b/test/regression/2875_connect_pub_to_sub_crash.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2021 Amazon.com Inc or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "gazebo/test/ServerFixture.hh"
+
+#include "gazebo/transport/Connection.hh"
+#include "gazebo/transport/SubscriptionTransport.hh"
+#include "gazebo/transport/TopicManager.hh"
+
+using namespace gazebo;
+
+class Issue2875Test : public ServerFixture
+{
+};
+
+/////////////////////////////////////////////////
+TEST_F(Issue2875Test, ConnectPubToSubDoesNotCrashForMissingPublication)
+{
+  this->Load("worlds/empty.world");
+  const std::string topic = "/chatter";
+  // Add a topic to the advertised topics list so that the search in FindPublication isn't
+  // against an empty container.
+  auto Publisher = transport::TopicManager::Instance()->Advertise("/other", "some_type", 1, 1);
+
+  transport::ConnectionPtr conn(new transport::Connection());
+  transport::SubscriptionTransportPtr subLink(new transport::SubscriptionTransport());
+  subLink->Init(conn, false);
+  // Expect that this doesn't die
+  transport::TopicManager::Instance()->ConnectPubToSub(topic, subLink);
+  // The topic does not exist - but the above call should not have crashed anyways.
+  ASSERT_EQ(transport::TopicManager::Instance()->FindPublication(topic), nullptr);
+}
+
+/////////////////////////////////////////////////
+// Main
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/regression/2875_connect_pub_to_sub_crash.cc
+++ b/test/regression/2875_connect_pub_to_sub_crash.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Amazon.com Inc or its affiliates. All rights reserved.
+ * Copyright (C) 2021 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -44,6 +44,7 @@ set(tests
   2430_revolute_joint_SetPosition.cc
   2505_revolute_joint_SetAxis.cc
   2728_nested_urdf.cc
+  2875_connect_pub_to_sub_crash.cc
   2896_gazebo_subnamespace.cc
   2902_performance_metrics_deadlock.cc
 )


### PR DESCRIPTION
Fixes #2875

This was causing a very occasional crash problem in real runs, and is reliably reproducible by the method shown in https://github.com/osrf/gazebo/issues/2875#issuecomment-822834452 - which case is explicitly forced by the added regression test. Though it's a pathological case, there is nothing illegal about the test's usage of a global, public API, and therefore it needs the protection. 

The crash case of #2875 is particularly bad in that it allows the server process to be crashed by an external process' actions - all it takes is a mis-timed "sub" message to the server.

This issue also exists in Gazebo9 and will need to be backported.