### PR TITLE
Fix light preview parameters

### DIFF
--- a/gazebo/gui/LightMaker.cc
+++ b/gazebo/gui/LightMaker.cc
@@ -115,6 +115,8 @@ bool LightMaker::Init()
   this->dataPtr->light->Load();
   scene->AddLight(this->dataPtr->light);
 
+  this->msg.clear_name();
+  this->dataPtr->light->UpdateFromMsg(this->msg);
   this->dataPtr->light->SetLightType(this->lightTypename);
   this->dataPtr->light->SetPosition(ignition::math::Vector3d(0, 0, 1));
   if (this->lightTypename == "directional")

--- a/gazebo/gui/LightMaker_TEST.cc
+++ b/gazebo/gui/LightMaker_TEST.cc
@@ -62,6 +62,7 @@ void LightMaker_TEST::PointLight()
   // Check there's a light in the scene -- this is the preview
   light = scene->LightByName("__default__");
   QVERIFY(light != NULL);
+  const auto previewLight = light;
 
   // Check that the light appeared in the center of the screen
   ignition::math::Vector3d startPos = pointLightMaker->EntityPosition();
@@ -97,6 +98,11 @@ void LightMaker_TEST::PointLight()
   // Check there's a light in the scene -- this is the final pointLight
   light = scene->LightByName("user_point_light_0");
   QVERIFY(light != NULL);
+
+  QVERIFY(light->LightType() == previewLight->LightType());
+  QVERIFY(light->DiffuseColor() == previewLight->DiffuseColor());
+  QVERIFY(light->SpecularColor() == previewLight->SpecularColor());
+  QVERIFY(light->Direction() == previewLight->Direction());
 
   // Terminate
   mainWindow->close();

--- a/gazebo/gui/LightMaker_TEST.cc
+++ b/gazebo/gui/LightMaker_TEST.cc
@@ -24,6 +24,18 @@
 #include "gazebo/gui/LightMaker.hh"
 #include "gazebo/gui/LightMaker_TEST.hh"
 
