### PR TITLE
Enable hardware PCF for spotlight shadows

### DIFF
--- a/gazebo/rendering/Light.cc
+++ b/gazebo/rendering/Light.cc
@@ -588,7 +588,7 @@ void Light::SetCastShadows(const bool _cast)
     if (_cast && this->dataPtr->shadowCameraSetup.isNull())
     {
       this->dataPtr->shadowCameraSetup =
-          Ogre::ShadowCameraSetupPtr(new Ogre::FocusedShadowCameraSetup());
+          Ogre::ShadowCameraSetupPtr(new Ogre::DefaultShadowCameraSetup());
       this->dataPtr->light->setCustomShadowCameraSetup(
           this->dataPtr->shadowCameraSetup);
       RTShaderSystem::Instance()->UpdateShadows();

--- a/gazebo/rendering/RTShaderSystem.cc
+++ b/gazebo/rendering/RTShaderSystem.cc
@@ -769,7 +769,7 @@ void RTShaderSystem::UpdateShadows(ScenePtr _scene)
   // vec4 texture(sampler2D, vec2, [float]).
   // NVidia, AMD, and Intel all take this as a cue to provide "hardware PCF",
   // a driver hack that softens shadow edges with 4-sample interpolation.
-  for (size_t i = 0u; i < dirShadowCount; ++i)
+  for (size_t i = 0u; i < dirShadowCount + spotShadowCount; ++i)
   {
     const Ogre::TexturePtr tex = sceneMgr->getShadowTexture(i);
     // This will fail if not using OpenGL as the rendering backend.

--- a/gazebo/rendering/RTShaderSystem.cc
+++ b/gazebo/rendering/RTShaderSystem.cc
@@ -780,6 +780,10 @@ void RTShaderSystem::UpdateShadows(ScenePtr _scene)
     glBindTexture(GL_TEXTURE_2D, texId);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE,
         GL_COMPARE_R_TO_TEXTURE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
+        GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
+        GL_LINEAR);
   }
 #endif
 

--- a/media/materials/programs/spotlight_shadow_demo_fp.glsl
+++ b/media/materials/programs/spotlight_shadow_demo_fp.glsl
@@ -1,13 +1,13 @@
-#version 120
+#version 130
 
-uniform sampler2D shadowMap0;
+uniform sampler2DShadow shadowMap0;
 varying vec4 lightSpacePos0;
 
 varying vec4 worldPos;
 varying vec4 worldViewPos;
 
 //------------------------------------------------------------------------------
-float ShadowSimple(in sampler2D shadowMap, in vec4 shadowMapPos)
+float ShadowSimple(in sampler2DShadow shadowMap, in vec4 shadowMapPos)
 {
   // perform perspective divide
   vec3 shadowMapUV = shadowMapPos.xyz / shadowMapPos.w;
@@ -16,7 +16,7 @@ float ShadowSimple(in sampler2D shadowMap, in vec4 shadowMapPos)
     return 0.0;
 
   // get closest depth value from light's perspective
-  float closestDepth = texture2D(shadowMap, shadowMapUV.xy).r;
+  float closestDepth = texture(shadowMap, shadowMapUV);
 
   // get depth of current fragment from light's perspective
   float currentDepth = shadowMapUV.z;


### PR DESCRIPTION
The `FocusedShadowCameraSetup` causes linear artifacts that was fixed by changing the shadow camera setup to `DefaultShadowCameraSetup`. There is a decrease in quality for shadows generated with the `DefaultShadowCameraSetup` but it shouldn't be a problem when hardware PCF is enabled.