### PR TITLE
Bump version to 11.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 11)
-set (GAZEBO_MINOR_VERSION 6)
+set (GAZEBO_MINOR_VERSION 7)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Gazebo 11.7.0 (2021-06-xx)
 
+1. Qualify `gazebo::util` in `using namespace` declarations.
+    * [Pull request #2979](https://github.com/osrf/gazebo/pull/2979)
+
 1. Distortion camera initialization fix
     * [Issue #2527](https://github.com/osrf/gazebo/issues/2527)
     * [Pull request #3033](https://github.com/osrf/gazebo/pull/3033)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,25 @@
 ## Gazebo 11
 
-## Gazebo 11.6.0 (2021-06-xx)
+## Gazebo 11.7.0 (2021-06-xx)
+
+1. Distortion camera initialization fix
+    * [Issue #2527](https://github.com/osrf/gazebo/issues/2527)
+    * [Pull request #3033](https://github.com/osrf/gazebo/pull/3033)
+
+1. Use CURL::libcurl instead of cmake variables
+    * [Pull request #3030](https://github.com/osrf/gazebo/pull/3030)
+
+1. Allow specifying lens flare and camera distortion texture format
+    * [Issue #3005](https://github.com/osrf/gazebo/issues/3005)
+    * [Pull request #3009](https://github.com/osrf/gazebo/pull/3009)
+
+1. Camera distortion normalization improvement and fix folding
+    * [Pull request #3009](https://github.com/osrf/gazebo/pull/3009)
+
+1. Fix Windows compilation in Server.cc (not -> !)
+    * [Pull request #3021](https://github.com/osrf/gazebo/pull/3021)
+
+## Gazebo 11.6.0 (2021-06-09)
 
 1. Enable output of gzerr for SDF sibling elements of any type with same name,
    following the SDF 1.7 specification.


### PR DESCRIPTION
I'd like to make a new release of gazebo11 to since we have made two improvements to camera distortion: #3009 and #3033 

https://github.com/osrf/gazebo/compare/gazebo11_11.6.0...scpeters:bump_11.7.0