### PR TITLE
Distortion normalization improvement + fix "folding" on large distortions

### DIFF
--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -201,7 +201,7 @@ void Distortion::SetCamera(CameraPtr _camera)
       this->dataPtr->lensCenter.Y() * this->dataPtr->distortionTexWidth);
 
   // declare variables before the loop
-  static auto unsetPixelVector =  ignition::math::Vector2d(-1, -1);
+  const auto unsetPixelVector =  ignition::math::Vector2d(-1, -1);
   ignition::math::Vector2d normalizedLocation,
       distortedLocation,
       newDistortedCoordinates,

--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -174,9 +174,9 @@ void Distortion::SetCamera(CameraPtr _camera)
   unsigned int texSide = _camera->ImageHeight() > _camera->ImageWidth() ?
       _camera->ImageHeight() : _camera->ImageWidth();
   // calculate focal length from largest fov
-  double fov = _camera->ImageHeight() > _camera->ImageWidth() ?
+  const double fov = _camera->ImageHeight() > _camera->ImageWidth() ?
       _camera->VFOV().Radian() : _camera->HFOV().Radian();
-  double focalLength = texSide/(2*tan(fov/2));
+  const double focalLength = texSide/(2*tan(fov/2));
   this->dataPtr->distortionTexWidth = texSide - 1;
   this->dataPtr->distortionTexHeight = texSide - 1;
   unsigned int imageSize =

--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -212,10 +212,12 @@ void Distortion::SetCamera(CameraPtr _camera)
   double normalizedColLocation, normalizedRowLocation;
 
   // fill the distortion map