+// from https://stackoverflow.com/a/65954026/1076564
+#define COMPARE_DBL(actual, expected, epsilon) \
+do {\
+  if (!QTest::compare_helper((qAbs(actual - expected) <= epsilon), \
+    QString{"Compared values are not the same in respect to epsilon %1"} \
+    .arg(epsilon).toLocal8Bit().constData(), \
+    QTest::toString(actual), \
+    QTest::toString(expected), \
+    #actual, #expected, __FILE__, __LINE__)) \
+  return;\
+} while (false)
+
 /////////////////////////////////////////////////
 void LightMaker_TEST::PointLight()
 {
@@ -103,6 +115,94 @@ void LightMaker_TEST::PointLight()
   QVERIFY(light->DiffuseColor() == previewLight->DiffuseColor());
   QVERIFY(light->SpecularColor() == previewLight->SpecularColor());
   QVERIFY(light->Direction() == previewLight->Direction());
+
+  // Terminate
+  mainWindow->close();
+  delete mainWindow;
+}
+
+/////////////////////////////////////////////////
+void LightMaker_TEST::SpotLight()
+{
+  this->resMaxPercentChange = 5.0;
+  this->shareMaxPercentChange = 2.0;
+
+  this->Load("worlds/empty.world", false, false, false);
+
+  // Create the main window.
+  gazebo::gui::MainWindow *mainWindow = new gazebo::gui::MainWindow();
+  QVERIFY(mainWindow != NULL);
+  mainWindow->Load();
+  mainWindow->Init();
+  mainWindow->show();
+
+  this->ProcessEventsAndDraw(mainWindow);
+
+  // Get scene
+  gazebo::rendering::ScenePtr scene = gazebo::rendering::get_scene();
+  QVERIFY(scene != NULL);
+
+  // Check there's no light in the scene yet
+  gazebo::rendering::LightPtr light = scene->LightByName("__default__");
+  QVERIFY(light == NULL);
+  light = scene->LightByName("user_spot_light_0");
+  QVERIFY(light == NULL);
+
+  // Create a spotLight maker
+  gazebo::gui::SpotLightMaker *spotLightMaker =
+      new gazebo::gui::SpotLightMaker();
+  QVERIFY(spotLightMaker != NULL);
+
+  // Start the maker to make a light
+  spotLightMaker->Start();
+
+  // Check there's a light in the scene -- this is the preview
+  light = scene->LightByName("__default__");
+  QVERIFY(light != NULL);
+  const auto previewLight = light;
+
+  // Check that the light appeared in the center of the screen
+  ignition::math::Vector3d startPos = spotLightMaker->EntityPosition();
+  QVERIFY(startPos == ignition::math::Vector3d::UnitZ);
+  QVERIFY(light->Position() == startPos);
+
+  // Mouse move
+  gazebo::common::MouseEvent mouseEvent;
+  mouseEvent.SetType(gazebo::common::MouseEvent::MOVE);
+  spotLightMaker->OnMouseMove(mouseEvent);
+
+  // Check that entity moved
+  ignition::math::Vector3d pos = spotLightMaker->EntityPosition();
+  QVERIFY(pos != startPos);
+  QVERIFY(light->Position() == pos);
+
+  // Mouse release
+  mouseEvent.SetType(gazebo::common::MouseEvent::RELEASE);
+  mouseEvent.SetButton(gazebo::common::MouseEvent::LEFT);
+  mouseEvent.SetDragging(false);
+  mouseEvent.SetPressPos(0, 0);
+  mouseEvent.SetPos(0, 0);
+  spotLightMaker->OnMouseRelease(mouseEvent);
+
+  // Check there's no light in the scene -- the preview is gone
+  light = scene->LightByName("__default__");
+  QVERIFY(light == NULL);
+  light = scene->LightByName("user_spot_light");
+  QVERIFY(light == NULL);
+
+  this->ProcessEventsAndDraw(mainWindow);
+
+  // Check there's a light in the scene -- this is the final pointLight
+  light = scene->LightByName("user_spot_light_0");
+  QVERIFY(light != NULL);
+
+  QVERIFY(light->LightType() == previewLight->LightType());
+  QVERIFY(light->DiffuseColor() == previewLight->DiffuseColor());
+  QVERIFY(light->SpecularColor() == previewLight->SpecularColor());
+  QVERIFY(light->Direction() == previewLight->Direction());
+  COMPARE_DBL(light->SpotInnerAngle(), previewLight->SpotInnerAngle(), 1e-3);
+  COMPARE_DBL(light->SpotOuterAngle(), previewLight->SpotOuterAngle(), 1e-3);
+  COMPARE_DBL(light->SpotFalloff(), previewLight->SpotFalloff(), 1e-3);
 
   // Terminate
   mainWindow->close();

--- a/gazebo/gui/LightMaker_TEST.hh
+++ b/gazebo/gui/LightMaker_TEST.hh
@@ -28,6 +28,9 @@ class LightMaker_TEST : public QTestFixture
   /// \brief Test creating a point light.
   private slots: void PointLight();
 
+  /// \brief Test creating a spot light.
+  private slots: void SpotLight();
+
   /// \brief Test creating a point light as a copy.
   private slots: void CopyLight();
 };

--- a/gazebo/rendering/Light.cc
+++ b/gazebo/rendering/Light.cc
@@ -156,14 +156,20 @@ void Light::UpdateSDFFromMsg(const msgs::Light &_msg)
 //////////////////////////////////////////////////
 void Light::UpdateFromMsg(ConstLightPtr &_msg)
 {
-  this->UpdateSDFFromMsg(*_msg);
+  this->UpdateFromMsg(*_msg);
+}
+
+//////////////////////////////////////////////////
+void Light::UpdateFromMsg(const msgs::Light &_msg)
+{
+  this->UpdateSDFFromMsg(_msg);
 
   this->Update();
 
-  if (_msg->has_pose())
+  if (_msg.has_pose())
   {
-    this->SetPosition(msgs::ConvertIgn(_msg->pose().position()));
-    this->SetRotation(msgs::ConvertIgn(_msg->pose().orientation()));
+    this->SetPosition(msgs::ConvertIgn(_msg.pose().position()));
+    this->SetRotation(msgs::ConvertIgn(_msg.pose().orientation()));
   }
 }
 

--- a/gazebo/rendering/Light.cc
+++ b/gazebo/rendering/Light.cc
@@ -156,7 +156,8 @@ void Light::UpdateSDFFromMsg(const msgs::Light &_msg)
 //////////////////////////////////////////////////
 void Light::UpdateFromMsg(ConstLightPtr &_msg)
 {
-  this->UpdateFromMsg(*_msg);
+  if (_msg)
+    this->UpdateFromMsg(*_msg);
 }
 
 //////////////////////////////////////////////////
@@ -628,6 +629,15 @@ bool Light::CastShadows() const
 }
 
 //////////////////////////////////////////////////
+double Light::SpotInnerAngle() const
+{
+  if (this->dataPtr->light->getType() != Ogre::Light::LT_SPOTLIGHT)
+    return std::numeric_limits<double>::quiet_NaN();
+
+  return this->dataPtr->light->getSpotlightInnerAngle().valueRadians();
+}
+
+//////////////////////////////////////////////////
 void Light::SetSpotInnerAngle(const double _angle)
 {
   sdf::ElementPtr elem = this->dataPtr->sdf->GetElement("spot");
@@ -643,6 +653,15 @@ void Light::SetSpotInnerAngle(const double _angle)
 }
 
 //////////////////////////////////////////////////
+double Light::SpotOuterAngle() const
+{
+  if (this->dataPtr->light->getType() != Ogre::Light::LT_SPOTLIGHT)
+    return std::numeric_limits<double>::quiet_NaN();
+
+  return this->dataPtr->light->getSpotlightOuterAngle().valueRadians();
+}
+
+//////////////////////////////////////////////////
 void Light::SetSpotOuterAngle(const double _angle)
 {
   sdf::ElementPtr elem = this->dataPtr->sdf->GetElement("spot");
@@ -655,6 +674,15 @@ void Light::SetSpotOuterAngle(const double _angle)
         Ogre::Radian(elem->Get<double>("outer_angle")),
         elem->Get<double>("falloff"));
   }
