### PR TITLE
Distortion camera initialization fix

### DIFF
--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -1627,8 +1627,11 @@ void Camera::SetRenderTarget(Ogre::RenderTarget *_target)
       // this->dataPtr->this->ssaoInstance->setEnabled(false);
     }
 
-    if (this->dataPtr->distortion)
+    if (this->dataPtr->distortion) 
+    {
       this->dataPtr->distortion->SetCamera(shared_from_this());
+      this->renderTarget->update();
+    }
 
     if (this->GetScene()->GetSkyX() != NULL)
       this->renderTarget->addListener(this->GetScene()->GetSkyX());

--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -1627,7 +1627,7 @@ void Camera::SetRenderTarget(Ogre::RenderTarget *_target)
       // this->dataPtr->this->ssaoInstance->setEnabled(false);
     }
 
-    if (this->dataPtr->distortion) 
+    if (this->dataPtr->distortion)
     {
       this->dataPtr->distortion->SetCamera(shared_from_this());
       this->renderTarget->update();

--- a/test/models/camera_barrel/model.config
+++ b/test/models/camera_barrel/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Camera with Barrel Distortion</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Nate Koenig</name>
+    <email>nate@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A simple camera with barrel distortion.
+  </description>
+</model>

--- a/test/models/camera_barrel/model.sdf
+++ b/test/models/camera_barrel/model.sdf
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="camera_barrel">
+    <static>true</static>
+    <link name="barrel">
+      <inertial>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.000166667</ixx>
+          <iyy>0.000166667</iyy>
+          <izz>0.000166667</izz>
+        </inertia>
+      </inertial>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor type="camera" name="camera_barrel">
+        <update_rate>30</update_rate>
+        <camera name="head_barrel">
+          <horizontal_fov>0.927295218</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <distortion>
+            <k1>-0.5</k1>
+            <k2>0</k2>
+            <p1>0</p1>
+            <p2>0</p2>
+            <k3>0</k3>
+            <center>0.5 0.5</center>
+          </distortion>
+        </camera>
+        <always_on>1</always_on>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/test/models/camera_pincushion/model.config
+++ b/test/models/camera_pincushion/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Camera with Pincushion Distortion</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Nate Koenig</name>
+    <email>nate@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A simple camera with pincushion distortion.
+  </description>
+</model>

--- a/test/models/camera_pincushion/model.sdf
+++ b/test/models/camera_pincushion/model.sdf
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="camera_pincushion">
+    <static>true</static>
+    <link name="pincushion">
+      <inertial>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.000166667</ixx>
+          <iyy>0.000166667</iyy>
+          <izz>0.000166667</izz>
+        </inertia>
+      </inertial>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor type="camera" name="camera_pincushion">
+        <update_rate>30</update_rate>
+        <camera name="head_pincushion">
+          <horizontal_fov>0.927295218</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <distortion>
+            <k1>0.5</k1>
+            <k2>0</k2>
+            <p1>0</p1>
+            <p2>0</p2>
+            <k3>0</k3>
+            <center>0.5 0.5</center>
+          </distortion>
+        </camera>
+        <always_on>1</always_on>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/test/models/cameras_with_distortion/model.config
+++ b/test/models/cameras_with_distortion/model.config
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Cameras with Barrel and Pincushion Distortion</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Nate Koenig</name>
+    <email>nate@osrfoundation.org</email>
+  </author>
+
+  <description>
+    A model with two cameras with barrel and pincushion distortion.
+  </description>
+</model>

--- a/test/models/cameras_with_distortion/model.sdf
+++ b/test/models/cameras_with_distortion/model.sdf
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="cameras_with_distortion">
+    <static>true</static>
+    <link name="link">
+      <inertial>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.000166667</ixx>
+          <iyy>0.000166667</iyy>
+          <izz>0.000166667</izz>
+        </inertia>
+      </inertial>
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor type="camera" name="camera_barrel">
+        <update_rate>30</update_rate>
+        <camera name="head_barrel">
+          <horizontal_fov>0.927295218</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <distortion>
+            <k1>-0.5</k1>
+            <k2>0</k2>
+            <p1>0</p1>
+            <p2>0</p2>
+            <k3>0</k3>
+            <center>0.5 0.5</center>
+          </distortion>
+        </camera>
+        <always_on>1</always_on>
+      </sensor>
+      <sensor type="camera" name="camera_pincushion">
+        <update_rate>60</update_rate>
+        <camera name="head_pincushion">
+          <horizontal_fov>0.927295218</horizontal_fov>
+          <image>
+            <width>640</width>
+            <height>480</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+          <distortion>
+            <k1>0.5</k1>
+            <k2>0</k2>
+            <p1>0</p1>
+            <p2>0</p2>
+            <k3>0</k3>
+            <center>0.5 0.5</center>
+          </distortion>
+        </camera>
+        <always_on>1</always_on>
+      </sensor>
+    </link>
+  </model>
+</sdf>

--- a/test/worlds/issue_2527_camera_distortion.world
+++ b/test/worlds/issue_2527_camera_distortion.world
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <include>
+      <pose>1.5 0 0 0 -1.57 0</pose>
+      <uri>model://checkerboard_plane</uri>
+    </include>
+
+    <include>
+      <uri>model://cameras_with_distortion</uri>
+    </include>
+
+    <include>
+      <pose>0 0.2 0 0 0 0</pose>
+      <uri>model://camera_barrel</uri>
+    </include>
+
+    <include>
+      <pose>0 -0.2 0 0 0 0</pose>
+      <uri>model://camera_pincushion</uri>
+    </include>
+
+    <gui>
+      <camera name="user">
+        <pose>-2 -2 1 0 0.25 0.50</pose>
+      </camera>
+    </gui>
+  </world>
+</sdf>


### PR DESCRIPTION
Closes #2527  - Last camera's distortion affects previous cameras' distortions

When loading multiple cameras on the application startup, each camera would finish initialization but their compositor's material would only be set after every camera has been initialized. This would make all compositor materials to be set to the most recently initialized camera.

To fix this issue, `the compositor material should be set right after their camera is done initializing` rather than `waiting for all the cameras to finish initialization`.

![fix](https://user-images.githubusercontent.com/14305903/123351583-47766080-d512-11eb-8927-ec5639c4eeb4.gif)