-  for (unsigned int mapRow = 0; mapRow < this->dataPtr->distortionTexHeight; ++mapRow)
+  for (unsigned int mapRow = 0; mapRow < this->dataPtr->distortionTexHeight;
+    ++mapRow)
   {
     normalizedRowLocation = mapRow*rowStepSize;
-    for (unsigned int mapCol = 0; mapCol < this->dataPtr->distortionTexWidth; ++mapCol)
+    for (unsigned int mapCol = 0; mapCol < this->dataPtr->distortionTexWidth;
+      ++mapCol)
     {
       normalizedColLocation = mapCol*colStepSize;
 
@@ -240,25 +242,29 @@ void Distortion::SetCamera(CameraPtr _camera)
 
       // compute the index in the distortion map
       distortedCol = distortedLocation.X() * this->dataPtr->distortionTexWidth;
-      distortedRow = distortedLocation.Y() * this->dataPtr->distortionTexHeight;
+      distortedRow = distortedLocation.Y() *
+        this->dataPtr->distortionTexHeight;
 
       // Note that the following makes sure that, for significant distortions,
-      // there is not a problem where the distorted image seems to fold over itself.
-      // This is accomplished by favoring pixels closer to the center of distortion,
-      // and this change applies to both the legacy and nonlegacy distortion modes.
+      // there is not a problem where the distorted image seems to fold over
+      // itself. This is accomplished by favoring pixels closer to the center
+      // of distortion, and this change applies to both the legacy and
+      // nonlegacy distortion modes.
 
       // Make sure the distorted pixel is within the texture dimensions
       if (distortedCol < this->dataPtr->distortionTexWidth &&
           distortedRow < this->dataPtr->distortionTexHeight)
       {
-        distortedIdx = distortedRow * this->dataPtr->distortionTexWidth + distortedCol;
+        distortedIdx = distortedRow * this->dataPtr->distortionTexWidth +
+          distortedCol;
 
         // check if the index has already been set
         if (this->dataPtr->distortionMap[distortedIdx] != unsetPixelVector)
         {
           // grab current coordinates that map to this destination
-          currDistortedCoordinates = this->dataPtr->distortionMap[distortedIdx] *
-                                     this->dataPtr->distortionTexWidth;
+          currDistortedCoordinates =
+            this->dataPtr->distortionMap[distortedIdx] *
+            this->dataPtr->distortionTexWidth;
 
           // grab new coordinates to map to
           newDistortedCoordinates[0] = mapCol;
@@ -504,7 +510,8 @@ ignition::math::Vector2d Distortion::Distort(
   dist.Y() += _p1 * (rSq + 2 * (normalized.Y()*normalized.Y())) +
       2 * _p2 * normalized.X() * normalized.Y();
 
-  return ((_center*_width) + ignition::math::Vector2d(dist.X(), dist.Y())*_f)/_width;
+  return ((_center*_width) +
+    ignition::math::Vector2d(dist.X(), dist.Y())*_f)/_width;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -135,7 +135,9 @@ void Distortion::Load(sdf::ElementPtr _sdf)
   {
     this->dataPtr->legacyMode = _sdf->Get<bool>(legacyMode);
   }
-  if (!this->dataPtr->legacyMode) {
+  if (!this->dataPtr->legacyMode && this->dataPtr->distortionCrop)
+  {
+    gzwarn << "Enable legacy mode to use distortion cropping" << std::endl;
     this->dataPtr->distortionCrop = false;
   }
 }

--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -237,6 +237,11 @@ void Distortion::SetCamera(CameraPtr _camera)
       distortedCol = distortedLocation.X() * this->dataPtr->distortionTexWidth;
       distortedRow = distortedLocation.Y() * this->dataPtr->distortionTexHeight;
 
+      // Note that the following makes sure that, for significant distortions,
+      // there is not a problem where the distorted image seems to fold over itself.
+      // This is accomplished by favoring pixels closer to the center of distortion,
+      // and this change applies to both the legacy and nonlegacy distortion modes.
+
       // Make sure the distorted pixel is within the texture dimensions
       if (distortedCol < this->dataPtr->distortionTexWidth &&
           distortedRow < this->dataPtr->distortionTexHeight)

--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -470,27 +470,7 @@ ignition::math::Vector2d Distortion::Distort(
     const ignition::math::Vector2d &_center, double _k1, double _k2, double _k3,
     double _p1, double _p2)
 {
-  // apply Brown's distortion model, see
-  // http://en.wikipedia.org/wiki/Distortion_%28optics%29#Software_correction
-
-  ignition::math::Vector2d normalized2d = _in - _center;
-  ignition::math::Vector3d normalized(normalized2d.X(), normalized2d.Y(), 0);
-  double rSq = normalized.X() * normalized.X() +
-               normalized.Y() * normalized.Y();
-
-  // radial
-  ignition::math::Vector3d dist = normalized * (1.0 +
-      _k1 * rSq +
-      _k2 * rSq * rSq +
-      _k3 * rSq * rSq * rSq);
-
-  // tangential
-  dist.X() += _p2 * (rSq + 2 * (normalized.X()*normalized.X())) +
-      2 * _p1 * normalized.X() * normalized.Y();
-  dist.Y() += _p1 * (rSq + 2 * (normalized.Y()*normalized.Y())) +
-      2 * _p2 * normalized.X() * normalized.Y();
-
-  return _center + ignition::math::Vector2d(dist.X(), dist.Y());
+  return Distort(_in, _center, _k1, _k2, _k3, _p1, _p2, 1u, 1.0);
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -224,13 +224,16 @@ void Distortion::SetCamera(CameraPtr _camera)
       normalizedLocation[0] = normalizedColLocation;
       normalizedLocation[1] = normalizedRowLocation;
 
-      if (this->dataPtr->legacyMode) {
+      if (this->dataPtr->legacyMode)
+      {
         distortedLocation = this->Distort(
             normalizedLocation,
             this->dataPtr->lensCenter,
             this->dataPtr->k1, this->dataPtr->k2, this->dataPtr->k3,
             this->dataPtr->p1, this->dataPtr->p2);
-      } else {
+      }
+      else
+      {
         distortedLocation = this->Distort(
             normalizedLocation,
             this->dataPtr->lensCenter,

--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -135,6 +135,9 @@ void Distortion::Load(sdf::ElementPtr _sdf)
   {
     this->dataPtr->legacyMode = _sdf->Get<bool>(legacyMode);
   }
+  if (!this->dataPtr->legacyMode) {
+    this->dataPtr->distortionCrop = false;
+  }
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/Distortion.hh
+++ b/gazebo/rendering/Distortion.hh
@@ -54,7 +54,8 @@ namespace gazebo
       public: void SetCamera(CameraPtr _camera);
 
       /// \brief Set whether to crop the black border around the distorted
-      /// image points.
+      /// image points. Note that cropping only occurs for the legacy mode
+      /// distortion implementation.
       /// \param[in] _crop True to crop the black border
       /// \sa Crop
       public: void SetCrop(const bool _crop);

--- a/gazebo/rendering/Distortion.hh
+++ b/gazebo/rendering/Distortion.hh
@@ -104,7 +104,7 @@ namespace gazebo
                   const ignition::math::Vector2d &_center,
                   double _k1, double _k2, double _k3,
                   double _p1, double _p2);
-                  
+
       /// \brief Apply distortion model using camera coordinates projection
       /// \param[in] _in Input uv coordinate.
       /// \param[in] _center Normalized distortion center.
@@ -118,9 +118,9 @@ namespace gazebo
       /// \return Distorted coordinate.
       public: static ignition::math::Vector2d Distort(
                   const ignition::math::Vector2d &_in,
-                  const ignition::math::Vector2d &_center, 
+                  const ignition::math::Vector2d &_center,
                   double _k1, double _k2, double _k3,
-                  double _p1, double _p2, 
+                  double _p1, double _p2,
                   unsigned int _width, double _f);
 
       /// \brief get the distortion map value.

--- a/gazebo/rendering/Distortion.hh
+++ b/gazebo/rendering/Distortion.hh
@@ -103,6 +103,24 @@ namespace gazebo
                   const ignition::math::Vector2d &_center,
                   double _k1, double _k2, double _k3,
                   double _p1, double _p2);
+                  
+      /// \brief Apply distortion model using camera coordinates projection
+      /// \param[in] _in Input uv coordinate.
+      /// \param[in] _center Normalized distortion center.
+      /// \param[in] _k1 Radial distortion coefficient k1.
+      /// \param[in] _k2 Radial distortion coefficient k2.
+      /// \param[in] _k3 Radial distortion coefficient k3.
+      /// \param[in] _p1 Tangential distortion coefficient p1.
+      /// \param[in] _p2 Tangential distortion coefficient p2.
+      /// \param[in] _width Width of the image texture in pixels.
+      /// \param[in] _f Focal length in pixels.
+      /// \return Distorted coordinate.
+      public: static ignition::math::Vector2d Distort(
+                  const ignition::math::Vector2d &_in,
+                  const ignition::math::Vector2d &_center, 
+                  double _k1, double _k2, double _k3,
+                  double _p1, double _p2, 
+                  unsigned int _width, double _f);
 
       /// \brief get the distortion map value.
       /// \return the distortion map value at the specified index,

--- a/gazebo/test/ServerFixture.cc
+++ b/gazebo/test/ServerFixture.cc
@@ -578,7 +578,8 @@ void ServerFixture::SpawnCamera(const std::string &_modelName,
     const std::string &_noiseType, double _noiseMean, double _noiseStdDev,
     bool _distortion, double _distortionK1, double _distortionK2,
     double _distortionK3, double _distortionP1, double _distortionP2,
-    double _cx, double _cy)
+    double _cx, double _cy,
+    bool _useRealDistortion)
 {
   msgs::Factory msg;
   std::ostringstream newModelStr;
@@ -623,6 +624,9 @@ void ServerFixture::SpawnCamera(const std::string &_modelName,
     << "        <p1>" << _distortionP1 << "</p1>"
     << "        <p2>" << _distortionP2 << "</p2>"
     << "        <center>" << _cx << " " << _cy << "</center>"
+    << "        <ignition:use_real_distortion>"
+      << (_useRealDistortion ? "true" : "false")
+      << "</ignition:use_real_distortion>"
     << "      </distortion>";
   }
 

--- a/gazebo/test/ServerFixture.cc
+++ b/gazebo/test/ServerFixture.cc
@@ -579,7 +579,8 @@ void ServerFixture::SpawnCamera(const std::string &_modelName,
     bool _distortion, double _distortionK1, double _distortionK2,
     double _distortionK3, double _distortionP1, double _distortionP2,
     double _cx, double _cy,
-    bool _useRealDistortion)
+    bool _legacyMode,
+    double _horizontalFov)
 {
   msgs::Factory msg;
   std::ostringstream newModelStr;
@@ -595,7 +596,7 @@ void ServerFixture::SpawnCamera(const std::string &_modelName,
     << "    <update_rate>" << _rate << "</update_rate>"
     << "    <visualize>true</visualize>"
     << "    <camera>"
-    << "      <horizontal_fov>0.78539816339744828</horizontal_fov>"
+    << "      <horizontal_fov>" << _horizontalFov << "</horizontal_fov>"
     << "      <image>"
     << "        <width>" << _width << "</width>"
     << "        <height>" << _height << "</height>"
@@ -624,9 +625,9 @@ void ServerFixture::SpawnCamera(const std::string &_modelName,
     << "        <p1>" << _distortionP1 << "</p1>"
     << "        <p2>" << _distortionP2 << "</p2>"
     << "        <center>" << _cx << " " << _cy << "</center>"
-    << "        <ignition:use_real_distortion>"
-      << (_useRealDistortion ? "true" : "false")
-      << "</ignition:use_real_distortion>"
+    << "        <ignition:legacy_mode>"
+      << (_legacyMode ? "true" : "false")
+      << "</ignition:legacy_mode>"
     << "      </distortion>";
   }
 

--- a/gazebo/test/ServerFixture.hh
+++ b/gazebo/test/ServerFixture.hh
@@ -254,6 +254,7 @@ namespace gazebo
     /// \param[in] _distortionP2 Distortion coefficient p2.
     /// \param[in] _cx Normalized optical center x, used for distortion.
     /// \param[in] _cy Normalized optical center y, used for distortion.
+    /// \param[in] _useRealDistortion Use real distortion
     protected: void SpawnCamera(const std::string &_modelName,
                    const std::string &_cameraName,
                    const ignition::math::Vector3d &_pos =
@@ -267,7 +268,8 @@ namespace gazebo
                    bool _distortion = false, double _distortionK1 = 0.0,
                    double _distortionK2 = 0.0, double _distortionK3 = 0.0,
                    double _distortionP1 = 0.0, double _distortionP2 = 0.0,
-                   double _cx = 0.5, double _cy = 0.5);
+                   double _cx = 0.5, double _cy = 0.5,
+                   bool _useRealDistortion = false);
 
     /// \brief Spawn a wide angle camera.
     /// \param[in] _modelName Name of the model.

--- a/gazebo/test/ServerFixture.hh
+++ b/gazebo/test/ServerFixture.hh
@@ -254,7 +254,7 @@ namespace gazebo
     /// \param[in] _distortionP2 Distortion coefficient p2.
     /// \param[in] _cx Normalized optical center x, used for distortion.
     /// \param[in] _cy Normalized optical center y, used for distortion.
-    /// \param[in] _useRealDistortion Use real distortion
+    /// \param[in] _legacyMode Use the legacy distortion model.
     protected: void SpawnCamera(const std::string &_modelName,
                    const std::string &_cameraName,
                    const ignition::math::Vector3d &_pos =

--- a/gazebo/test/ServerFixture.hh
+++ b/gazebo/test/ServerFixture.hh
@@ -255,6 +255,7 @@ namespace gazebo
     /// \param[in] _cx Normalized optical center x, used for distortion.
     /// \param[in] _cy Normalized optical center y, used for distortion.
     /// \param[in] _legacyMode Use the legacy distortion model.
+    /// \param[in] _horizontalFov The horizontal field of view.
     protected: void SpawnCamera(const std::string &_modelName,
                    const std::string &_cameraName,
                    const ignition::math::Vector3d &_pos =

--- a/gazebo/test/ServerFixture.hh
+++ b/gazebo/test/ServerFixture.hh
@@ -269,7 +269,8 @@ namespace gazebo
                    double _distortionK2 = 0.0, double _distortionK3 = 0.0,
                    double _distortionP1 = 0.0, double _distortionP2 = 0.0,
                    double _cx = 0.5, double _cy = 0.5,
-                   bool _useRealDistortion = false);
+                   bool _legacyMode = true,
+                   double _horizontalFov = 0.78539816339744828);
 
     /// \brief Spawn a wide angle camera.
     /// \param[in] _modelName Name of the model.

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -40,14 +40,10 @@ unsigned char* img = NULL;
 unsigned char* img2 = NULL;
 unsigned char* img3 = NULL;
 unsigned char* img4 = NULL;
-unsigned char* img5 = NULL;
-unsigned char* img6 = NULL;
 int imageCount = 0;
 int imageCount2 = 0;
 int imageCount3 = 0;
 int imageCount4 = 0;
-int imageCount5 = 0;
-int imageCount6 = 0;
 std::string pixelFormat = "";
 
 // list of timestamped images used by the Timestamp test
@@ -708,12 +704,10 @@ TEST_F(CameraSensor, CheckDistortion)
     return;
   }
 
-  // Spawn 6 cameras. One has no distortion.
+  // Spawn 4 cameras. One has no distortion.
   // The second has distortion, but all the distortion parameters are set to 0.
   // The third has barrel (negative k1) distortion.
   // The fourth has pincushion (positive k1) distortion.
-  // The fifth has barrel (negative k1) distortion.
-  // The sixth has pincushion (positive k1) distortion.
   std::string modelNameUndistorted = "camera_model_undistorted";
   std::string cameraNameUndistorted = "camera_sensor_undistorted";
   std::string modelNameFlat = "camera_model_flat";
@@ -722,10 +716,6 @@ TEST_F(CameraSensor, CheckDistortion)
   std::string cameraNameBarrel = "camera_sensor_barrel";
   std::string modelNamePincushion = "camera_model_pincushion";
   std::string cameraNamePincushion = "camera_sensor_pincushion";
-  std::string modelNameExtremeBarrel = "camera_model_extreme_barrel";
-  std::string cameraNameExtremeBarrel = "camera_sensor_extreme_barrel";
-  std::string modelNameExtremePincushion = "camera_model_extreme_pincushion";
-  std::string cameraNameExtremePincushion = "camera_sensor_extreme_pincushion";
   unsigned int width  = 320;
   unsigned int height = 240;
   double updateRate = 10;
@@ -733,191 +723,131 @@ TEST_F(CameraSensor, CheckDistortion)
       ignition::math::Vector3d(-5, 0, 5),
       ignition::math::Quaterniond(0, IGN_DTOR(15), 0));
 
-  for (auto isUseLegacyDistortionMode: {true, false}) {
-    // spawn an undistorted camera
-    SpawnCamera(modelNameUndistorted, cameraNameUndistorted, setPose.Pos(),
-        setPose.Rot().Euler(), width, height, updateRate);
-    // spawn a flat camera
-    SpawnCamera(modelNameFlat, cameraNameFlat, setPose.Pos(),
-        setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, 0, 0, 0, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
-    // spawn a camera with barrel distortion
-    SpawnCamera(modelNameBarrel, cameraNameBarrel, setPose.Pos(),
-        setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, -0.1349, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
-    // spawn a camera with pincushion distortion
-    SpawnCamera(modelNamePincushion, cameraNamePincushion, setPose.Pos(),
-        setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, 0.1349, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
-    // spawn a camera with extreme barrel distortion
-    SpawnCamera(modelNameExtremeBarrel, cameraNameExtremeBarrel, setPose.Pos(),
-        setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, -0.5, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
-    // spawn a camera with extreme pincushion distortion
-    SpawnCamera(modelNameExtremePincushion, cameraNameExtremePincushion,
-        setPose.Pos(), setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, 0.5, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
+  // spawn an undistorted camera
+  SpawnCamera(modelNameUndistorted, cameraNameUndistorted, setPose.Pos(),
+      setPose.Rot().Euler(), width, height, updateRate);
+  // spawn a flat camera
+  SpawnCamera(modelNameFlat, cameraNameFlat, setPose.Pos(),
+      setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, 0, 0, 0, 0, 0, 0.5, 0.5);
+  // spawn a camera with barrel distortion
+  SpawnCamera(modelNameBarrel, cameraNameBarrel, setPose.Pos(),
+      setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, -0.1349, -0.51868, -0.001, 0, 0, 0.5, 0.5);
+  // spawn a camera with pincushion distortion
+  SpawnCamera(modelNamePincushion, cameraNamePincushion, setPose.Pos(),
+      setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, 0.1349, 0.51868, 0.001, 0, 0, 0.5, 0.5);
 
-    sensors::SensorPtr sensorUndistorted =
-      sensors::get_sensor(cameraNameUndistorted);
-    sensors::CameraSensorPtr camSensorUndistorted =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorUndistorted);
-
-    sensors::SensorPtr sensorFlat =
-      sensors::get_sensor(cameraNameFlat);
-    sensors::CameraSensorPtr camSensorFlat =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorFlat);
-
-    sensors::SensorPtr sensorBarrel =
+  sensors::SensorPtr sensorUndistorted =
+    sensors::get_sensor(cameraNameUndistorted);
+  sensors::CameraSensorPtr camSensorUndistorted =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorUndistorted);
+  sensors::SensorPtr sensorFlat =
+    sensors::get_sensor(cameraNameFlat);
+  sensors::CameraSensorPtr camSensorFlat =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorFlat);
+  sensors::SensorPtr sensorBarrel =
       sensors::get_sensor(cameraNameBarrel);
-    sensors::CameraSensorPtr camSensorBarrel =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
-
-    sensors::SensorPtr sensorPincushion =
+  sensors::CameraSensorPtr camSensorBarrel =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
+  sensors::SensorPtr sensorPincushion =
       sensors::get_sensor(cameraNamePincushion);
-    sensors::CameraSensorPtr camSensorPincushion =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorPincushion);
+  sensors::CameraSensorPtr camSensorPincushion =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorPincushion);
 
-    sensors::SensorPtr sensorExtremeBarrel =
-      sensors::get_sensor(cameraNameExtremeBarrel);
-    sensors::CameraSensorPtr camSensorExtremeBarrel =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorExtremeBarrel);
+  imageCount = 0;
+  imageCount2 = 0;
+  imageCount3 = 0;
+  imageCount4 = 0;
+  img = new unsigned char[width * height*3];
+  img2 = new unsigned char[width * height*3];
+  img3 = new unsigned char[width * height*3];
+  img4 = new unsigned char[width * height*3];
+  event::ConnectionPtr c =
+    camSensorUndistorted->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount, img,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c2 =
+    camSensorFlat->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount2, img2,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c3 =
+    camSensorBarrel->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount3, img3,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c4 =
+    camSensorPincushion->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount4, img4,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
 
-    sensors::SensorPtr sensorExtremePincushion =
-      sensors::get_sensor(cameraNameExtremePincushion);
-    sensors::CameraSensorPtr camSensorExtremePincushion =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorExtremePincushion);
-
-    imageCount = 0;
-    imageCount2 = 0;
-    imageCount3 = 0;
-    imageCount4 = 0;
-    imageCount5 = 0;
-    imageCount6 = 0;
-    img = new unsigned char[width * height*3];
-    img2 = new unsigned char[width * height*3];
-    img3 = new unsigned char[width * height*3];
-    img4 = new unsigned char[width * height*3];
-    img5 = new unsigned char[width * height*3];
-    img6 = new unsigned char[width * height*3];
-    event::ConnectionPtr c =
-      camSensorUndistorted->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount, img,
-            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-            std::placeholders::_4, std::placeholders::_5));
-    event::ConnectionPtr c2 =
-      camSensorFlat->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount2, img2,
-            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-            std::placeholders::_4, std::placeholders::_5));
-    event::ConnectionPtr c3 =
-      camSensorBarrel->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount3, img3,
-            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-            std::placeholders::_4, std::placeholders::_5));
-    event::ConnectionPtr c4 =
-      camSensorPincushion->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount4, img4,
-            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-            std::placeholders::_4, std::placeholders::_5));
-    event::ConnectionPtr c5 =
-      camSensorExtremeBarrel->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount5, img5,
-            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-            std::placeholders::_4, std::placeholders::_5));
-    event::ConnectionPtr c6 =
-      camSensorExtremePincushion->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount6, img6,
-            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-            std::placeholders::_4, std::placeholders::_5));
-
-    // Get some images
-    while (imageCount < 10 || imageCount2 < 10 ||
-        imageCount3 < 10 || imageCount4 < 10 ||
-        imageCount5 < 10 || imageCount6 < 10)
-    {
-      common::Time::MSleep(10);
-    }
-
-    unsigned int diffMax = 0, diffSum = 0;
-    double diffAvg = 0.0;
-
-    // We expect that there will be some non-zero difference between the images,
-    // except for the 0.0 distortion camera, which should return a completely
-    // identical camera to the one with no distortion tag in the SDF.
-
-    this->ImageCompare(img, img2, width, height, 3,
-                      diffMax, diffSum, diffAvg);
-    EXPECT_EQ(diffSum, 0u);
-
-    this->ImageCompare(img, img3, width, height, 3,
-                      diffMax, diffSum, diffAvg);
-    EXPECT_NE(diffSum, 0u);
-
-    this->ImageCompare(img, img4, width, height, 3,
-                      diffMax, diffSum, diffAvg);
-    EXPECT_NE(diffSum, 0u);
-
-    this->ImageCompare(img3, img4, width, height, 3,
-                      diffMax, diffSum, diffAvg);
-    EXPECT_NE(diffSum, 0u);
-
-    this->ImageCompare(img, img5, width, height, 3,
-                      diffMax, diffSum, diffAvg);
-    EXPECT_NE(diffSum, 0u);
-
-    this->ImageCompare(img3, img6, width, height, 3,
-                      diffMax, diffSum, diffAvg);
-    EXPECT_NE(diffSum, 0u);
-
-    // Compare colors. Barrel distorted image should have more darker pixels than
-    // the original as the ground plane has been warped to occupy more of the
-    // image. The same should be true for pincushion distortion, because the
-    // ground plane is still distorted to be larger - just different parts
-    // of the image are distorted.
-    unsigned int colorSum = 0;
-    unsigned int colorSum3 = 0;
-    unsigned int colorSum4 = 0;
-    unsigned int colorSum5 = 0;
-    unsigned int colorSum6 = 0;
-    for (unsigned int y = 0; y < height; ++y)
-    {
-      for (unsigned int x = 0; x < width*3; x+=3)
-      {
-        unsigned int r = img[(y*width*3) + x];
-        unsigned int g = img[(y*width*3) + x + 1];
-        unsigned int b = img[(y*width*3) + x + 2];
-        colorSum += r + g + b;
-        unsigned int r3 = img3[(y*width*3) + x];
-        unsigned int g3 = img3[(y*width*3) + x + 1];
-        unsigned int b3 = img3[(y*width*3) + x + 2];
-        colorSum3 += r3 + g3 + b3;
-        unsigned int r4 = img4[(y*width*3) + x];
-        unsigned int g4 = img4[(y*width*3) + x + 1];
-        unsigned int b4 = img4[(y*width*3) + x + 2];
-        colorSum4 += r4 + g4 + b4;
-        unsigned int r5 = img5[(y*width*3) + x];
-        unsigned int g5 = img5[(y*width*3) + x + 1];
-        unsigned int b5 = img5[(y*width*3) + x + 2];
-        colorSum5 += r5 + g5 + b5;
-        unsigned int r6 = img6[(y*width*3) + x];
-        unsigned int g6 = img6[(y*width*3) + x + 1];
-        unsigned int b6 = img6[(y*width*3) + x + 2];
-        colorSum6 += r6 + g6 + b6;
-      }
-    }
-    EXPECT_GT(colorSum, colorSum3);
-    EXPECT_GT(colorSum, colorSum4);
-    EXPECT_GT(colorSum, colorSum5);
-    EXPECT_GT(colorSum, colorSum6);
-
-    delete[] img;
-    delete[] img2;
-    delete[] img3;
-    delete[] img4;
-    delete[] img5;
-    delete[] img6;
+  // Get some images
+  while (imageCount < 10 || imageCount2 < 10 ||
+      imageCount3 < 10 || imageCount4 < 10)
+  {
+    common::Time::MSleep(10);
   }
