### PR TITLE
Find tbb version < 2021 with pkg-config

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -301,7 +301,7 @@ if (PKG_CONFIG_FOUND)
 
   #################################################
   # Find TBB
-  pkg_check_modules(TBB tbb)
+  pkg_check_modules(TBB tbb<2021)
   set (TBB_PKG_CONFIG "tbb")
   if (NOT TBB_FOUND)
     message(STATUS "TBB not found, attempting to detect manually")


### PR DESCRIPTION
We don't support 2021 and newer, see #2867. A recent release of `tbb` in https://github.com/Homebrew/homebrew-core/pull/80329 added a `.pc` file, which defeated the logic we added in https://github.com/ignition-tooling/release-tools/pull/466 to find our back-dated version of `tbb@2020_u3` added in https://github.com/osrf/homebrew-simulation/pull/1483 and which does not install a `.pc` file. To avoid finding the new version, add a `<2021` version constraint to `pkg_check_modules` so it should not accept a `.pc` file from 2021 or later.