### PR TITLE
Qualify `gazebo::util` in `using namespace` directives.

### DIFF
--- a/gazebo/util/Diagnostics.cc
+++ b/gazebo/util/Diagnostics.cc
@@ -26,7 +26,7 @@
 #include "gazebo/util/Diagnostics.hh"
 
 using namespace gazebo;
-using namespace util;
+using namespace gazebo::util;
 
 //////////////////////////////////////////////////
 DiagnosticManager::DiagnosticManager()

--- a/gazebo/util/IntrospectionClient.cc
+++ b/gazebo/util/IntrospectionClient.cc
@@ -30,7 +30,7 @@
 #include "gazebo/util/IntrospectionClientPrivate.hh"
 
 using namespace gazebo;
-using namespace util;
+using namespace gazebo::util;
 
 //////////////////////////////////////////////////
 IntrospectionClient::IntrospectionClient()

--- a/gazebo/util/IntrospectionManager.cc
+++ b/gazebo/util/IntrospectionManager.cc
@@ -30,7 +30,7 @@
 #include "gazebo/util/IntrospectionManagerPrivate.hh"
 
 using namespace gazebo;
-using namespace util;
+using namespace gazebo::util;
 
 //////////////////////////////////////////////////
 IntrospectionManager::IntrospectionManager()

--- a/gazebo/util/LogPlay.cc
+++ b/gazebo/util/LogPlay.cc
@@ -46,7 +46,7 @@
 #include "gazebo/util/LogPlay.hh"
 
 using namespace gazebo;
-using namespace util;
+using namespace gazebo::util;
 
 /////////////////////////////////////////////////
 LogPlay::LogPlay()

--- a/gazebo/util/LogRecord.cc
+++ b/gazebo/util/LogRecord.cc
@@ -56,7 +56,7 @@
 #include "gazebo/util/LogRecord.hh"
 
 using namespace gazebo;
-using namespace util;
+using namespace gazebo::util;
 
 //////////////////////////////////////////////////
 LogRecord::LogRecord()

--- a/gazebo/util/OpenAL.cc
+++ b/gazebo/util/OpenAL.cc
@@ -42,7 +42,7 @@
 #include "gazebo/util/OpenAL.hh"
 
 using namespace gazebo;
-using namespace util;
+using namespace gazebo::util;
 
 #ifdef HAVE_OPENAL
 /////////////////////////////////////////////////


### PR DESCRIPTION
This avoids ambiguity in the presence of a top-level namespace named `util`, e.g. https://godbolt.org/z/WMfseEGPf.