+
+  unsigned int diffMax = 0, diffSum = 0;
+  double diffAvg = 0.0;
+
+  // We expect that there will be some non-zero difference between the images,
+  // except for the 0.0 distortion camera, which should return a completely
+  // identical camera to the one with no distortion tag in the SDF.
+
+  this->ImageCompare(img, img2, width, height, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_EQ(diffSum, 0u);
+
+  this->ImageCompare(img, img3, width, height, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_NE(diffSum, 0u);
+
+  this->ImageCompare(img, img4, width, height, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_NE(diffSum, 0u);
+
+  this->ImageCompare(img3, img4, width, height, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_NE(diffSum, 0u);
+
+  // Compare colors. Barrel distorted image should have more darker pixels than
+  // the original as the ground plane has been warped to occupy more of the
+  // image. The same should be true for pincushion distortion, because the
+  // ground plane is still distorted to be larger - just different parts
+  // of the image are distorted.
+  unsigned int colorSum = 0;
+  unsigned int colorSum3 = 0;
+  unsigned int colorSum4 = 0;
+  for (unsigned int y = 0; y < height; ++y)
+  {
+    for (unsigned int x = 0; x < width*3; x+=3)
+    {
+      unsigned int r = img[(y*width*3) + x];
+      unsigned int g = img[(y*width*3) + x + 1];
+      unsigned int b = img[(y*width*3) + x + 2];
+      colorSum += r + g + b;
+      unsigned int r3 = img3[(y*width*3) + x];
+      unsigned int g3 = img3[(y*width*3) + x + 1];
+      unsigned int b3 = img3[(y*width*3) + x + 2];
+      colorSum3 += r3 + g3 + b3;
+      unsigned int r4 = img4[(y*width*3) + x];
+      unsigned int g4 = img4[(y*width*3) + x + 1];
+      unsigned int b4 = img4[(y*width*3) + x + 2];
+      colorSum4 += r4 + g4 + b4;
+    }
+  }
+  EXPECT_GT(colorSum, colorSum3);
+  EXPECT_GT(colorSum, colorSum4);
+
+  delete[] img;
+  delete[] img2;
+  delete[] img3;
+  delete[] img4;
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -733,189 +733,191 @@ TEST_F(CameraSensor, CheckDistortion)
       ignition::math::Vector3d(-5, 0, 5),
       ignition::math::Quaterniond(0, IGN_DTOR(15), 0));
 
-  // spawn an undistorted camera
-  SpawnCamera(modelNameUndistorted, cameraNameUndistorted, setPose.Pos(),
-      setPose.Rot().Euler(), width, height, updateRate);
-  // spawn a flat camera
-  SpawnCamera(modelNameFlat, cameraNameFlat, setPose.Pos(),
-      setPose.Rot().Euler(), width, height, updateRate,
-      "", 0, 0, true, 0, 0, 0, 0, 0, 0.5, 0.5);
-  // spawn a camera with barrel distortion
-  SpawnCamera(modelNameBarrel, cameraNameBarrel, setPose.Pos(),
-      setPose.Rot().Euler(), width, height, updateRate,
-      "", 0, 0, true, -0.1349, -0.51868, -0.001, 0, 0, 0.5, 0.5);
-  // spawn a camera with pincushion distortion
-  SpawnCamera(modelNamePincushion, cameraNamePincushion, setPose.Pos(),
-      setPose.Rot().Euler(), width, height, updateRate,
-      "", 0, 0, true, 0.1349, 0.51868, 0.001, 0, 0, 0.5, 0.5);
-  // spawn a camera with extreme barrel distortion
-  SpawnCamera(modelNameExtremeBarrel, cameraNameExtremeBarrel, setPose.Pos(),
-      setPose.Rot().Euler(), width, height, updateRate,
-      "", 0, 0, true, -0.5, -0.51868, -0.001, 0, 0, 0.5, 0.5);
-  // spawn a camera with extreme pincushion distortion
-  SpawnCamera(modelNameExtremePincushion, cameraNameExtremePincushion,
-      setPose.Pos(), setPose.Rot().Euler(), width, height, updateRate,
-      "", 0, 0, true, 0.5, 0.51868, 0.001, 0, 0, 0.5, 0.5);
+  for (auto isUseRealDistortion: {true, false}) {
+    // spawn an undistorted camera
+    SpawnCamera(modelNameUndistorted, cameraNameUndistorted, setPose.Pos(),
+        setPose.Rot().Euler(), width, height, updateRate);
+    // spawn a flat camera
+    SpawnCamera(modelNameFlat, cameraNameFlat, setPose.Pos(),
+        setPose.Rot().Euler(), width, height, updateRate,
+        "", 0, 0, true, 0, 0, 0, 0, 0, 0.5, 0.5, isUseRealDistortion);
+    // spawn a camera with barrel distortion
+    SpawnCamera(modelNameBarrel, cameraNameBarrel, setPose.Pos(),
+        setPose.Rot().Euler(), width, height, updateRate,
+        "", 0, 0, true, -0.1349, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
+    // spawn a camera with pincushion distortion
+    SpawnCamera(modelNamePincushion, cameraNamePincushion, setPose.Pos(),
+        setPose.Rot().Euler(), width, height, updateRate,
+        "", 0, 0, true, 0.1349, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
+    // spawn a camera with extreme barrel distortion
+    SpawnCamera(modelNameExtremeBarrel, cameraNameExtremeBarrel, setPose.Pos(),
+        setPose.Rot().Euler(), width, height, updateRate,
+        "", 0, 0, true, -0.5, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
+    // spawn a camera with extreme pincushion distortion
+    SpawnCamera(modelNameExtremePincushion, cameraNameExtremePincushion,
+        setPose.Pos(), setPose.Rot().Euler(), width, height, updateRate,
+        "", 0, 0, true, 0.5, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
 
-  sensors::SensorPtr sensorUndistorted =
-    sensors::get_sensor(cameraNameUndistorted);
-  sensors::CameraSensorPtr camSensorUndistorted =
-    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorUndistorted);
+    sensors::SensorPtr sensorUndistorted =
+      sensors::get_sensor(cameraNameUndistorted);
+    sensors::CameraSensorPtr camSensorUndistorted =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorUndistorted);
 
-  sensors::SensorPtr sensorFlat =
-    sensors::get_sensor(cameraNameFlat);
-  sensors::CameraSensorPtr camSensorFlat =
-    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorFlat);
+    sensors::SensorPtr sensorFlat =
+      sensors::get_sensor(cameraNameFlat);
+    sensors::CameraSensorPtr camSensorFlat =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorFlat);
 
-  sensors::SensorPtr sensorBarrel =
-    sensors::get_sensor(cameraNameBarrel);
-  sensors::CameraSensorPtr camSensorBarrel =
-    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
+    sensors::SensorPtr sensorBarrel =
+      sensors::get_sensor(cameraNameBarrel);
+    sensors::CameraSensorPtr camSensorBarrel =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
 
-  sensors::SensorPtr sensorPincushion =
-    sensors::get_sensor(cameraNamePincushion);
-  sensors::CameraSensorPtr camSensorPincushion =
-    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorPincushion);
+    sensors::SensorPtr sensorPincushion =
+      sensors::get_sensor(cameraNamePincushion);
+    sensors::CameraSensorPtr camSensorPincushion =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorPincushion);
 
-  sensors::SensorPtr sensorExtremeBarrel =
-    sensors::get_sensor(cameraNameExtremeBarrel);
-  sensors::CameraSensorPtr camSensorExtremeBarrel =
-    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
+    sensors::SensorPtr sensorExtremeBarrel =
+      sensors::get_sensor(cameraNameExtremeBarrel);
+    sensors::CameraSensorPtr camSensorExtremeBarrel =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
 
-  sensors::SensorPtr sensorExtremePincushion =
-    sensors::get_sensor(cameraNameExtremePincushion);
-  sensors::CameraSensorPtr camSensorExtremePincushion =
-    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorExtremePincushion);
+    sensors::SensorPtr sensorExtremePincushion =
+      sensors::get_sensor(cameraNameExtremePincushion);
+    sensors::CameraSensorPtr camSensorExtremePincushion =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorExtremePincushion);
 
