### PR TITLE
Build gazebo_test_fixture target when running make install

### DIFF
--- a/gazebo/test/CMakeLists.txt
+++ b/gazebo/test/CMakeLists.txt
@@ -8,3 +8,5 @@ gz_install_includes("test"
   ServerFixture.hh
   ${PROJECT_BINARY_DIR}/test_config.h
 )
+
+set_target_properties(gazebo_test_fixture PROPERTIES DEPENDS ALL)


### PR DESCRIPTION
When running `make install` without other commands `gazebo_test_fixture` is not build since no target needs it. That is triggering a failure since the install target will look for the library to be installed ([see Debian log](https://buildd.debian.org/status/fetch.php?pkg=gazebo&arch=all&ver=11.5.1%2Bdfsg-1&stamp=1621980186&file=log)).

The PR adds the target to the ALL target which is being used by install. 