### PR TITLE
Use CURL::libcurl instead of variables

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -95,11 +95,11 @@ find_package(CURL)
 if (CURL_FOUND)
   if (NOT TARGET CURL::libcurl)
     # Make a target on Bionic because FindCURL.cmake only sets old-style CMake variables
-    add_library(CURL::libcurl UNKNOWN IMPORTED)
+    add_library(CURL::libcurl SHARED IMPORTED)
     set_target_properties(CURL::libcurl PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${CURL_LIBRARIES}"
-    )
+      INTERFACE_LINK_LIBRARIES "${CURL_LIBRARIES}")
+    message(STATUS "XXX CURL include dirs: ${CURL_INCLUDE_DIRS} libraries: ${CURL_LIBRARIES} XXX")
     if (WIN32)
       set_target_properties(CURL::libcurl PROPERTIES
         INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB")

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -95,11 +95,14 @@ find_package(CURL)
 if (CURL_FOUND)
   if (NOT TARGET CURL::libcurl)
     # Make a target on Bionic because FindCURL.cmake only sets old-style CMake variables
-    add_library(CURL::libcurl INTERFACE)
-    target_include_directories(CURL::libcurl INTERFACE "${CURL_INCLUDE_DIRS}")
-    target_link_libraries(CURL::libcurl INTERFACE "${CURL_LIBRARIES}")
+    add_library(CURL::libcurl UNKNOWN IMPORTED)
+    set_target_properties(CURL::libcurl PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES "${CURL_LIBRARIES}"
+    )
     if (WIN32)
-      target_compile_definitions(CURL::libcurl INTERFACE "CURL_STATICLIB")
+      set_target_properties(CURL::libcurl PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB")
     endif()
   endif()
 endif ()

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -93,7 +93,6 @@ endif ()
 
 find_package(CURL)
 if (CURL_FOUND AND NOT TARGET CURL::libcurl AND CURL_LIBRARY)
-  message(STATUS "XXX CURL include dirs: ${CURL_INCLUDE_DIRS} libraries: ${CURL_LIBRARIES} curl library: ${CURL_LIBRARY} XXX")
   # Make a target on Bionic because FindCURL.cmake only sets old-style CMake variables
   add_library(CURL::libcurl SHARED IMPORTED)
   set_target_properties(CURL::libcurl PROPERTIES

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -92,18 +92,17 @@ endif ()
 # Find packages
 
 find_package(CURL)
-if (CURL_FOUND)
-  if (NOT TARGET CURL::libcurl)
-    # Make a target on Bionic because FindCURL.cmake only sets old-style CMake variables
-    add_library(CURL::libcurl SHARED IMPORTED)
+if (CURL_FOUND AND NOT TARGET CURL::libcurl AND CURL_LIBRARY)
+  message(STATUS "XXX CURL include dirs: ${CURL_INCLUDE_DIRS} libraries: ${CURL_LIBRARIES} curl library: ${CURL_LIBRARY} XXX")
+  # Make a target on Bionic because FindCURL.cmake only sets old-style CMake variables
+  add_library(CURL::libcurl SHARED IMPORTED)
+  set_target_properties(CURL::libcurl PROPERTIES
+    IMPORTED_LOCATION "${CURL_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES "${CURL_LIBRARIES}")
+  if (WIN32)
     set_target_properties(CURL::libcurl PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "${CURL_LIBRARIES}")
-    message(STATUS "XXX CURL include dirs: ${CURL_INCLUDE_DIRS} libraries: ${CURL_LIBRARIES} XXX")
-    if (WIN32)
-      set_target_properties(CURL::libcurl PROPERTIES
-        INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB")
-    endif()
+      INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
 endif ()
 

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -93,14 +93,15 @@ endif ()
 
 find_package(CURL)
 if (CURL_FOUND)
-  # FindCURL.cmake distributed with CMake exports
-  # the CURL_INCLUDE_DIRS variable, while the pkg_check_modules
-  # function exports the CURL_INCLUDEDIR variable.
-  # TODO: once the configure.bat VS2013 based script has been removed,
-  #       remove the call pkg_check_modules(CURL libcurl) and all the uses of
-  #       CURL_LIBDIR and CURL_INCLUDEDIR and use directly the variables
-  #       CURL_INCLUDE_DIRS and CURL_LIBRARIES provided by FindCURL.cmake
-  set(CURL_INCLUDEDIR ${CURL_INCLUDE_DIRS})
+  if (NOT TARGET CURL::libcurl)
+    # Make a target on Bionic because FindCURL.cmake only sets old-style CMake variables
+    add_library(CURL::libcurl INTERFACE)
+    target_include_directories(CURL::libcurl INTERFACE "${CURL_INCLUDE_DIRS}")
+    target_link_libraries(CURL::libcurl INTERFACE "${CURL_LIBRARIES}")
+    if (WIN32)
+      target_compile_definitions(CURL::libcurl INTERFACE "CURL_STATICLIB")
+    endif()
+  endif()
 endif ()
 
 # In Visual Studio we use configure.bat to trick all path cmake
@@ -110,13 +111,6 @@ if (MSVC)
 endif()
 
 if (PKG_CONFIG_FOUND)
-  if (NOT CURL_FOUND)
-    pkg_check_modules(CURL libcurl)
-  endif ()
-  if (NOT CURL_FOUND)
-    BUILD_ERROR ("Missing: libcurl. Required for connection to model database.")
-  endif()
-
   pkg_check_modules(PROFILER libprofiler)
   if (PROFILER_FOUND)
     set (CMAKE_LINK_FLAGS_PROFILE "-Wl,--no-as-needed -lprofiler -Wl,--as-needed ${CMAKE_LINK_FLAGS_PROFILE}" CACHE INTERNAL "Link flags for profile")

--- a/gazebo/CMakeLists.txt
+++ b/gazebo/CMakeLists.txt
@@ -16,7 +16,6 @@ link_directories(
   ${SDFormat_LIBRARY_DIRS}
   ${PROJECT_BINARY_DIR}/test
   ${TBB_LIBRARY_DIR}
-  ${CURL_LIBDIR}
   ${IGNITION-MSGS_LIBRARY_DIRS}
 )
 

--- a/gazebo/common/CMakeLists.txt
+++ b/gazebo/common/CMakeLists.txt
@@ -17,10 +17,6 @@ if (HAVE_GDAL)
   include_directories(${GDAL_INCLUDE_DIR})
 endif()
 
-if (CURL_FOUND AND WIN32)
-  add_definitions(-DCURL_STATICLIB)
-endif()
-
 include_directories(${tinyxml_INCLUDE_DIRS})
 link_directories(${tinyxml_LIBRARY_DIRS})
 

--- a/gazebo/common/CMakeLists.txt
+++ b/gazebo/common/CMakeLists.txt
@@ -229,7 +229,6 @@ target_compile_definitions(gazebo_common
 target_link_libraries(gazebo_common
   PUBLIC
     ${Boost_LIBRARIES}
-    CURL::libcurl
     ${freeimage_LIBRARIES}
     ignition-common3::graphics
     ${IGNITION-FUEL_TOOLS_LIBRARIES}
@@ -240,6 +239,7 @@ target_link_libraries(gazebo_common
     ${SDFormat_LIBRARIES}
     ${tinyxml_LIBRARIES}
   PRIVATE
+    CURL::libcurl
     ${libtool_library}
     ${libavcodec_LIBRARIES}
     ${libavformat_LIBRARIES}

--- a/gazebo/common/CMakeLists.txt
+++ b/gazebo/common/CMakeLists.txt
@@ -17,12 +17,8 @@ if (HAVE_GDAL)
   include_directories(${GDAL_INCLUDE_DIR})
 endif()
 
-if (CURL_FOUND)
-  include_directories(${CURL_INCLUDEDIR})
-  link_directories(${CURL_LIBDIR})
-  if (WIN32)
-    add_definitions(-DCURL_STATICLIB)
-  endif()
+if (CURL_FOUND AND WIN32)
+  add_definitions(-DCURL_STATICLIB)
 endif()
 
 include_directories(${tinyxml_INCLUDE_DIRS})
@@ -237,7 +233,7 @@ target_compile_definitions(gazebo_common
 target_link_libraries(gazebo_common
   PUBLIC
     ${Boost_LIBRARIES}
-    ${CURL_LIBRARIES}
+    CURL::libcurl
     ${freeimage_LIBRARIES}
     ignition-common3::graphics
     ${IGNITION-FUEL_TOOLS_LIBRARIES}

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -176,7 +176,6 @@ gz_install_includes("plugins" TrackedVehiclePlugin.hh)
 foreach (src ${plugins_single_header})
   add_library(${src} SHARED ${src}.cc)
   target_link_libraries(${src}
-    CURL::libcurl
     libgazebo
     ${ogre_libraries}
     ${IGNITION-TRANSPORT_LIBRARIES}
@@ -192,6 +191,8 @@ target_include_directories(SimpleTrackedVehiclePlugin SYSTEM PRIVATE
         ${CMAKE_SOURCE_DIR}/deps/opende/include)
 target_link_libraries(SimpleTrackedVehiclePlugin TrackedVehiclePlugin)
 add_dependencies(SimpleTrackedVehiclePlugin TrackedVehiclePlugin)
+
+target_link_libraries(StaticMapPlugin CURL::libcurl)
 
 target_link_libraries(WheelTrackedVehiclePlugin TrackedVehiclePlugin)
 add_dependencies(WheelTrackedVehiclePlugin TrackedVehiclePlugin)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -163,7 +163,6 @@ set (DARTplugins
 
 add_library(TrackedVehiclePlugin SHARED TrackedVehiclePlugin.cc)
 target_link_libraries(TrackedVehiclePlugin
-        CURL::libcurl
         libgazebo
         ${ogre_libraries}
         ${IGNITION-TRANSPORT_LIBRARIES}
@@ -200,7 +199,6 @@ add_dependencies(WheelTrackedVehiclePlugin TrackedVehiclePlugin)
 foreach (src ${plugins_private_header})
   add_library(${src} SHARED ${src}.cc)
   target_link_libraries(${src}
-    CURL::libcurl
     libgazebo
     ${ogre_libraries}
     ${IGNITION-TRANSPORT_LIBRARIES}
@@ -216,7 +214,6 @@ endforeach ()
 foreach (src ${GUIplugins})
   add_library(${src} SHARED ${src}.cc ${${src}_MOC})
   target_link_libraries(${src}
-                        CURL::libcurl
                         libgazebo
                         gazebo_gui
                         ${ogre_libraries}
@@ -236,7 +233,6 @@ if (HAVE_DART_URDF)
   foreach (src ${DARTplugins})
     add_library(${src} SHARED ${src}.cc)
     target_link_libraries(${src}
-      CURL::libcurl
       libgazebo
       ${DART_LIBRARIES}
     )

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -28,7 +28,6 @@ if(WIN32 AND NOT UNIX)
 endif()
 
 include_directories(SYSTEM
-  ${CURL_INCLUDEDIR}
   ${PROJECT_SOURCE_DIR}
   ${PROTOBUF_INCLUDE_DIR}
   ${SDFormat_INCLUDE_DIRS}
@@ -53,15 +52,11 @@ include_directories(SYSTEM
 # failures in clang.
 link_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${CURL_LIBDIR}
   ${CCD_LIBRARY_DIRS}
   ${SDFormat_LIBRARY_DIRS}
   ${tinyxml_LIBRARY_DIRS}
 )
 
-if (WIN32)
-  add_definitions(-DCURL_STATICLIB)
-endif()
 add_definitions(${Qt5Core_DEFINITIONS})
 set (CMAKE_AUTOMOC ON)
 
@@ -168,6 +163,7 @@ set (DARTplugins
 
 add_library(TrackedVehiclePlugin SHARED TrackedVehiclePlugin.cc)
 target_link_libraries(TrackedVehiclePlugin
+        CURL::libcurl
         libgazebo
         ${ogre_libraries}
         ${IGNITION-TRANSPORT_LIBRARIES}
@@ -181,6 +177,7 @@ gz_install_includes("plugins" TrackedVehiclePlugin.hh)
 foreach (src ${plugins_single_header})
   add_library(${src} SHARED ${src}.cc)
   target_link_libraries(${src}
+    CURL::libcurl
     libgazebo
     ${ogre_libraries}
     ${IGNITION-TRANSPORT_LIBRARIES}
@@ -203,6 +200,7 @@ add_dependencies(WheelTrackedVehiclePlugin TrackedVehiclePlugin)
 foreach (src ${plugins_private_header})
   add_library(${src} SHARED ${src}.cc)
   target_link_libraries(${src}
+    CURL::libcurl
     libgazebo
     ${ogre_libraries}
     ${IGNITION-TRANSPORT_LIBRARIES}
@@ -218,6 +216,7 @@ endforeach ()
 foreach (src ${GUIplugins})
   add_library(${src} SHARED ${src}.cc ${${src}_MOC})
   target_link_libraries(${src}
+                        CURL::libcurl
                         libgazebo
                         gazebo_gui
                         ${ogre_libraries}
@@ -237,6 +236,7 @@ if (HAVE_DART_URDF)
   foreach (src ${DARTplugins})
     add_library(${src} SHARED ${src}.cc)
     target_link_libraries(${src}
+      CURL::libcurl
       libgazebo
       ${DART_LIBRARIES}
     )

--- a/plugins/rest_web/CMakeLists.txt
+++ b/plugins/rest_web/CMakeLists.txt
@@ -41,7 +41,10 @@ include_directories(
 )
 
 add_library(RestWebPlugin SHARED ${server_src} )
-target_link_libraries(RestWebPlugin ${GAZEBO_libraries} gazebo_msgs)
+target_link_libraries(RestWebPlugin
+  CURL::libcurl
+  ${GAZEBO_libraries}
+  gazebo_msgs)
 install (TARGETS RestWebPlugin
          LIBRARY DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}
          ARCHIVE DESTINATION ${GAZEBO_PLUGIN_LIB_INSTALL_DIR}

--- a/plugins/rest_web/RestUiLoginDialog.cc
+++ b/plugins/rest_web/RestUiLoginDialog.cc
@@ -16,7 +16,6 @@
 */
 
 #include <iostream>
-#include <curl/curl.h>
 
 #include "RestUiLoginDialog.hh"
 #include "RestUiWidget.hh"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -45,7 +45,6 @@ if (WIN32)
 endif()
 
 target_link_libraries(gz
- CURL::libcurl
  libgazebo_client
  gazebo_gui
  gazebo_physics

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -24,14 +24,6 @@ if (HAVE_DART)
   link_directories(${DART_LIBRARY_DIRS})
 endif()
 
-if (CURL_FOUND)
-  include_directories(${CURL_INCLUDEDIR})
-  link_directories(${CURL_LIBDIR})
-  if (WIN32)
-    add_definitions(-DCURL_STATICLIB)
-  endif()
-endif()
-
 if(NOT WIN32)
   # gz_TEST and gz_log_TEST use fork(), that is not available on Windows
   set (test_sources
@@ -53,6 +45,7 @@ if (WIN32)
 endif()
 
 target_link_libraries(gz
+ CURL::libcurl
  libgazebo_client
  gazebo_gui
  gazebo_physics


### PR DESCRIPTION
Maybe this will fix the build failures in this job :shrug: 
https://build.osrfoundation.org/job/gazebo-ci-pr_any-windows7-amd64/ws/ws/

The trouble is `gazebo_common` is linking against `libcurl.dll` instead of `libcurl_imp.lib`. I have no idea why that happens. The exported CMake targets on Windows seem reasonable to me, so maybe using them will solve the issue.