-  imageCount = 0;
-  imageCount2 = 0;
-  imageCount3 = 0;
-  imageCount4 = 0;
-  imageCount5 = 0;
-  imageCount6 = 0;
-  img = new unsigned char[width * height*3];
-  img2 = new unsigned char[width * height*3];
-  img3 = new unsigned char[width * height*3];
-  img4 = new unsigned char[width * height*3];
-  img5 = new unsigned char[width * height*3];
-  img6 = new unsigned char[width * height*3];
-  event::ConnectionPtr c =
-    camSensorUndistorted->Camera()->ConnectNewImageFrame(
-        std::bind(&::OnNewCameraFrame, &imageCount, img,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5));
-  event::ConnectionPtr c2 =
-    camSensorFlat->Camera()->ConnectNewImageFrame(
-        std::bind(&::OnNewCameraFrame, &imageCount2, img2,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5));
-  event::ConnectionPtr c3 =
-    camSensorBarrel->Camera()->ConnectNewImageFrame(
-        std::bind(&::OnNewCameraFrame, &imageCount3, img3,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5));
-  event::ConnectionPtr c4 =
-    camSensorPincushion->Camera()->ConnectNewImageFrame(
-        std::bind(&::OnNewCameraFrame, &imageCount4, img4,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5));
-  event::ConnectionPtr c5 =
-    camSensorExtremeBarrel->Camera()->ConnectNewImageFrame(
-        std::bind(&::OnNewCameraFrame, &imageCount5, img5,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5));
-  event::ConnectionPtr c6 =
-    camSensorExtremePincushion->Camera()->ConnectNewImageFrame(
-        std::bind(&::OnNewCameraFrame, &imageCount6, img6,
-          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-          std::placeholders::_4, std::placeholders::_5));
+    imageCount = 0;
+    imageCount2 = 0;
+    imageCount3 = 0;
+    imageCount4 = 0;
+    imageCount5 = 0;
+    imageCount6 = 0;
+    img = new unsigned char[width * height*3];
+    img2 = new unsigned char[width * height*3];
+    img3 = new unsigned char[width * height*3];
+    img4 = new unsigned char[width * height*3];
+    img5 = new unsigned char[width * height*3];
+    img6 = new unsigned char[width * height*3];
+    event::ConnectionPtr c =
+      camSensorUndistorted->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount, img,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    event::ConnectionPtr c2 =
+      camSensorFlat->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount2, img2,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    event::ConnectionPtr c3 =
+      camSensorBarrel->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount3, img3,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    event::ConnectionPtr c4 =
+      camSensorPincushion->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount4, img4,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    event::ConnectionPtr c5 =
+      camSensorExtremeBarrel->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount5, img5,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
+    event::ConnectionPtr c6 =
+      camSensorExtremePincushion->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount6, img6,
+            std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+            std::placeholders::_4, std::placeholders::_5));
 
-  // Get some images
-  while (imageCount < 10 || imageCount2 < 10 ||
-      imageCount3 < 10 || imageCount4 < 10 ||
-      imageCount5 < 10 || imageCount6 < 10)
-  {
-    common::Time::MSleep(10);
-  }
-
-  unsigned int diffMax = 0, diffSum = 0;
-  double diffAvg = 0.0;
-
-  // We expect that there will be some non-zero difference between the images,
-  // except for the 0.0 distortion camera, which should return a completely
-  // identical camera to the one with no distortion tag in the SDF.
-
-  this->ImageCompare(img, img2, width, height, 3,
-                     diffMax, diffSum, diffAvg);
-  EXPECT_EQ(diffSum, 0u);
-
-  this->ImageCompare(img, img3, width, height, 3,
-                     diffMax, diffSum, diffAvg);
-  EXPECT_NE(diffSum, 0u);
-
-  this->ImageCompare(img, img4, width, height, 3,
-                     diffMax, diffSum, diffAvg);
-  EXPECT_NE(diffSum, 0u);
-
-  this->ImageCompare(img3, img4, width, height, 3,
-                     diffMax, diffSum, diffAvg);
-  EXPECT_NE(diffSum, 0u);
-
-  this->ImageCompare(img, img5, width, height, 3,
-                     diffMax, diffSum, diffAvg);
-  EXPECT_NE(diffSum, 0u);
-
-  this->ImageCompare(img3, img6, width, height, 3,
-                     diffMax, diffSum, diffAvg);
-  EXPECT_NE(diffSum, 0u);
-
-  // Compare colors. Barrel distorted image should have more darker pixels than
-  // the original as the ground plane has been warped to occupy more of the
-  // image. The same should be true for pincushion distortion, because the
-  // ground plane is still distorted to be larger - just different parts
-  // of the image are distorted.
-  unsigned int colorSum = 0;
-  unsigned int colorSum3 = 0;
-  unsigned int colorSum4 = 0;
-  unsigned int colorSum5 = 0;
-  unsigned int colorSum6 = 0;
-  for (unsigned int y = 0; y < height; ++y)
-  {
-    for (unsigned int x = 0; x < width*3; x+=3)
+    // Get some images
+    while (imageCount < 10 || imageCount2 < 10 ||
+        imageCount3 < 10 || imageCount4 < 10 ||
+        imageCount5 < 10 || imageCount6 < 10)
     {
-      unsigned int r = img[(y*width*3) + x];
-      unsigned int g = img[(y*width*3) + x + 1];
-      unsigned int b = img[(y*width*3) + x + 2];
-      colorSum += r + g + b;
-      unsigned int r3 = img3[(y*width*3) + x];
-      unsigned int g3 = img3[(y*width*3) + x + 1];
-      unsigned int b3 = img3[(y*width*3) + x + 2];
-      colorSum3 += r3 + g3 + b3;
-      unsigned int r4 = img4[(y*width*3) + x];
-      unsigned int g4 = img4[(y*width*3) + x + 1];
-      unsigned int b4 = img4[(y*width*3) + x + 2];
-      colorSum4 += r4 + g4 + b4;
-      unsigned int r5 = img5[(y*width*3) + x];
-      unsigned int g5 = img5[(y*width*3) + x + 1];
-      unsigned int b5 = img5[(y*width*3) + x + 2];
-      colorSum5 += r5 + g5 + b5;
-      unsigned int r6 = img6[(y*width*3) + x];
-      unsigned int g6 = img6[(y*width*3) + x + 1];
-      unsigned int b6 = img6[(y*width*3) + x + 2];
-      colorSum6 += r6 + g6 + b6;
+      common::Time::MSleep(10);
     }
-  }
-  EXPECT_GT(colorSum, colorSum3);
-  EXPECT_GT(colorSum, colorSum4);
-  EXPECT_GT(colorSum, colorSum5);
-  EXPECT_GT(colorSum, colorSum6);
 
