### PR TITLE
Check for SDF files containing sibling elements of the same type with the same name (Gazebo9)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## Gazebo 9
 
+## Gazebo 9.18.0 (2021-06-xx)
+
+1. Enable output of gzerr for SDF sibling elements of same type with same name,
+   following the SDF 1.6 specification.
+   Environment variable GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS can be set to
+   use the previous behaviour and do not report these problems.
+    * []()
+
 ## Gazebo 9.17.0 (2021-04-21)
 
 1. Generate spot light shadow maps

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -30,6 +30,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
 
+#include <sdf/parser.hh>
 #include <sdf/sdf.hh>
 
 #include <ignition/math/Rand.hh>
@@ -69,6 +70,13 @@ namespace gazebo
 {
   struct ServerPrivate
   {
+    void InspectSDFElement(const sdf::ElementPtr _elem) {
+      if (! sdf::recursiveSameTypeUniqueNames(_elem)) {
+        gzerr << "SDF is not valid, see errors above. "
+              << "This can lead to an unexpected behaviour." << "\n";
+      }
+    }
+
     /// \brief Boolean used to stop the server.
     static bool stop;
 
@@ -446,6 +454,8 @@ bool Server::PreLoad()
 bool Server::LoadImpl(sdf::ElementPtr _elem,
                       const std::string &_physics)
 {
+  this->dataPtr->InspectSDFElement(_elem);
+
   // If a physics engine is specified,
   if (_physics.length())
   {

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -70,11 +70,14 @@ namespace gazebo
 {
   struct ServerPrivate
   {
-    void InspectSDFElement(const sdf::ElementPtr _elem) {
-      if (! sdf::recursiveSameTypeUniqueNames(_elem)) {
+    void InspectSDFElement(const sdf::ElementPtr _elem)
+    {
+      if (common::getEnv("GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS"))
+        return;
+
+      if (not sdf::recursiveSameTypeUniqueNames(_elem))
         gzerr << "SDF is not valid, see errors above. "
               << "This can lead to an unexpected behaviour." << "\n";
-      }
     }
 
     /// \brief Boolean used to stop the server.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -95,6 +95,7 @@ set(tests
   rest_web.cc
   saving_and_loading.cc
   sdf.cc
+  sdf_errors.cc
   sensor.cc
   server_fixture.cc
   sim_events.cc

--- a/test/integration/sdf_errors.cc
+++ b/test/integration/sdf_errors.cc
@@ -115,7 +115,11 @@ TEST_F(SDFLogsTest, DuplicateSiblingSameTypeDisabled)
   setenv("GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS", "", 1);
   Load("worlds/test_sdf16_err_sibling_same_type.world");
   EXPECT_NO_ERR_IN_LOG();
+#ifdef _WIN32
+ _putenv("GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS");
+#else
   unsetenv("GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS");
+#endif
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/sdf_errors.cc
+++ b/test/integration/sdf_errors.cc
@@ -68,9 +68,11 @@ class SDFLogsTest : public ServerFixture
       " was found in the log. The test does not expect it be there";
   }
 
-  public: void EXPECT_ERR_IN_LOG()
+  public: void EXPECT_SDF_ERR_IN_LOG()
   {
     EXPECT_LOG_STRING("[Err] ");
+    std::string sdfErrorString = "SDF is not valid";
+    EXPECT_LOG_STRING(sdfErrorString);
   }
 
   private: bool log_string_search(const std::string expected_text)
@@ -103,10 +105,7 @@ TEST_F(SDFLogsTest, EmptyWorldNoErrors)
 TEST_F(SDFLogsTest, DuplicateSiblingSameType)
 {
   Load("worlds/test_sdf16_err_sibling_same_type.world");
-
-  EXPECT_ERR_IN_LOG();
-  std::string sdfErrorString = "SDF is not valid";
-  EXPECT_LOG_STRING(sdfErrorString);
+  EXPECT_SDF_ERR_IN_LOG();
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/sdf_errors.cc
+++ b/test/integration/sdf_errors.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "gazebo/common/CommonIface.hh"
+#include "gazebo/test/ServerFixture.hh"
+
+using namespace gazebo;
+
+class SDFLogsTest : public ServerFixture
+{
+  public: void SetUp()
+  {
+#ifndef _WIN32
+  const boost::filesystem::path home = common::getEnv("HOME");
+#else
+  const boost::filesystem::path home = common::getEnv("HOMEPATH");
+#endif
+    boost::filesystem::path log_path("/.gazebo/server-11345/default.log");
+    path = home / log_path;
+  }
+
+  public: void EXPECT_LOG_STRING(const std::string expected_text)
+  {
+    EXPECT_TRUE(log_string_search(expected_text)) <<
+      "The text '" + expected_text + "'" +
+      " was not found in the log. The test expects it to be there";
+  }
+
+  public: void EXPECT_NO_ERR_IN_LOG()
+  {
+    EXPECT_NO_LOG_STRING("[Err] ");
+  }
+
+  public: void EXPECT_NO_LOG_STRING(const std::string no_expected_text)
+  {
+    EXPECT_FALSE(log_string_search(no_expected_text)) <<
+      "The text '" + no_expected_text + "'" +
+      " was found in the log. The test does not expect it be there";
+  }
+
+  public: void EXPECT_ERR_IN_LOG()
+  {
+    EXPECT_LOG_STRING("[Err] ");
+  }
+
+  private: bool log_string_search(const std::string expected_text)
+  {
+    // Open the log file, and read back the string
+    std::ifstream ifs(path.string().c_str(), std::ios::in);
+    std::string loggedString;
+
+    while (!ifs.eof())
+    {
+      std::string line;
+      std::getline(ifs, line);
+      loggedString += line;
+    }
+
+    return loggedString.find(expected_text) != std::string::npos;
+  }
+
+  private: boost::filesystem::path path;
+};
+
+/////////////////////////////////////////////////
+TEST_F(SDFLogsTest, EmptyWorldNoErrors)
+{
+  Load("worlds/empty.world");
+  EXPECT_NO_ERR_IN_LOG();
+}
+
+/////////////////////////////////////////////////
+TEST_F(SDFLogsTest, DuplicateSiblingSameType)
+{
+  Load("worlds/test_sdf_err_sibling_same_type.world");
+
+  EXPECT_ERR_IN_LOG();
+  std::string sdfErrorString = "SDF is not valid";
+  EXPECT_LOG_STRING(sdfErrorString);
+}
+
+/////////////////////////////////////////////////
+TEST_F(SDFLogsTest, DuplicateSiblingDifferentType)
+{
+  // 1.6 SDF does not enforce different names for different types
+  Load("worlds/test_sdf_err_sibling_different_type.world");
+  EXPECT_NO_ERR_IN_LOG();
+}
+
+/////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/integration/sdf_errors.cc
+++ b/test/integration/sdf_errors.cc
@@ -124,8 +124,8 @@ TEST_F(SDFLogsTest, DuplicateSiblingSameTypeDisabled)
 /////////////////////////////////////////////////
 TEST_F(SDFLogsTest, DuplicateSiblingDifferentType)
 {
-  // 1.6 SDF does not enforce different names for different types
   Load("worlds/test_sdf16_err_sibling_different_type.world");
+  // 1.6 SDF does not enforce different names for different types
   EXPECT_NO_ERR_IN_LOG();
 }
 

--- a/test/integration/sdf_errors.cc
+++ b/test/integration/sdf_errors.cc
@@ -22,6 +22,20 @@
 
 using namespace gazebo;
 
+/////////////////////////////////////////////////
+#ifdef _WIN32
+static int setenv(const char *envname, const char *envval, int overwrite)
+{
+  char *original = getenv(envname);
+  if (!original || !!overwrite)
+  {
+    std::string envstring = std::string(envname) + "=" + envval;
+    return _putenv(envstring.c_str());
+  }
+  return 0;
+}
+#endif
+
 class SDFLogsTest : public ServerFixture
 {
   public: void SetUp()
@@ -88,7 +102,7 @@ TEST_F(SDFLogsTest, EmptyWorldNoErrors)
 /////////////////////////////////////////////////
 TEST_F(SDFLogsTest, DuplicateSiblingSameType)
 {
-  Load("worlds/test_sdf_err_sibling_same_type.world");
+  Load("worlds/test_sdf16_err_sibling_same_type.world");
 
   EXPECT_ERR_IN_LOG();
   std::string sdfErrorString = "SDF is not valid";
@@ -96,10 +110,18 @@ TEST_F(SDFLogsTest, DuplicateSiblingSameType)
 }
 
 /////////////////////////////////////////////////
+TEST_F(SDFLogsTest, DuplicateSiblingSameTypeDisabled)
+{
+  setenv("GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS", "", 1);
+  Load("worlds/test_sdf16_err_sibling_same_type.world");
+  EXPECT_NO_ERR_IN_LOG();
+}
+
+/////////////////////////////////////////////////
 TEST_F(SDFLogsTest, DuplicateSiblingDifferentType)
 {
   // 1.6 SDF does not enforce different names for different types
-  Load("worlds/test_sdf_err_sibling_different_type.world");
+  Load("worlds/test_sdf16_err_sibling_different_type.world");
   EXPECT_NO_ERR_IN_LOG();
 }
 

--- a/test/integration/sdf_errors.cc
+++ b/test/integration/sdf_errors.cc
@@ -115,6 +115,7 @@ TEST_F(SDFLogsTest, DuplicateSiblingSameTypeDisabled)
   setenv("GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS", "", 1);
   Load("worlds/test_sdf16_err_sibling_same_type.world");
   EXPECT_NO_ERR_IN_LOG();
+  unsetenv("GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS");
 }
 
 /////////////////////////////////////////////////

--- a/test/worlds/test_sdf16_err_sibling_different_type.world
+++ b/test/worlds/test_sdf16_err_sibling_different_type.world
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<sdf version='1.6'>
+  <world name='default'>
+
+    <model name='wall'>
+      <static>1</static>
+      <pose frame=''>0 0 1 0 0 1</pose>
+      <link name='wall'>
+        <collision name='repeated_name'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </collision>
+         <collision name='collision_1'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </collision>
+         <collision name='collision_2'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='repeated_name'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/test/worlds/test_sdf16_err_sibling_same_type.world
+++ b/test/worlds/test_sdf16_err_sibling_same_type.world
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<sdf version='1.6'>
+  <world name='default'>
+
+    <model name='wall'>
+      <static>1</static>
+      <pose frame=''>0 0 1 0 0 1</pose>
+      <link name='wall'>
+        <collision name='collision_1'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </collision>
+         <collision name='collision_1'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </collision>
+         <collision name='collision_1'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name='visual'>
+          <pose frame=''>-2.5 0 0 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>5 0.2 2</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
~~**Prerequisite:** this requires https://github.com/osrf/sdformat/pull/580 . In Draft until then.~~
The PR adds a check for SDF files containing sibling elements with the same type. This is part of the [SDF specs ](http://sdformat.org/tutorials?tut=pose_frame_semantics&ver=1.5&cat=specification&#element-naming-rules-in-sdf-1-4) but was not enforced or check until now in Gazebo.

Since this PR will change the output behavior in the series of Gazebo9 releases I'm adding a check for an environment variable `GAZEBO9_BACKWARDS_COMPAT_WARNINGS_ERRORS` that users can set to avoid this new behavior if users want to preserve current behavior. 