### PR TITLE
Add warning if GAZEBO_RESOURCE_PATH may not be set correctly

### DIFF
--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -359,10 +359,10 @@ bool Server::ParseArgs(int _argc, char **_argv)
       gzwarn << "Falling back on worlds/empty.world\n";
       if (!this->LoadFile("worlds/empty.world", physics))
       {
-        gzwarn << "worlds/empty.world could not be opened, "
-               << "probably because it was not found. "
-               << "Make sure the environment variable "
-               << "GAZEBO_RESOURCE_PATH is set correctly.\n";
+        gzerr << "worlds/empty.world could not be opened, "
+              << "probably because it was not found. "
+              << "Your GAZEBO_RESOURCE_PATH is probably improperly set. "
+              << "Have you sourced <prefix>/share/gazebo/setup.sh?\n";
         return false;
       }
     }

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -358,11 +358,13 @@ bool Server::ParseArgs(int _argc, char **_argv)
     {
       gzwarn << "Falling back on worlds/empty.world\n";
       if (!this->LoadFile("worlds/empty.world", physics))
+      {
         gzwarn << "worlds/empty.world could not be opened, "
                << "probably because it was not found. "
                << "Make sure the environment variable "
                << "GAZEBO_RESOURCE_PATH is set correctly.\n";
         return false;
+      }
     }
 
     if (this->dataPtr->vm.count("profile"))

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -358,6 +358,10 @@ bool Server::ParseArgs(int _argc, char **_argv)
     {
       gzwarn << "Falling back on worlds/empty.world\n";
       if (!this->LoadFile("worlds/empty.world", physics))
+        gzwarn << "worlds/empty.world could not be opened, "
+               << "probably because it was not found. "
+               << "Make sure the environment variable "
+               << "GAZEBO_RESOURCE_PATH is set correctly.\n";
         return false;
     }
 

--- a/gazebo/rendering/RTShaderSystem.cc
+++ b/gazebo/rendering/RTShaderSystem.cc
@@ -477,7 +477,9 @@ bool RTShaderSystem::GetPaths(std::string &coreLibsPath, std::string &cachePath)
   // Core shader lib not found -> shader generating will fail.
   if (coreLibsPath.empty())
   {
-    gzerr << "Unable to find shader lib. Shader generating will fail.";
+    gzerr << "Unable to find shader lib. Shader generating will fail. "
+          << "Your GAZEBO_RESOURCE_PATH is probably improperly set. "
+          << "Have you sourced <prefix>/share/gazebo/setup.sh?\n";
     return false;
   }
 


### PR DESCRIPTION
This adds an informative warning that should help if people run into #2044.

If you reproduce the error, as @scpeters describes in https://github.com/osrf/gazebo/issues/2044#issuecomment-818246300, the following is the output. The last line is the new warning.
```bash
$ cd <anywhere but your gazebo repos root directory>
$ export GAZEBO_RESOURCE_PATH=/tmp
$ gzserver --verbose
Gazebo multi-robot simulator, version 11.4.0
Copyright (C) 2012 Open Source Robotics Foundation.
Released under the Apache 2 License.
http://gazebosim.org

[Msg] Waiting for master.
[Msg] Connected to gazebo master @ http://127.0.0.1:11345
[Msg] Publicized address: 172.17.0.2
[Err] [RTShaderSystem.cc:480] Unable to find shader lib. Shader generating will fail.[Wrn] [SystemPaths.cc:459] File or path does not exist [""] [worlds/empty.world]
[Err] [Server.cc:448] Could not open file[worlds/empty.world]
[Wrn] [Server.cc:359] Falling back on worlds/empty.world
[Wrn] [SystemPaths.cc:459] File or path does not exist [""] [worlds/empty.world]
[Err] [Server.cc:448] Could not open file[worlds/empty.world]
[Wrn] [Server.cc:361] worlds/empty.world could not be opened, probably because it was not found. Make sure the environment variable GAZEBO_RESOURCE_PATH is set correctly.
```