-  delete[] img;
-  delete[] img2;
-  delete[] img3;
-  delete[] img4;
-  delete[] img5;
-  delete[] img6;
+    unsigned int diffMax = 0, diffSum = 0;
+    double diffAvg = 0.0;
+
+    // We expect that there will be some non-zero difference between the images,
+    // except for the 0.0 distortion camera, which should return a completely
+    // identical camera to the one with no distortion tag in the SDF.
+
+    this->ImageCompare(img, img2, width, height, 3,
+                      diffMax, diffSum, diffAvg);
+    EXPECT_EQ(diffSum, 0u);
+
+    this->ImageCompare(img, img3, width, height, 3,
+                      diffMax, diffSum, diffAvg);
+    EXPECT_NE(diffSum, 0u);
+
+    this->ImageCompare(img, img4, width, height, 3,
+                      diffMax, diffSum, diffAvg);
+    EXPECT_NE(diffSum, 0u);
+
+    this->ImageCompare(img3, img4, width, height, 3,
+                      diffMax, diffSum, diffAvg);
+    EXPECT_NE(diffSum, 0u);
+
+    this->ImageCompare(img, img5, width, height, 3,
+                      diffMax, diffSum, diffAvg);
+    EXPECT_NE(diffSum, 0u);
+
+    this->ImageCompare(img3, img6, width, height, 3,
+                      diffMax, diffSum, diffAvg);
+    EXPECT_NE(diffSum, 0u);
+
+    // Compare colors. Barrel distorted image should have more darker pixels than
+    // the original as the ground plane has been warped to occupy more of the
+    // image. The same should be true for pincushion distortion, because the
+    // ground plane is still distorted to be larger - just different parts
+    // of the image are distorted.
+    unsigned int colorSum = 0;
+    unsigned int colorSum3 = 0;
+    unsigned int colorSum4 = 0;
+    unsigned int colorSum5 = 0;
+    unsigned int colorSum6 = 0;
+    for (unsigned int y = 0; y < height; ++y)
+    {
+      for (unsigned int x = 0; x < width*3; x+=3)
+      {
+        unsigned int r = img[(y*width*3) + x];
+        unsigned int g = img[(y*width*3) + x + 1];
+        unsigned int b = img[(y*width*3) + x + 2];
+        colorSum += r + g + b;
+        unsigned int r3 = img3[(y*width*3) + x];
+        unsigned int g3 = img3[(y*width*3) + x + 1];
+        unsigned int b3 = img3[(y*width*3) + x + 2];
+        colorSum3 += r3 + g3 + b3;
+        unsigned int r4 = img4[(y*width*3) + x];
+        unsigned int g4 = img4[(y*width*3) + x + 1];
+        unsigned int b4 = img4[(y*width*3) + x + 2];
+        colorSum4 += r4 + g4 + b4;
+        unsigned int r5 = img5[(y*width*3) + x];
+        unsigned int g5 = img5[(y*width*3) + x + 1];
+        unsigned int b5 = img5[(y*width*3) + x + 2];
+        colorSum5 += r5 + g5 + b5;
+        unsigned int r6 = img6[(y*width*3) + x];
+        unsigned int g6 = img6[(y*width*3) + x + 1];
+        unsigned int b6 = img6[(y*width*3) + x + 2];
+        colorSum6 += r6 + g6 + b6;
+      }
+    }
+    EXPECT_GT(colorSum, colorSum3);
+    EXPECT_GT(colorSum, colorSum4);
+    EXPECT_GT(colorSum, colorSum5);
+    EXPECT_GT(colorSum, colorSum6);
+
+    delete[] img;
+    delete[] img2;
+    delete[] img3;
+    delete[] img4;
+    delete[] img5;
+    delete[] img6;
+  }
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2199,7 +2199,7 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
   unsigned int cornerColorSumImg4 = img4[0] + img4[1] + img4[2];
   EXPECT_EQ(cornerColorSumImg4, 192u);
 
-  auto getFirstColIdxOfMineCart = [middleRow, width](const unsigned char* img)
+  auto getFirstColIdxOfMineCart = [](const unsigned char* img)
   {
     for (unsigned int x = 0; x < width*3; x+=3)
     {

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2209,7 +2209,7 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
         return x;
       }
     }
-    return width-1;
+    return (width-1) * 3;
   };
 
   // Check mine cart location meets expectations

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -733,30 +733,30 @@ TEST_F(CameraSensor, CheckDistortion)
       ignition::math::Vector3d(-5, 0, 5),
       ignition::math::Quaterniond(0, IGN_DTOR(15), 0));
 
