### PR TITLE
Avoid range-loop-construct in TopicManager

### DIFF
--- a/gazebo/transport/TopicManager.hh
+++ b/gazebo/transport/TopicManager.hh
@@ -128,7 +128,7 @@ namespace gazebo
                 {
                   if (iter2.first == _topic)
                   {
-                    for (const auto liter : iter2.second)
+                    for (const auto &liter : iter2.second)
                     {
                       publication->AddSubscription(liter);
                     }


### PR DESCRIPTION
Clang (on OSX) issues a warning at the TopicManager:
```
/usr/local/Cellar/gazebo11/11.3.0/include/gazebo-11/gazebo/transport/TopicManager.hh:131:37: error: loop variable 'liter' of type 'const boost::shared_ptr<gazebo::transport::Node>' creates a copy from type 'const boost::shared_ptr<gazebo::transport::Node>' [-Werror,-Wrange-loop-construct]
                    for (const auto liter : iter2.second)
                                    ^
/usr/local/Cellar/gazebo11/11.3.0/include/gazebo-11/gazebo/transport/TopicManager.hh:131:26: note: use reference type 'const boost::shared_ptr<gazebo::transport::Node> &' to prevent copying
                    for (const auto liter : iter2.second)
                         ^~~~~~~~~~~~~~~~~~
                                    &
1 error generated.
```

As proposed, using it as a reference silences the warning.