### PR TITLE
Initialize the `worldPoseDirty` flag in Collision.cc.

### DIFF
--- a/gazebo/physics/Collision.cc
+++ b/gazebo/physics/Collision.cc
@@ -57,7 +57,7 @@ static SDFCollisionInitializer g_SDFInit;
 
 //////////////////////////////////////////////////
 Collision::Collision(LinkPtr _link)
-: Entity(_link), maxContacts(1)
+: Entity(_link), maxContacts(1), worldPoseDirty(true)
 {
   this->AddType(Base::COLLISION);
 


### PR DESCRIPTION
This potentially resolves a rarely occuring issue in long-running runs of gzserver.
The uninitialized value was found by running Gazebo in Valgrind.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>>