-  for (auto isUseRealDistortion: {true, false}) {
+  for (auto isUseLegacyDistortionMode: {true, false}) {
     // spawn an undistorted camera
     SpawnCamera(modelNameUndistorted, cameraNameUndistorted, setPose.Pos(),
         setPose.Rot().Euler(), width, height, updateRate);
     // spawn a flat camera
     SpawnCamera(modelNameFlat, cameraNameFlat, setPose.Pos(),
         setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, 0, 0, 0, 0, 0, 0.5, 0.5, isUseRealDistortion);
+        "", 0, 0, true, 0, 0, 0, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
     // spawn a camera with barrel distortion
     SpawnCamera(modelNameBarrel, cameraNameBarrel, setPose.Pos(),
         setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, -0.1349, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
+        "", 0, 0, true, -0.1349, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
     // spawn a camera with pincushion distortion
     SpawnCamera(modelNamePincushion, cameraNamePincushion, setPose.Pos(),
         setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, 0.1349, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
+        "", 0, 0, true, 0.1349, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
     // spawn a camera with extreme barrel distortion
     SpawnCamera(modelNameExtremeBarrel, cameraNameExtremeBarrel, setPose.Pos(),
         setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, -0.5, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
+        "", 0, 0, true, -0.5, -0.51868, -0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
     // spawn a camera with extreme pincushion distortion
     SpawnCamera(modelNameExtremePincushion, cameraNameExtremePincushion,
         setPose.Pos(), setPose.Rot().Euler(), width, height, updateRate,
-        "", 0, 0, true, 0.5, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseRealDistortion);
+        "", 0, 0, true, 0.5, 0.51868, 0.001, 0, 0, 0.5, 0.5, isUseLegacyDistortionMode);
 
     sensors::SensorPtr sensorUndistorted =
       sensors::get_sensor(cameraNameUndistorted);
@@ -781,7 +781,7 @@ TEST_F(CameraSensor, CheckDistortion)
     sensors::SensorPtr sensorExtremeBarrel =
       sensors::get_sensor(cameraNameExtremeBarrel);
     sensors::CameraSensorPtr camSensorExtremeBarrel =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensorExtremeBarrel);
 
     sensors::SensorPtr sensorExtremePincushion =
       sensors::get_sensor(cameraNameExtremePincushion);
@@ -2110,4 +2110,231 @@ TEST_F(CameraSensor, SetCompositorNames)
     delete [] img;
   }
 #endif
+}
+
+/////////////////////////////////////////////////
+TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
+{
+  Load("worlds/test/issue_3003_distortion_implementation_correction.world");
+
+  // Make sure the render engine is available.
+  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
+      rendering::RenderEngine::NONE)
+  {
+    gzerr << "No rendering engine, unable to run camera test\n";
+    return;
+  }
+
+  // Spawn cameras.
+  std::string modelNameBarrelLegacy = "camera_model_barrel_legacy";
+  std::string cameraNameBarrelLegacy = "camera_sensor_barrel_legacy";
+  std::string modelNameBarrelNew = "camera_model_barrel_new";
+  std::string cameraNameBarrelNew = "camera_sensor_barrel_new";
+
+  std::string modelNamePincushionLegacy = "camera_model_pincushion_legacy";
+  std::string cameraNamePincushionLegacy = "camera_sensor_pincushion_legacy";
+  std::string modelNamePincushionNew = "camera_model_pincushion_new";
+  std::string cameraNamePincushionNew = "camera_sensor_pincushion_new";
+  unsigned int width  = 160;
+  unsigned int height = 120;
+  double updateRate = 10;
+  ignition::math::Pose3d setPose(
+      ignition::math::Vector3d(0.5, 0, 0),
+      ignition::math::Quaterniond(0, 0, 0));
+
+  double horizontalFov = 1.6;
+
+  // spawn a camera with  pincushion distortion
+  SpawnCamera(modelNamePincushionLegacy, cameraNamePincushionLegacy,
+      setPose.Pos(), setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, 0.5, 0, 0, 0, 0, 0.5, 0.5,
+      true, horizontalFov);
+  SpawnCamera(modelNamePincushionNew, cameraNamePincushionNew,
+      setPose.Pos(), setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, 0.5, 0, 0, 0, 0, 0.5, 0.5,
+      false, horizontalFov);
+  // spawn a camera with barrel distortion
+  SpawnCamera(modelNameBarrelLegacy, cameraNameBarrelLegacy, setPose.Pos(),
+      setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, -0.5, 0, 0, 0, 0, 0.5, 0.5,
+      true, horizontalFov);
+  SpawnCamera(modelNameBarrelNew, cameraNameBarrelNew, setPose.Pos(),
+      setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, -0.5, 0, 0, 0, 0, 0.5, 0.5,
+      false, horizontalFov);
+
+  sensors::SensorPtr sensorPincushionLegacy =
+    sensors::get_sensor(cameraNamePincushionLegacy);
+  sensors::CameraSensorPtr camSensorPincushionLegacy =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorPincushionLegacy);
+  sensors::SensorPtr sensorPincushionNew =
+    sensors::get_sensor(cameraNamePincushionNew);
+  sensors::CameraSensorPtr camSensorPincushionNew =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorPincushionNew);
+
+  sensors::SensorPtr sensorBarrelLegacy =
+    sensors::get_sensor(cameraNameBarrelLegacy);
+  sensors::CameraSensorPtr camSensorBarrelLegacy =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrelLegacy);
+  sensors::SensorPtr sensorBarrelNew =
+    sensors::get_sensor(cameraNameBarrelNew);
+  sensors::CameraSensorPtr camSensorBarrelNew =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrelNew);
+
+  imageCount = 0;
+  imageCount2 = 0;
+  imageCount3 = 0;
+  imageCount4 = 0;
+
+  img = new unsigned char[width * height*3];
+  img2 = new unsigned char[width * height*3];
+  img3 = new unsigned char[width * height*3];
+  img4 = new unsigned char[width * height*3];
+
+
+  event::ConnectionPtr c1 =
+    camSensorPincushionLegacy->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount, img,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c2 =
+    camSensorPincushionNew->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount2, img2,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c3 =
+    camSensorBarrelLegacy->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount3, img3,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c4 =
+    camSensorBarrelNew->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount4, img4,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+
+  // Get some images
+  while (
+    imageCount < 10 || imageCount2 < 10 ||
+    imageCount3 < 10 || imageCount4 < 10)
+  {
+    common::Time::MSleep(10);
+  }
+
+  // Compare colors. Barrel distorted image should have more darker pixels than
+  // the original as the ground plane has been warped to occupy more of the
+  // image. The same should be true for pincushion distortion, because the
+  // ground plane is still distorted to be larger - just different parts
+  // of the image are distorted.
+  unsigned int colorSum1 = 0;
+  unsigned int colorSum2 = 0;
+  unsigned int colorSum3 = 0;
+  unsigned int colorSum4 = 0;
+  unsigned int dumpsterRow = height / 2;
+  for (unsigned int x = 0; x < width*3; x+=3)
+  {
+    unsigned int r1 = img[(dumpsterRow*width*3) + x];
+    unsigned int g1 = img[(dumpsterRow*width*3) + x + 1];
+    unsigned int b1 = img[(dumpsterRow*width*3) + x + 2];
+    colorSum1 += r1 + g1 + b1;
+    unsigned int r2 = img2[(dumpsterRow*width*3) + x];
+    unsigned int g2 = img2[(dumpsterRow*width*3) + x + 1];
+    unsigned int b2 = img2[(dumpsterRow*width*3) + x + 2];
+    colorSum2 += r2 + g2 + b2;
+    unsigned int r3 = img3[(dumpsterRow*width*3) + x];
+    unsigned int g3 = img3[(dumpsterRow*width*3) + x + 1];
+    unsigned int b3 = img3[(dumpsterRow*width*3) + x + 2];
+    colorSum3 += r3 + g3 + b3;
+    unsigned int r4 = img4[(dumpsterRow*width*3) + x];
+    unsigned int g4 = img4[(dumpsterRow*width*3) + x + 1];
+    unsigned int b4 = img4[(dumpsterRow*width*3) + x + 2];
+    colorSum4 += r4 + g4 + b4;
+  }
+
+  // Check that the legacy mode distorts the pincuchin images less
+  EXPECT_GT(colorSum1, colorSum2+800);
+  // Check that there is a good difference in the barrel images
+  // this difference is largely caused by the edges of the new
+  // distortion model which appear gray when they have no value
+  // and gray (192) has a much lower value than white (765)
+  EXPECT_GT(colorSum3, colorSum4+20000);
+
+  // Check that no cropping occurs - specifically the corners
+  // in both image should be white and have a value of 765=255*3
+  // since the background of the environment is white
+  unsigned int cornerColorSumImg1 = img[0] + img[1] + img[2];
+  unsigned int cornerColorSumImg2 = img2[0] + img2[1] + img2[2];
+  unsigned int cornerColorSumImg3 = img3[0] + img3[1] + img3[2];
+  EXPECT_EQ(cornerColorSumImg1, 765u);
+  EXPECT_EQ(cornerColorSumImg2, 765u);
+  EXPECT_EQ(cornerColorSumImg3, 765u);
+  // Check that cropping occurs - specifically the corners
+  // in both image should be white and have a value of 192,
+  // which is the gray for pixels that haven't been assigned
+  unsigned int cornerColorSumImg4 = img4[0] + img4[1] + img4[2];
+  EXPECT_EQ(cornerColorSumImg4, 192u);
+
+  // Check dumpster location meets expectations
+  unsigned int idxOfFirstDumpsterPixelImg1 = 0;
+  unsigned int idxOfFirstDumpsterPixelImg2 = 0;
+  unsigned int idxOfFirstDumpsterPixelImg3 = 0;
+  unsigned int idxOfFirstDumpsterPixelImg4 = 0;
+  for (unsigned int x = 0; x < width*3; x+=3)
+  {
+    unsigned int r1 = img[(dumpsterRow*width*3) + x];
+    unsigned int g1 = img[(dumpsterRow*width*3) + x + 1];
+    unsigned int b1 = img[(dumpsterRow*width*3) + x + 2];
+    unsigned int pixelSum = r1 + g1 + b1;
+    if (pixelSum != 765u && pixelSum != 192u) {
+      idxOfFirstDumpsterPixelImg1 = x;
+      break;
+    }
+  }
+  for (unsigned int x = 0; x < width*3; x+=3)
+  {
+    unsigned int r2 = img2[(dumpsterRow*width*3) + x];
+    unsigned int g2 = img2[(dumpsterRow*width*3) + x + 1];
+    unsigned int b2 = img2[(dumpsterRow*width*3) + x + 2];
+    unsigned int pixelSum = r2 + g2 + b2;
+    if (pixelSum != 765u && pixelSum != 192u) {
+      idxOfFirstDumpsterPixelImg2 = x;
+      break;
+    }
+  }
+  for (unsigned int x = 0; x < width*3; x+=3)
+  {
+    unsigned int r3 = img3[(dumpsterRow*width*3) + x];
+    unsigned int g3 = img3[(dumpsterRow*width*3) + x + 1];
+    unsigned int b3 = img3[(dumpsterRow*width*3) + x + 2];
+    unsigned int pixelSum = r3 + g3 + b3;
+    if (pixelSum != 765u && pixelSum != 192u) {
+      idxOfFirstDumpsterPixelImg3 = x;
+      break;
+    }
+  }
+  for (unsigned int x = 0; x < width*3; x+=3)
+  {
+    unsigned int r4 = img4[(dumpsterRow*width*3) + x];
+    unsigned int g4 = img4[(dumpsterRow*width*3) + x + 1];
+    unsigned int b4 = img4[(dumpsterRow*width*3) + x + 2];
+    unsigned int pixelSum = r4 + g4 + b4;
+    if (pixelSum != 765u && pixelSum != 192u) {
+      idxOfFirstDumpsterPixelImg4 = x;
+      break;
+    }
+  }
+  // Check that, in the pin cushion case, the dumpster is seen closer to the
+  // left in the new version. This makes sense as the new distortion mode
+  // should have more significant distortion than the legacy mode.
+  ASSERT_GT(idxOfFirstDumpsterPixelImg1, idxOfFirstDumpsterPixelImg2+15);
+  // Check that, in the barrel case, the dumpster is seen closer to the left
+  // in the legacy distortion mode than in the new mode. This makes sense
+  // because the legacy mode crops the image removing the edges where there
+  // is no image information.
+  ASSERT_LT(idxOfFirstDumpsterPixelImg3, idxOfFirstDumpsterPixelImg4-25);
+
+  delete[] img;
+  delete[] img2;
+  delete[] img3;
+  delete[] img4;
 }

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2056,23 +2056,22 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
   }
 
   // Spawn cameras.
-  std::string modelNameBarrelLegacy = "camera_model_barrel_legacy";
-  std::string cameraNameBarrelLegacy = "camera_sensor_barrel_legacy";
-  std::string modelNameBarrelNew = "camera_model_barrel_new";
-  std::string cameraNameBarrelNew = "camera_sensor_barrel_new";
+  const std::string modelNameBarrelLegacy = "camera_model_barrel_legacy";
+  const std::string cameraNameBarrelLegacy = "camera_sensor_barrel_legacy";
+  const std::string modelNameBarrelNew = "camera_model_barrel_new";
+  const std::string cameraNameBarrelNew = "camera_sensor_barrel_new";
 