+}
+
+//////////////////////////////////////////////////
+double Light::SpotFalloff() const
+{
+  if (this->dataPtr->light->getType() != Ogre::Light::LT_SPOTLIGHT)
+    return std::numeric_limits<double>::quiet_NaN();
+
+  return this->dataPtr->light->getSpotlightFalloff();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/Light.hh
+++ b/gazebo/rendering/Light.hh
@@ -214,6 +214,10 @@ namespace gazebo
       /// \param[in] _msg Light message to update from
       public: void UpdateFromMsg(ConstLightPtr &_msg);
 
+      /// \brief Update a light source from a message.
+      /// \param[in] _msg Light message to update from
+      public: void UpdateFromMsg(const msgs::Light &_msg);
+
       /// \brief Clone the light with a new name
       /// \param[in] _name Name of the cloned light.
       /// \param[in] _scene Scene to contain the light.

--- a/gazebo/rendering/Light.hh
+++ b/gazebo/rendering/Light.hh
@@ -182,13 +182,25 @@ namespace gazebo
       public: void SetAttenuation(double _constant, double _linear,
                                   double _quadratic);
 
+      /// \brief Get the spot light inner angle
+      /// \return The inner angle in radians (or NaN if the light is not spot).
+      public: double SpotInnerAngle() const;
+
       /// \brief Set the spot light inner angle
       /// \param[in] _angle Inner angle in radians
       public: void SetSpotInnerAngle(const double _angle);
 
+      /// \brief Get the spot light outer angle
+      /// \return The outer angle in radians (or NaN if the light is not spot).
+      public: double SpotOuterAngle() const;
+
       /// \brief Set the spot light outer angle
       /// \param[in] _angle Outer angle in radians
       public: void SetSpotOuterAngle(const double _angle);
+
+      /// \brief Get the spot light falloff
+      /// \return The falloff value (or NaN if the light is not spot).
+      public: double SpotFalloff() const;
 
       /// \brief Set the spot light falloff
       /// \param[in] _value Falloff value


### PR DESCRIPTION
Fixes #2981 . See the issue for detailed description.


https://user-images.githubusercontent.com/182533/115697965-661a7880-a364-11eb-9ac8-74f06fbdc843.mp4

I also wanted to add tests for the inner/outer angle, but they have no getters. Should I add these? Please, also check that the copy of `light` I make in the test is actually still a pointer to the preview light and is not pointing to the same object `light` does at the end of the test. I think it should be so, but another pair of eyes would be good :)