### PR TITLE
Fix Windows compilation in Server.cc (not -> !)

### DIFF
--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -94,7 +94,7 @@ namespace gazebo
       else
         result = sdf::recursiveSameTypeUniqueNames(_elem);
 
-      if (not result)
+      if (!result)
         gzerr << "SDF is not valid, see errors above. "
               << "This can lead to an unexpected behaviour." << "\n";
     }


### PR DESCRIPTION
Windows does not follow the standard unfortunately and currently compilation is broken:
```
2021-06-10T12:52:03.2087118Z ..\gazebo\Server.cc(97): error C2065: 'not': undeclared identifier
2021-06-10T12:52:03.2087763Z ..\gazebo\Server.cc(97): error C2146: syntax error: missing ')' before identifier 'result'
2021-06-10T12:52:03.2088385Z ..\gazebo\Server.cc(97): error C2059: syntax error: ')'
2021-06-10T12:52:03.2088955Z ..\gazebo\Server.cc(98): error C2064: term does not evaluate to a function taking 1 arguments
```

This change fixes the error.

/cc @traversaro @wolfv