-  std::string modelNamePincushionLegacy = "camera_model_pincushion_legacy";
-  std::string cameraNamePincushionLegacy = "camera_sensor_pincushion_legacy";
-  std::string modelNamePincushionNew = "camera_model_pincushion_new";
-  std::string cameraNamePincushionNew = "camera_sensor_pincushion_new";
-  unsigned int width  = 160;
-  unsigned int height = 120;
-  double updateRate = 10;
-  ignition::math::Pose3d setPose(
+  const std::string modelNamePincushionLegacy = "camera_model_pincushion_legacy";
+  const std::string cameraNamePincushionLegacy = "camera_sensor_pincushion_legacy";
+  const std::string modelNamePincushionNew = "camera_model_pincushion_new";
+  const std::string cameraNamePincushionNew = "camera_sensor_pincushion_new";
+  const unsigned int width  = 160;
+  const unsigned int height = 120;
+  const double updateRate = 10;
+  const ignition::math::Pose3d setPose(
       ignition::math::Vector3d(0.5, 0, 0),
       ignition::math::Quaterniond(0, 0, 0));
-
-  double horizontalFov = 1.6;
+  const double horizontalFov = 1.6;
 
   // spawn a camera with  pincushion distortion
   SpawnCamera(modelNamePincushionLegacy, cameraNamePincushionLegacy,
@@ -2150,37 +2149,32 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
     common::Time::MSleep(10);
   }
 
-  // Compare colors. Barrel distorted image should have more darker pixels than
-  // the original as the ground plane has been warped to occupy more of the
-  // image. The same should be true for pincushion distortion, because the
-  // ground plane is still distorted to be larger - just different parts
-  // of the image are distorted.
   unsigned int colorSum1 = 0;
   unsigned int colorSum2 = 0;
   unsigned int colorSum3 = 0;
   unsigned int colorSum4 = 0;
-  unsigned int dumpsterRow = height / 2;
+  const unsigned int middleRow = height / 2;
   for (unsigned int x = 0; x < width*3; x+=3)
   {
-    unsigned int r1 = img[(dumpsterRow*width*3) + x];
-    unsigned int g1 = img[(dumpsterRow*width*3) + x + 1];
-    unsigned int b1 = img[(dumpsterRow*width*3) + x + 2];
+    unsigned int r1 = img[(middleRow*width*3) + x];
+    unsigned int g1 = img[(middleRow*width*3) + x + 1];
+    unsigned int b1 = img[(middleRow*width*3) + x + 2];
     colorSum1 += r1 + g1 + b1;
-    unsigned int r2 = img2[(dumpsterRow*width*3) + x];
-    unsigned int g2 = img2[(dumpsterRow*width*3) + x + 1];
-    unsigned int b2 = img2[(dumpsterRow*width*3) + x + 2];
+    unsigned int r2 = img2[(middleRow*width*3) + x];
+    unsigned int g2 = img2[(middleRow*width*3) + x + 1];
+    unsigned int b2 = img2[(middleRow*width*3) + x + 2];
     colorSum2 += r2 + g2 + b2;
-    unsigned int r3 = img3[(dumpsterRow*width*3) + x];
-    unsigned int g3 = img3[(dumpsterRow*width*3) + x + 1];
-    unsigned int b3 = img3[(dumpsterRow*width*3) + x + 2];
+    unsigned int r3 = img3[(middleRow*width*3) + x];
+    unsigned int g3 = img3[(middleRow*width*3) + x + 1];
+    unsigned int b3 = img3[(middleRow*width*3) + x + 2];
     colorSum3 += r3 + g3 + b3;
-    unsigned int r4 = img4[(dumpsterRow*width*3) + x];
-    unsigned int g4 = img4[(dumpsterRow*width*3) + x + 1];
-    unsigned int b4 = img4[(dumpsterRow*width*3) + x + 2];
+    unsigned int r4 = img4[(middleRow*width*3) + x];
+    unsigned int g4 = img4[(middleRow*width*3) + x + 1];
+    unsigned int b4 = img4[(middleRow*width*3) + x + 2];
     colorSum4 += r4 + g4 + b4;
   }
 
-  // Check that the legacy mode distorts the pincuchin images less
+  // Check that the legacy mode distorts the pincushion images less
   EXPECT_GT(colorSum1, colorSum2+800);
   // Check that there is a good difference in the barrel images
   // this difference is largely caused by the edges of the new
@@ -2188,79 +2182,51 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
   // and gray (192) has a much lower value than white (765)
   EXPECT_GT(colorSum3, colorSum4+20000);
 
-  // Check that no cropping occurs - specifically the corners
-  // in both image should be white and have a value of 765=255*3
-  // since the background of the environment is white
+  // Check that the corners contain rendered pixels.
+  // Specifically, the corners in each image should be white and
+  // have a value of 765=255*3 since the background of the environment
+  // is white
   unsigned int cornerColorSumImg1 = img[0] + img[1] + img[2];
   unsigned int cornerColorSumImg2 = img2[0] + img2[1] + img2[2];
   unsigned int cornerColorSumImg3 = img3[0] + img3[1] + img3[2];
   EXPECT_EQ(cornerColorSumImg1, 765u);
   EXPECT_EQ(cornerColorSumImg2, 765u);
   EXPECT_EQ(cornerColorSumImg3, 765u);
-  // Check that cropping occurs - specifically the corners
-  // in both image should be white and have a value of 192,
-  // which is the gray for pixels that haven't been assigned
+  // Check that this image is not cropped and that the corner pixel
+  // has the gray value assigned to unrendered pixels
   unsigned int cornerColorSumImg4 = img4[0] + img4[1] + img4[2];
   EXPECT_EQ(cornerColorSumImg4, 192u);
 
-  // Check dumpster location meets expectations
-  unsigned int idxOfFirstDumpsterPixelImg1 = 0;
-  unsigned int idxOfFirstDumpsterPixelImg2 = 0;
-  unsigned int idxOfFirstDumpsterPixelImg3 = 0;
-  unsigned int idxOfFirstDumpsterPixelImg4 = 0;
-  for (unsigned int x = 0; x < width*3; x+=3)
+  auto getFirstColIdxOfMineCart = [middleRow, width](const unsigned char* img)
   {
-    unsigned int r1 = img[(dumpsterRow*width*3) + x];
-    unsigned int g1 = img[(dumpsterRow*width*3) + x + 1];
-    unsigned int b1 = img[(dumpsterRow*width*3) + x + 2];
-    unsigned int pixelSum = r1 + g1 + b1;
-    if (pixelSum != 765u && pixelSum != 192u) {
-      idxOfFirstDumpsterPixelImg1 = x;
-      break;
+    for (unsigned int x = 0; x < width*3; x+=3)
+    {
+      const unsigned int r = img[(middleRow*width*3) + x];
+      const unsigned int g = img[(middleRow*width*3) + x + 1];
+      const unsigned int b = img[(middleRow*width*3) + x + 2];
+      const unsigned int pixelSum = r + g + b;
+      if (pixelSum != 765u && pixelSum != 192u) {
+        return x;
+      }
     }
-  }
-  for (unsigned int x = 0; x < width*3; x+=3)
-  {
-    unsigned int r2 = img2[(dumpsterRow*width*3) + x];
-    unsigned int g2 = img2[(dumpsterRow*width*3) + x + 1];
-    unsigned int b2 = img2[(dumpsterRow*width*3) + x + 2];
-    unsigned int pixelSum = r2 + g2 + b2;
-    if (pixelSum != 765u && pixelSum != 192u) {
-      idxOfFirstDumpsterPixelImg2 = x;
-      break;
-    }
-  }
-  for (unsigned int x = 0; x < width*3; x+=3)
-  {
-    unsigned int r3 = img3[(dumpsterRow*width*3) + x];
-    unsigned int g3 = img3[(dumpsterRow*width*3) + x + 1];
-    unsigned int b3 = img3[(dumpsterRow*width*3) + x + 2];
-    unsigned int pixelSum = r3 + g3 + b3;
-    if (pixelSum != 765u && pixelSum != 192u) {
-      idxOfFirstDumpsterPixelImg3 = x;
-      break;
-    }
-  }
-  for (unsigned int x = 0; x < width*3; x+=3)
-  {
-    unsigned int r4 = img4[(dumpsterRow*width*3) + x];
-    unsigned int g4 = img4[(dumpsterRow*width*3) + x + 1];
-    unsigned int b4 = img4[(dumpsterRow*width*3) + x + 2];
-    unsigned int pixelSum = r4 + g4 + b4;
-    if (pixelSum != 765u && pixelSum != 192u) {
-      idxOfFirstDumpsterPixelImg4 = x;
-      break;
-    }
-  }
-  // Check that, in the pin cushion case, the dumpster is seen closer to the
+    return width-1;
+  };
+
+  // Check mine cart location meets expectations
+  const unsigned int idxOfFirstMineCartPixelImg1 = getFirstColIdxOfMineCart(img);
+  const unsigned int idxOfFirstMineCartPixelImg2 = getFirstColIdxOfMineCart(img2);
+  const unsigned int idxOfFirstMineCartPixelImg3 = getFirstColIdxOfMineCart(img3);
+  const unsigned int idxOfFirstMineCartPixelImg4 = getFirstColIdxOfMineCart(img4);
+
+  // Check that, in the pin cushion case, the mine cart is seen closer to the
   // left in the new version. This makes sense as the new distortion mode
   // should have more significant distortion than the legacy mode.
-  ASSERT_GT(idxOfFirstDumpsterPixelImg1, idxOfFirstDumpsterPixelImg2+15);
-  // Check that, in the barrel case, the dumpster is seen closer to the left
+  EXPECT_GT(idxOfFirstMineCartPixelImg1, idxOfFirstMineCartPixelImg2+15);
+  // Check that, in the barrel case, the mine cart is seen closer to the left
   // in the legacy distortion mode than in the new mode. This makes sense
   // because the legacy mode crops the image removing the edges where there
   // is no image information.
-  ASSERT_LT(idxOfFirstDumpsterPixelImg3, idxOfFirstDumpsterPixelImg4-25);
+  EXPECT_LT(idxOfFirstMineCartPixelImg3, idxOfFirstMineCartPixelImg4-25);
 
   delete[] img;
   delete[] img2;

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2061,8 +2061,10 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
   const std::string modelNameBarrelNew = "camera_model_barrel_new";
   const std::string cameraNameBarrelNew = "camera_sensor_barrel_new";
 
-  const std::string modelNamePincushionLegacy = "camera_model_pincushion_legacy";
-  const std::string cameraNamePincushionLegacy = "camera_sensor_pincushion_legacy";
+  const std::string modelNamePincushionLegacy =
+    "camera_model_pincushion_legacy";
+  const std::string cameraNamePincushionLegacy =
+    "camera_sensor_pincushion_legacy";
   const std::string modelNamePincushionNew = "camera_model_pincushion_new";
   const std::string cameraNamePincushionNew = "camera_sensor_pincushion_new";
   const unsigned int width  = 160;
@@ -2213,20 +2215,20 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
   };
 
   // Check mine cart location meets expectations
-  const unsigned int idxOfFirstMineCartPixelImg1 = getFirstColIdxOfMineCart(img);
-  const unsigned int idxOfFirstMineCartPixelImg2 = getFirstColIdxOfMineCart(img2);
-  const unsigned int idxOfFirstMineCartPixelImg3 = getFirstColIdxOfMineCart(img3);
-  const unsigned int idxOfFirstMineCartPixelImg4 = getFirstColIdxOfMineCart(img4);
+  const unsigned int mineCartColIdx1 = getFirstColIdxOfMineCart(img);
+  const unsigned int mineCartColIdx2 = getFirstColIdxOfMineCart(img2);
+  const unsigned int mineCartColIdx3 = getFirstColIdxOfMineCart(img3);
+  const unsigned int mineCartColIdx4 = getFirstColIdxOfMineCart(img4);
 
   // Check that, in the pin cushion case, the mine cart is seen closer to the
   // left in the new version. This makes sense as the new distortion mode
   // should have more significant distortion than the legacy mode.
-  EXPECT_GT(idxOfFirstMineCartPixelImg1, idxOfFirstMineCartPixelImg2+15);
+  EXPECT_GT(mineCartColIdx1, mineCartColIdx2+15);
   // Check that, in the barrel case, the mine cart is seen closer to the left
   // in the legacy distortion mode than in the new mode. This makes sense
   // because the legacy mode crops the image removing the edges where there
   // is no image information.
-  EXPECT_LT(idxOfFirstMineCartPixelImg3, idxOfFirstMineCartPixelImg4-25);
+  EXPECT_LT(mineCartColIdx3, mineCartColIdx4-25);
 
   delete[] img;
   delete[] img2;

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -40,10 +40,14 @@ unsigned char* img = NULL;
 unsigned char* img2 = NULL;
 unsigned char* img3 = NULL;
 unsigned char* img4 = NULL;
+unsigned char* img5 = NULL;
+unsigned char* img6 = NULL;
 int imageCount = 0;
 int imageCount2 = 0;
 int imageCount3 = 0;
 int imageCount4 = 0;
+int imageCount5 = 0;
+int imageCount6 = 0;
 std::string pixelFormat = "";
 
 // list of timestamped images used by the Timestamp test
@@ -704,10 +708,12 @@ TEST_F(CameraSensor, CheckDistortion)
     return;
   }
 
-  // Spawn 4 cameras. One has no distortion.
+  // Spawn 6 cameras. One has no distortion.
   // The second has distortion, but all the distortion parameters are set to 0.
   // The third has barrel (negative k1) distortion.
   // The fourth has pincushion (positive k1) distortion.
+  // The fifth has barrel (negative k1) distortion.
+  // The sixth has pincushion (positive k1) distortion.
   std::string modelNameUndistorted = "camera_model_undistorted";
   std::string cameraNameUndistorted = "camera_sensor_undistorted";
   std::string modelNameFlat = "camera_model_flat";
@@ -716,6 +722,10 @@ TEST_F(CameraSensor, CheckDistortion)
   std::string cameraNameBarrel = "camera_sensor_barrel";
   std::string modelNamePincushion = "camera_model_pincushion";
   std::string cameraNamePincushion = "camera_sensor_pincushion";
+  std::string modelNameExtremeBarrel = "camera_model_extreme_barrel";
+  std::string cameraNameExtremeBarrel = "camera_sensor_extreme_barrel";
+  std::string modelNameExtremePincushion = "camera_model_extreme_pincushion";
+  std::string cameraNameExtremePincushion = "camera_sensor_extreme_pincushion";
   unsigned int width  = 320;
   unsigned int height = 240;
   double updateRate = 10;
@@ -738,32 +748,57 @@ TEST_F(CameraSensor, CheckDistortion)
   SpawnCamera(modelNamePincushion, cameraNamePincushion, setPose.Pos(),
       setPose.Rot().Euler(), width, height, updateRate,
       "", 0, 0, true, 0.1349, 0.51868, 0.001, 0, 0, 0.5, 0.5);
+  // spawn a camera with extreme barrel distortion
+  SpawnCamera(modelNameExtremeBarrel, cameraNameExtremeBarrel, setPose.Pos(),
+      setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, -0.5, -0.51868, -0.001, 0, 0, 0.5, 0.5);
+  // spawn a camera with extreme pincushion distortion
+  SpawnCamera(modelNameExtremePincushion, cameraNameExtremePincushion,
+      setPose.Pos(), setPose.Rot().Euler(), width, height, updateRate,
+      "", 0, 0, true, 0.5, 0.51868, 0.001, 0, 0, 0.5, 0.5);
 
   sensors::SensorPtr sensorUndistorted =
     sensors::get_sensor(cameraNameUndistorted);
   sensors::CameraSensorPtr camSensorUndistorted =
     std::dynamic_pointer_cast<sensors::CameraSensor>(sensorUndistorted);
+
   sensors::SensorPtr sensorFlat =
     sensors::get_sensor(cameraNameFlat);
   sensors::CameraSensorPtr camSensorFlat =
     std::dynamic_pointer_cast<sensors::CameraSensor>(sensorFlat);
+
   sensors::SensorPtr sensorBarrel =
-      sensors::get_sensor(cameraNameBarrel);
+    sensors::get_sensor(cameraNameBarrel);
   sensors::CameraSensorPtr camSensorBarrel =
     std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
+
   sensors::SensorPtr sensorPincushion =
-      sensors::get_sensor(cameraNamePincushion);
+    sensors::get_sensor(cameraNamePincushion);
   sensors::CameraSensorPtr camSensorPincushion =
     std::dynamic_pointer_cast<sensors::CameraSensor>(sensorPincushion);
+
+  sensors::SensorPtr sensorExtremeBarrel =
+    sensors::get_sensor(cameraNameExtremeBarrel);
+  sensors::CameraSensorPtr camSensorExtremeBarrel =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorBarrel);
+
+  sensors::SensorPtr sensorExtremePincushion =
+    sensors::get_sensor(cameraNameExtremePincushion);
+  sensors::CameraSensorPtr camSensorExtremePincushion =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorExtremePincushion);
 
   imageCount = 0;
   imageCount2 = 0;
   imageCount3 = 0;
   imageCount4 = 0;
+  imageCount5 = 0;
+  imageCount6 = 0;
   img = new unsigned char[width * height*3];
   img2 = new unsigned char[width * height*3];
   img3 = new unsigned char[width * height*3];
   img4 = new unsigned char[width * height*3];
+  img5 = new unsigned char[width * height*3];
+  img6 = new unsigned char[width * height*3];
   event::ConnectionPtr c =
     camSensorUndistorted->Camera()->ConnectNewImageFrame(
         std::bind(&::OnNewCameraFrame, &imageCount, img,
@@ -784,10 +819,21 @@ TEST_F(CameraSensor, CheckDistortion)
         std::bind(&::OnNewCameraFrame, &imageCount4, img4,
           std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
           std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c5 =
+    camSensorExtremeBarrel->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount5, img5,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c6 =
+    camSensorExtremePincushion->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount6, img6,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
 
   // Get some images
   while (imageCount < 10 || imageCount2 < 10 ||
-      imageCount3 < 10 || imageCount4 < 10)
+      imageCount3 < 10 || imageCount4 < 10 ||
+      imageCount5 < 10 || imageCount6 < 10)
   {
     common::Time::MSleep(10);
   }
@@ -815,6 +861,14 @@ TEST_F(CameraSensor, CheckDistortion)
                      diffMax, diffSum, diffAvg);
   EXPECT_NE(diffSum, 0u);
 
+  this->ImageCompare(img, img5, width, height, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_NE(diffSum, 0u);
+
+  this->ImageCompare(img3, img6, width, height, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_NE(diffSum, 0u);
+
   // Compare colors. Barrel distorted image should have more darker pixels than
   // the original as the ground plane has been warped to occupy more of the
   // image. The same should be true for pincushion distortion, because the
@@ -823,6 +877,8 @@ TEST_F(CameraSensor, CheckDistortion)
   unsigned int colorSum = 0;
   unsigned int colorSum3 = 0;
   unsigned int colorSum4 = 0;
+  unsigned int colorSum5 = 0;
+  unsigned int colorSum6 = 0;
   for (unsigned int y = 0; y < height; ++y)
   {
     for (unsigned int x = 0; x < width*3; x+=3)
@@ -839,15 +895,27 @@ TEST_F(CameraSensor, CheckDistortion)
       unsigned int g4 = img4[(y*width*3) + x + 1];
       unsigned int b4 = img4[(y*width*3) + x + 2];
       colorSum4 += r4 + g4 + b4;
+      unsigned int r5 = img5[(y*width*3) + x];
+      unsigned int g5 = img5[(y*width*3) + x + 1];
+      unsigned int b5 = img5[(y*width*3) + x + 2];
+      colorSum5 += r5 + g5 + b5;
+      unsigned int r6 = img6[(y*width*3) + x];
+      unsigned int g6 = img6[(y*width*3) + x + 1];
+      unsigned int b6 = img6[(y*width*3) + x + 2];
+      colorSum6 += r6 + g6 + b6;
     }
   }
   EXPECT_GT(colorSum, colorSum3);
   EXPECT_GT(colorSum, colorSum4);
+  EXPECT_GT(colorSum, colorSum5);
+  EXPECT_GT(colorSum, colorSum6);
 
   delete[] img;
   delete[] img2;
   delete[] img3;
   delete[] img4;
+  delete[] img5;
+  delete[] img6;
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2191,7 +2191,6 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
   img3 = new unsigned char[width * height*3];
   img4 = new unsigned char[width * height*3];
 
-
   event::ConnectionPtr c1 =
     camSensorPincushionLegacy->Camera()->ConnectNewImageFrame(
         std::bind(&::OnNewCameraFrame, &imageCount, img,

--- a/worlds/test/issue_3003_distortion_implementation_correction.world
+++ b/worlds/test/issue_3003_distortion_implementation_correction.world
@@ -1,0 +1,65 @@
+<sdf version='1.7'>
+  <world name='default' xmlns:ignition='http://ignitionrobotics.org/schema'>
+    <scene>
+      <shadows>0</shadows>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>1 1 1 1</background>
+    </scene>
+    <model name='minecart'>
+      <static>1</static>
+      <link name='base_link'>
+        <collision name='collision'>
+          <geometry>
+            <mesh>
+              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/meshes/minecart.dae</uri>
+            </mesh>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='polySurface1278_visual'>
+          <geometry>
+            <mesh>
+              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/meshes/minecart.dae</uri>
+              <submesh>
+                <name>polySurface1278</name>
+                <center>0</center>
+              </submesh>
+            </mesh>
+          </geometry>
+          <material>
+            <diffuse>1 1 1 1</diffuse>
+            <specular>1 1 1 1</specular>
+            <pbr>
+              <metal>
+                <albedo_map>materials/textures/MineCart_Albedo.png</albedo_map>
+                <metalness_map>materials/textures/MineCart_Metalness.png</metalness_map>
+                <roughness_map>materials/textures/MineCart_Roughness.png</roughness_map>
+              </metal>
+            </pbr>
+            <script>
+              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/materials/scripts/</uri>
+              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/materials/textures/</uri>
+              <name>UrbanTile/MineCart_Diffuse</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>3 1 0 0 -0 0</pose>
+    </model>
+  </world>
+</sdf>

--- a/worlds/test/issue_3003_distortion_implementation_correction.world
+++ b/worlds/test/issue_3003_distortion_implementation_correction.world
@@ -11,7 +11,8 @@
         <collision name='collision'>
           <geometry>
             <mesh>
-              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/meshes/minecart.dae</uri>
+              <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/mine cart/4/files/meshes/minecart.dae
+</uri>
             </mesh>
           </geometry>
           <max_contacts>10</max_contacts>
@@ -31,7 +32,7 @@
         <visual name='polySurface1278_visual'>
           <geometry>
             <mesh>
-              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/meshes/minecart.dae</uri>
+              <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/mine cart/4/files/meshes/minecart.dae</uri>
               <submesh>
                 <name>polySurface1278</name>
                 <center>0</center>
@@ -49,8 +50,8 @@
               </metal>
             </pbr>
             <script>
-              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/materials/scripts/</uri>
-              <uri>/root/.ignition/fuel/fuel.ignitionrobotics.org/openrobotics/models/mine cart/4/materials/textures/</uri>
+              <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/mine cart/4/files/materials/scripts/</uri>
+              <uri>https://fuel.ignitionrobotics.org/1.0/openrobotics/models/mine cart/4/files/materials/textures/</uri>
               <name>UrbanTile/MineCart_Diffuse</name>
             </script>
           </material>


### PR DESCRIPTION
Fixes #3003.

Modifies how Brown's distortion equations are applied to better reflect real distortion. Image is projected from image plane to camera plane to apply distortion equations, then projected back to image plane.

Before/after focal scaling implementation:
![distortion_comparisons_gazebo](https://user-images.githubusercontent.com/19412869/119889653-b51b7680-beeb-11eb-9d62-7bb3a5aad43d.png)

Before/after extreme distortion edge case fix:
<img src="https://user-images.githubusercontent.com/6635382/119860667-6b229880-becb-11eb-82e4-fcb0731306f6.png" alt="before fix" width="300"/> <img src="https://user-images.githubusercontent.com/6635382/119860678-6eb61f80-becb-11eb-8159-595ad9154490.png" alt="after fix" width="300"/>

---

We use a tag `<ignition:legacy_mode>` in a distortion context to select this new behavior.

Regardless of if the new mode or legacy mode are used, this PR adds a bug fix for heavy distortions that prevents the distorted image from "folding back" on itself, as seen in the image above.