### PR TITLE
Partially fixes #1718 - Apply Force/Torque for nested models

### DIFF
--- a/gazebo/gui/ApplyWrenchDialog.cc
+++ b/gazebo/gui/ApplyWrenchDialog.cc
@@ -488,7 +488,8 @@ bool ApplyWrenchDialog::SetModel(const std::string &_modelName)
     rendering::VisualPtr childVis = vis->GetChild(i);
 
     // Skip all children that aren't links
-    if(childVis->GetType() != rendering::Visual::VT_LINK){
+    if (childVis->GetType() != rendering::Visual::VT_LINK)
+    {
       continue;
     }
 

--- a/gazebo/gui/ApplyWrenchDialog.cc
+++ b/gazebo/gui/ApplyWrenchDialog.cc
@@ -486,6 +486,12 @@ bool ApplyWrenchDialog::SetModel(const std::string &_modelName)
   for (unsigned int i = 0; i < vis->GetChildCount(); ++i)
   {
     rendering::VisualPtr childVis = vis->GetChild(i);
+
+    // Skip all children that aren't links
+    if(childVis->GetType() != rendering::Visual::VT_LINK){
+      continue;
+    }
+
     std::string linkName = childVis->Name();
 
     // Issue #1553: This is failing to get real links sometimes:
@@ -493,7 +499,8 @@ bool ApplyWrenchDialog::SetModel(const std::string &_modelName)
     // if (!((flags != GZ_VISIBILITY_ALL) && (flags & GZ_VISIBILITY_GUI)))
     if (linkName.find("_GL_MANIP_") == std::string::npos)
     {
-      std::string unscopedLinkName = linkName.substr(linkName.find("::") + 2);
+      std::string unscopedLinkName = linkName.substr(linkName.rfind("::") + 2);
+
       this->dataPtr->linksComboBox->addItem(
           QString::fromStdString(unscopedLinkName));
 
@@ -539,7 +546,7 @@ bool ApplyWrenchDialog::SetLink(const std::string &_linkName)
     return false;
 
   // Select on combo box
-  std::string unscopedLinkName = _linkName.substr(_linkName.find("::") + 2);
+  std::string unscopedLinkName = _linkName.substr(_linkName.rfind("::") + 2);
   int index = -1;
   for (int i = 0; i < this->dataPtr->linksComboBox->count(); ++i)
   {

--- a/gazebo/gui/ApplyWrenchDialog.cc
+++ b/gazebo/gui/ApplyWrenchDialog.cc
@@ -500,7 +500,14 @@ bool ApplyWrenchDialog::SetModel(const std::string &_modelName)
     // if (!((flags != GZ_VISIBILITY_ALL) && (flags & GZ_VISIBILITY_GUI)))
     if (linkName.find("_GL_MANIP_") == std::string::npos)
     {
-      std::string unscopedLinkName = linkName.substr(linkName.rfind("::") + 2);
+      size_t modelNamePos = linkName.find(_modelName);
+      // Skip if the model name isn't in the scoped link name
+      if (modelNamePos == std::string::npos)
+      {
+        continue;
+      }
+      std::string unscopedLinkName = linkName.substr(modelNamePos +
+          + _modelName.size() + 2);
 
       this->dataPtr->linksComboBox->addItem(
           QString::fromStdString(unscopedLinkName));
@@ -546,8 +553,18 @@ bool ApplyWrenchDialog::SetLink(const std::string &_linkName)
   if (!gui::get_active_camera() || !gui::get_active_camera()->GetScene())
     return false;
 
-  // Select on combo box
-  std::string unscopedLinkName = _linkName.substr(_linkName.rfind("::") + 2);
+  size_t modelNamePos = _linkName.find(this->dataPtr->modelName);
+  std::string unscopedLinkName;
+
+  // Leave unscopedLinkName empty if model name cannot be found
+  // in the scoped link name
+  if (modelNamePos != std::string::npos)
+  {
+     // Select on combo box
+    unscopedLinkName = _linkName.substr(modelNamePos +
+        this->dataPtr->modelName.size() + 2);
+  }
+
   int index = -1;
   for (int i = 0; i < this->dataPtr->linksComboBox->count(); ++i)
   {

--- a/gazebo/gui/ApplyWrenchDialog_TEST.cc
+++ b/gazebo/gui/ApplyWrenchDialog_TEST.cc
@@ -49,15 +49,16 @@ void ApplyWrenchDialog_TEST::ApplyForceTorqueFromDialog()
   gazebo::rendering::ScenePtr scene = cam->GetScene();
   QVERIFY(scene != nullptr);
 
-  //Test parameters for regular and nested models
+  // Test parameters for regular and nested models
   const unsigned int testCount = 2;
-  std::string modelNameList[testCount] = {"multilink", "nested_outer::nested_inner"};
+  std::string modelNameList[testCount] =
+      {"multilink", "nested_outer::nested_inner"};
   std::string boxLinkList[testCount] = {"box_link", "nested_box_link"};
   std::string sphereLinkList[testCount] = {"sphere_link", "nested_sphere_link"};
 
   for (unsigned int i = 0; i < testCount; ++i)
   {
-    //QString defines operator== for c-strings, but not std::string
+    // QString defines operator== for c-strings, but not std::string
     const char *currentModel = modelNameList[i].c_str();
     const char *currentUnscopedBoxLink = boxLinkList[i].c_str();
     const char *currentUnscopedSphereLink = sphereLinkList[i].c_str();
@@ -140,7 +141,8 @@ void ApplyWrenchDialog_TEST::ApplyForceTorqueFromDialog()
         applyTorqueButton = it;
       else if (it->text().toLower().toStdString() == "apply all")
         applyAllButton = it;
-      else if (it->text().toLower().toStdString() == "clear" && !clearForceButton)
+      else if (it->text().toLower().toStdString() == "clear" &&
+          !clearForceButton)
         clearForceButton = it;
       else if (it->text().toLower().toStdString() == "clear")
         clearTorqueButton = it;
@@ -261,7 +263,7 @@ void ApplyWrenchDialog_TEST::ApplyForceTorqueFromDialog()
     delete applyWrenchDialog;
   }
 
-  //Cleanup
+  // Cleanup
   cam->Fini();
   mainWindow->close();
   delete mainWindow;

--- a/gazebo/gui/ApplyWrenchDialog_TEST.cc
+++ b/gazebo/gui/ApplyWrenchDialog_TEST.cc
@@ -32,7 +32,7 @@ void ApplyWrenchDialog_TEST::ApplyForceTorqueFromDialog()
   this->shareMaxPercentChange = 2.0;
 
   // World with one model which has 2 links, no ground plane and gravity is off
-  this->Load("worlds/multilink_shape.world", false, false, false);
+  this->Load("worlds/nested_multilink_shape.world", false, false, false);
 
   // Create the main window.
   gazebo::gui::MainWindow *mainWindow = new gazebo::gui::MainWindow();

--- a/gazebo/gui/ApplyWrenchDialog_TEST.cc
+++ b/gazebo/gui/ApplyWrenchDialog_TEST.cc
@@ -49,200 +49,219 @@ void ApplyWrenchDialog_TEST::ApplyForceTorqueFromDialog()
   gazebo::rendering::ScenePtr scene = cam->GetScene();
   QVERIFY(scene != nullptr);
 
-  // Get the model
-  gazebo::rendering::VisualPtr modelVis = scene->GetVisual("multilink");
-  QVERIFY(modelVis != nullptr);
+  //Test parameters for regular and nested models
+  const unsigned int testCount = 2;
+  std::string modelNameList[testCount] = {"multilink", "nested_outer::nested_inner"};
+  std::string boxLinkList[testCount] = {"box_link", "nested_box_link"};
+  std::string sphereLinkList[testCount] = {"sphere_link", "nested_sphere_link"};
 
-  // Get the box link
-  gazebo::rendering::VisualPtr boxLinkVis =
-      scene->GetVisual("multilink::box_link");
-  QVERIFY(boxLinkVis != nullptr);
-  auto boxLinkPose = boxLinkVis->WorldPose();
-  QVERIFY(boxLinkPose == boxLinkVis->WorldPose());
-
-  // Get the sphere link
-  gazebo::rendering::VisualPtr sphereLinkVis =
-      scene->GetVisual("multilink::sphere_link");
-  QVERIFY(sphereLinkVis != nullptr);
-  auto sphereLinkPose = sphereLinkVis->WorldPose();
-  QVERIFY(sphereLinkPose == sphereLinkVis->WorldPose());
-
-  // Check that an inexistent model doesn't break anything
-  gazebo::gui::ApplyWrenchDialog *applyWrenchDialogFakeModel =
-      new gazebo::gui::ApplyWrenchDialog();
-  applyWrenchDialogFakeModel->Init("fake_model", "fake_link");
-
-  // Check that an inexistent link doesn't break anything
-  gazebo::gui::ApplyWrenchDialog *applyWrenchDialogFakeLink =
-      new gazebo::gui::ApplyWrenchDialog();
-  applyWrenchDialogFakeLink->Init("multilink", "fake_link");
-
-  // Initialize dialog with the box link
-  gazebo::gui::ApplyWrenchDialog *applyWrenchDialog =
-      new gazebo::gui::ApplyWrenchDialog();
-  applyWrenchDialog->Init("multilink", "multilink::box_link");
-
-  // Get combo box
-  QList<QComboBox *> comboBoxes =
-      applyWrenchDialog->findChildren<QComboBox *>();
-  QVERIFY(comboBoxes.size() == 1u);
-
-  // Check the combo box's items
-  QVERIFY(comboBoxes[0]->count() == 2u);
-  QVERIFY(comboBoxes[0]->itemText(0) == "box_link");
-  QVERIFY(comboBoxes[0]->itemText(1) == "sphere_link");
-  QVERIFY(comboBoxes[0]->currentIndex() == 0u);
-
-  // Get radio buttons
-  QList<QRadioButton *> radioButtons =
-      applyWrenchDialog->findChildren<QRadioButton *>();
-  QVERIFY(radioButtons.size() == 2u);
-
-  // Get spins
-  QList<QDoubleSpinBox *> spins =
-      applyWrenchDialog->findChildren<QDoubleSpinBox *>();
-  QVERIFY(spins.size() == 11u);
-
-  // Get buttons
-  QList<QPushButton *> buttons =
-      applyWrenchDialog->findChildren<QPushButton *>();
-  QVERIFY(buttons.size() == 6u);
-
-  QPushButton *applyForceButton = nullptr;
-  QPushButton *applyTorqueButton = nullptr;
-  QPushButton *applyAllButton = nullptr;
-  QPushButton *clearForceButton = nullptr;
-  QPushButton *clearTorqueButton = nullptr;
-  QPushButton *cancelButton = nullptr;
-  for (auto it : buttons)
+  for (unsigned int i = 0; i < testCount; ++i)
   {
-    QVERIFY(it);
-    if (it->text().toLower().toStdString() == "apply force")
-      applyForceButton = it;
-    else if (it->text().toLower().toStdString() == "apply torque")
-      applyTorqueButton = it;
-    else if (it->text().toLower().toStdString() == "apply all")
-      applyAllButton = it;
-    else if (it->text().toLower().toStdString() == "clear" && !clearForceButton)
-      clearForceButton = it;
-    else if (it->text().toLower().toStdString() == "clear")
-      clearTorqueButton = it;
-    else if (it->text().toLower().toStdString() == "cancel")
-      cancelButton = it;
+    //QString defines operator== for c-strings, but not std::string
+    const char *currentModel = modelNameList[i].c_str();
+    const char *currentUnscopedBoxLink = boxLinkList[i].c_str();
+    const char *currentUnscopedSphereLink = sphereLinkList[i].c_str();
+    std::string _scopedBoxLink = modelNameList[i] + "::" + boxLinkList[i];
+    std::string _scopedSphereLink = modelNameList[i] + "::" + sphereLinkList[i];
+    const char *currentScopedBoxLink = _scopedBoxLink.c_str();
+    const char *currentScopedSphereLink = _scopedSphereLink.c_str();
+
+    // Get the model
+    gazebo::rendering::VisualPtr modelVis = scene->GetVisual(modelNameList[i]);
+    QVERIFY(modelVis != nullptr);
+
+    // Get the box link
+    gazebo::rendering::VisualPtr boxLinkVis =
+        scene->GetVisual(currentScopedBoxLink);
+    QVERIFY(boxLinkVis != nullptr);
+    auto boxLinkPose = boxLinkVis->WorldPose();
+    QVERIFY(boxLinkPose == boxLinkVis->WorldPose());
+
+    // Get the sphere link
+    gazebo::rendering::VisualPtr sphereLinkVis =
+        scene->GetVisual(currentScopedSphereLink);
+    QVERIFY(sphereLinkVis != nullptr);
+    auto sphereLinkPose = sphereLinkVis->WorldPose();
+    QVERIFY(sphereLinkPose == sphereLinkVis->WorldPose());
+
+    // Check that an inexistent model doesn't break anything
+    gazebo::gui::ApplyWrenchDialog *applyWrenchDialogFakeModel =
+        new gazebo::gui::ApplyWrenchDialog();
+    applyWrenchDialogFakeModel->Init("fake_model", "fake_link");
+
+    // Check that an inexistent link doesn't break anything
+    gazebo::gui::ApplyWrenchDialog *applyWrenchDialogFakeLink =
+        new gazebo::gui::ApplyWrenchDialog();
+    applyWrenchDialogFakeLink->Init(currentModel, "fake_link");
+
+    // Initialize dialog with the box link
+    gazebo::gui::ApplyWrenchDialog *applyWrenchDialog =
+        new gazebo::gui::ApplyWrenchDialog();
+    applyWrenchDialog->Init(currentModel, currentScopedBoxLink);
+
+    // Get combo box
+    QList<QComboBox *> comboBoxes =
+        applyWrenchDialog->findChildren<QComboBox *>();
+    QVERIFY(comboBoxes.size() == 1u);
+
+    // Check the combo box's items
+    QVERIFY(comboBoxes[0]->count() == 2u);
+    QVERIFY(comboBoxes[0]->itemText(0) == currentUnscopedBoxLink);
+    QVERIFY(comboBoxes[0]->itemText(1) == currentUnscopedSphereLink);
+    QVERIFY(comboBoxes[0]->currentIndex() == 0u);
+
+    // Get radio buttons
+    QList<QRadioButton *> radioButtons =
+        applyWrenchDialog->findChildren<QRadioButton *>();
+    QVERIFY(radioButtons.size() == 2u);
+
+    // Get spins
+    QList<QDoubleSpinBox *> spins =
+        applyWrenchDialog->findChildren<QDoubleSpinBox *>();
+    QVERIFY(spins.size() == 11u);
+
+    // Get buttons
+    QList<QPushButton *> buttons =
+        applyWrenchDialog->findChildren<QPushButton *>();
+    QVERIFY(buttons.size() == 6u);
+
+    QPushButton *applyForceButton = nullptr;
+    QPushButton *applyTorqueButton = nullptr;
+    QPushButton *applyAllButton = nullptr;
+    QPushButton *clearForceButton = nullptr;
+    QPushButton *clearTorqueButton = nullptr;
+    QPushButton *cancelButton = nullptr;
+    for (auto it : buttons)
+    {
+      QVERIFY(it);
+      if (it->text().toLower().toStdString() == "apply force")
+        applyForceButton = it;
+      else if (it->text().toLower().toStdString() == "apply torque")
+        applyTorqueButton = it;
+      else if (it->text().toLower().toStdString() == "apply all")
+        applyAllButton = it;
+      else if (it->text().toLower().toStdString() == "clear" && !clearForceButton)
+        clearForceButton = it;
+      else if (it->text().toLower().toStdString() == "clear")
+        clearTorqueButton = it;
+      else if (it->text().toLower().toStdString() == "cancel")
+        cancelButton = it;
+    }
+    QVERIFY(applyForceButton);
+    QVERIFY(applyTorqueButton);
+    QVERIFY(applyAllButton);
+    QVERIFY(clearForceButton);
+    QVERIFY(clearTorqueButton);
+    QVERIFY(cancelButton);
+
+    // Set and apply force on X axis, magnitude 1000
+    spins[0]->setValue(1.0);
+    spins[3]->setValue(1000.0);
+    applyForceButton->click();
+
+    this->ProcessEventsAndDraw(mainWindow);
+
+    // Check that force spin was updated according to magnitude
+    QCOMPARE(spins[0]->value(), 1000.0);
+
+    // Check that link moved on X axis
+    QVERIFY(boxLinkPose.Pos().X() < boxLinkVis->WorldPose().Pos().X());
+    QVERIFY(boxLinkPose.Pos().Y() -
+        boxLinkVis->WorldPose().Pos().Y() < 1e-6);
+    QVERIFY(boxLinkPose.Pos().Z() -
+        boxLinkVis->WorldPose().Pos().Z() < 1e-6);
+    QCOMPARE(boxLinkPose.Rot(), boxLinkVis->WorldPose().Rot());
+
+    // Save current pose
+    boxLinkPose = boxLinkVis->WorldPose();
+
+    // Set and apply torque about -Z axis, magnitude 1000
+    spins[9]->setValue(-1.0);
+    spins[10]->setValue(1000.0);
+    applyTorqueButton->click();
+
+    this->ProcessEventsAndDraw(mainWindow);
+
+    // Check that torque spin was updated according to magnitude
+    QCOMPARE(spins[9]->value(), -1000.0);
+
+    // Check that link rotated
+    QVERIFY(boxLinkPose.Pos().X() < boxLinkVis->WorldPose().Pos().X());
+    QVERIFY(boxLinkPose.Pos().Y() -
+        boxLinkVis->WorldPose().Pos().Y() < 1e-6);
+    QVERIFY(boxLinkPose.Pos().Z() -
+        boxLinkVis->WorldPose().Pos().Z() < 1e-6);
+    QVERIFY(boxLinkPose.Rot() != boxLinkVis->WorldPose().Rot());
+
+    // Save current pose
+    boxLinkPose = boxLinkVis->WorldPose();
+
+    // Apply force and torque
+    applyAllButton->click();
+
+    this->ProcessEventsAndDraw(mainWindow);
+
+    // Check that link translated and rotated
+    QVERIFY(boxLinkPose.Pos() != boxLinkVis->WorldPose().Pos());
+    QVERIFY(boxLinkPose.Rot() != boxLinkVis->WorldPose().Rot());
+
+    // Change link
+    comboBoxes[0]->setCurrentIndex(1);
+    QVERIFY(comboBoxes[0]->currentText() == currentUnscopedSphereLink);
+
+    // Clear force
+    clearForceButton->click();
+    QCOMPARE(spins[0]->value(), 0.0);
+    QCOMPARE(spins[1]->value(), 0.0);
+    QCOMPARE(spins[2]->value(), 0.0);
+    QCOMPARE(spins[3]->value(), 0.0);
+
+    // Clear torque
+    clearTorqueButton->click();
+    QCOMPARE(spins[7]->value(), 0.0);
+    QCOMPARE(spins[8]->value(), 0.0);
+    QCOMPARE(spins[9]->value(), 0.0);
+    QCOMPARE(spins[10]->value(), 0.0);
+
+    // Apply zero force and torque
+    applyAllButton->click();
+
+    this->ProcessEventsAndDraw(mainWindow);
+
+    // Check that link didn't move
+    QVERIFY(sphereLinkPose.Pos() == sphereLinkVis->WorldPose().Pos());
+    QVERIFY(sphereLinkPose.Rot() == sphereLinkVis->WorldPose().Rot());
+
+    // Set and apply force on Y axis with an offset on X
+    spins[1]->setValue(1000.0);
+    spins[4]->setValue(1.0);
+    applyForceButton->click();
+
+    this->ProcessEventsAndDraw(mainWindow);
+
+    // Check that link translated and rotated
+    QVERIFY(sphereLinkPose.Pos() != sphereLinkVis->WorldPose().Pos());
+    QVERIFY(sphereLinkPose.Rot() != sphereLinkVis->WorldPose().Rot());
+
+    // Select CoM as application point
+    radioButtons[0]->click();
+
+    this->ProcessEventsAndDraw(mainWindow);
+
+    // Check that force offset spins were updated
+    QCOMPARE(spins[4]->value(), 0.0);
+    QCOMPARE(spins[5]->value(), 0.0);
+    QCOMPARE(spins[6]->value(), 0.0);
+
+    // Close dialog
+    cancelButton->click();
+
+    this->ProcessEventsAndDraw(mainWindow);
+
+    delete applyWrenchDialog;
   }
-  QVERIFY(applyForceButton);
-  QVERIFY(applyTorqueButton);
-  QVERIFY(applyAllButton);
-  QVERIFY(clearForceButton);
-  QVERIFY(clearTorqueButton);
-  QVERIFY(cancelButton);
 
-  // Set and apply force on X axis, magnitude 1000
-  spins[0]->setValue(1.0);
-  spins[3]->setValue(1000.0);
-  applyForceButton->click();
-
-  this->ProcessEventsAndDraw(mainWindow);
-
-  // Check that force spin was updated according to magnitude
-  QCOMPARE(spins[0]->value(), 1000.0);
-
-  // Check that link moved on X axis
-  QVERIFY(boxLinkPose.Pos().X() < boxLinkVis->WorldPose().Pos().X());
-  QVERIFY(boxLinkPose.Pos().Y() -
-      boxLinkVis->WorldPose().Pos().Y() < 1e-6);
-  QVERIFY(boxLinkPose.Pos().Z() -
-      boxLinkVis->WorldPose().Pos().Z() < 1e-6);
-  QCOMPARE(boxLinkPose.Rot(), boxLinkVis->WorldPose().Rot());
-
-  // Save current pose
-  boxLinkPose = boxLinkVis->WorldPose();
-
-  // Set and apply torque about -Z axis, magnitude 1000
-  spins[9]->setValue(-1.0);
-  spins[10]->setValue(1000.0);
-  applyTorqueButton->click();
-
-  this->ProcessEventsAndDraw(mainWindow);
-
-  // Check that torque spin was updated according to magnitude
-  QCOMPARE(spins[9]->value(), -1000.0);
-
-  // Check that link rotated
-  QVERIFY(boxLinkPose.Pos().X() < boxLinkVis->WorldPose().Pos().X());
-  QVERIFY(boxLinkPose.Pos().Y() -
-      boxLinkVis->WorldPose().Pos().Y() < 1e-6);
-  QVERIFY(boxLinkPose.Pos().Z() -
-      boxLinkVis->WorldPose().Pos().Z() < 1e-6);
-  QVERIFY(boxLinkPose.Rot() != boxLinkVis->WorldPose().Rot());
-
-  // Save current pose
-  boxLinkPose = boxLinkVis->WorldPose();
-
-  // Apply force and torque
-  applyAllButton->click();
-
-  this->ProcessEventsAndDraw(mainWindow);
-
-  // Check that link translated and rotated
-  QVERIFY(boxLinkPose.Pos() != boxLinkVis->WorldPose().Pos());
-  QVERIFY(boxLinkPose.Rot() != boxLinkVis->WorldPose().Rot());
-
-  // Change link
-  comboBoxes[0]->setCurrentIndex(1);
-  QVERIFY(comboBoxes[0]->currentText() == "sphere_link");
-
-  // Clear force
-  clearForceButton->click();
-  QCOMPARE(spins[0]->value(), 0.0);
-  QCOMPARE(spins[1]->value(), 0.0);
-  QCOMPARE(spins[2]->value(), 0.0);
-  QCOMPARE(spins[3]->value(), 0.0);
-
-  // Clear torque
-  clearTorqueButton->click();
-  QCOMPARE(spins[7]->value(), 0.0);
-  QCOMPARE(spins[8]->value(), 0.0);
-  QCOMPARE(spins[9]->value(), 0.0);
-  QCOMPARE(spins[10]->value(), 0.0);
-
-  // Apply zero force and torque
-  applyAllButton->click();
-
-  this->ProcessEventsAndDraw(mainWindow);
-
-  // Check that link didn't move
-  QVERIFY(sphereLinkPose.Pos() == sphereLinkVis->WorldPose().Pos());
-  QVERIFY(sphereLinkPose.Rot() == sphereLinkVis->WorldPose().Rot());
-
-  // Set and apply force on Y axis with an offset on X
-  spins[1]->setValue(1000.0);
-  spins[4]->setValue(1.0);
-  applyForceButton->click();
-
-  this->ProcessEventsAndDraw(mainWindow);
-
-  // Check that link translated and rotated
-  QVERIFY(sphereLinkPose.Pos() != sphereLinkVis->WorldPose().Pos());
-  QVERIFY(sphereLinkPose.Rot() != sphereLinkVis->WorldPose().Rot());
-
-  // Select CoM as application point
-  radioButtons[0]->click();
-
-  this->ProcessEventsAndDraw(mainWindow);
-
-  // Check that force offset spins were updated
-  QCOMPARE(spins[4]->value(), 0.0);
-  QCOMPARE(spins[5]->value(), 0.0);
-  QCOMPARE(spins[6]->value(), 0.0);
-
-  // Close dialog
-  cancelButton->click();
-
-  this->ProcessEventsAndDraw(mainWindow);
-
-  delete applyWrenchDialog;
-
+  //Cleanup
   cam->Fini();
   mainWindow->close();
   delete mainWindow;

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -169,7 +169,6 @@ ModelRightMenu::~ModelRightMenu()
 void ModelRightMenu::Run(const std::string &_entityName, const QPoint &_pt,
     EntityTypes _type)
 {
-
   // Set to scoped name
   this->entityName = _entityName;
 
@@ -281,10 +280,10 @@ void ModelRightMenu::OnApplyWrench()
   {
     modelName = this->entityName;
     // If model selected just take the first link
-    for(unsigned int i = 0; i < vis->GetChildCount(); ++i)
+    for (unsigned int i = 0; i < vis->GetChildCount(); ++i)
     {
       rendering::VisualPtr currentChild = vis->GetChild(i);
-      if(currentChild->GetType() == rendering::Visual::VT_LINK)
+      if (currentChild->GetType() == rendering::Visual::VT_LINK)
       {
         linkName = currentChild->Name();
         break;

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -169,14 +169,15 @@ ModelRightMenu::~ModelRightMenu()
 void ModelRightMenu::Run(const std::string &_entityName, const QPoint &_pt,
     EntityTypes _type)
 {
+
   // Find out the entity type
-  if (_type == EntityTypes::MODEL)
-  {
-    this->entityName = _entityName.substr(0, _entityName.find("::"));
-  }
-  else if (_type == EntityTypes::LINK || _type == EntityTypes::LIGHT)
+  if (_type == EntityTypes::MODEL || _type == EntityTypes::LIGHT)
   {
     this->entityName = _entityName;
+  }
+  else if (_type == EntityTypes::LINK)
+  {
+    this->entityName = _entityName.substr(0, _entityName.rfind("::"));
   }
 
   QMenu menu;
@@ -287,12 +288,26 @@ void ModelRightMenu::OnApplyWrench()
   {
     modelName = this->entityName;
     // If model selected just take the first link
-    linkName = vis->GetChild(0)->Name();
+    for(unsigned int i = 0; i < vis->GetChildCount(); i++){
+      rendering::VisualPtr currentChild = vis->GetChild(i);
+      if(currentChild->GetType() == rendering::Visual::VT_LINK){
+        linkName = currentChild->Name();
+        break;
+      }
+    }
+
+    //TODO: Determine what to do with model without any links
   }
   else
   {
-    modelName = vis->GetRootVisual()->Name();
-    linkName = this->entityName;
+    modelName = this->entityName;
+    for(unsigned int i = 0; i < vis->GetChildCount(); i++){
+      rendering::VisualPtr currentChild = vis->GetChild(i);
+      if(currentChild->GetType() == rendering::Visual::VT_LINK){
+        linkName = currentChild->Name();
+        break;
+      }
+    }
   }
 
   applyWrenchDialog->Init(modelName, linkName);

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -281,15 +281,15 @@ void ModelRightMenu::OnApplyWrench()
   {
     modelName = this->entityName;
     // If model selected just take the first link
-    for(unsigned int i = 0; i < vis->GetChildCount(); i++){
+    for(unsigned int i = 0; i < vis->GetChildCount(); ++i)
+    {
       rendering::VisualPtr currentChild = vis->GetChild(i);
-      if(currentChild->GetType() == rendering::Visual::VT_LINK){
+      if(currentChild->GetType() == rendering::Visual::VT_LINK)
+      {
         linkName = currentChild->Name();
         break;
       }
     }
-
-    //TODO: Determine what to do with model without any links
   }
   else
   {

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -170,7 +170,7 @@ void ModelRightMenu::Run(const std::string &_entityName, const QPoint &_pt,
     EntityTypes _type)
 {
 
-  // Set to unscoped name
+  // Set to scoped name
   this->entityName = _entityName;
 
   QMenu menu;

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -292,8 +292,12 @@ void ModelRightMenu::OnApplyWrench()
   }
   else
   {
-    modelName = this->entityName.substr(0, this->entityName.rfind("::"));
-    linkName = this->entityName;
+    // Links should always have a parent
+    if (vis->GetParent() != nullptr)
+    {
+      modelName = vis->GetParent()->Name();
+      linkName = this->entityName;
+    }
   }
 
   applyWrenchDialog->Init(modelName, linkName);

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -170,15 +170,8 @@ void ModelRightMenu::Run(const std::string &_entityName, const QPoint &_pt,
     EntityTypes _type)
 {
 
-  // Find out the entity type
-  if (_type == EntityTypes::MODEL || _type == EntityTypes::LIGHT)
-  {
-    this->entityName = _entityName;
-  }
-  else if (_type == EntityTypes::LINK)
-  {
-    this->entityName = _entityName.substr(0, _entityName.rfind("::"));
-  }
+  // Set to unscoped name
+  this->entityName = _entityName;
 
   QMenu menu;
 
@@ -284,7 +277,7 @@ void ModelRightMenu::OnApplyWrench()
   }
 
   std::string modelName, linkName;
-  if (vis == vis->GetRootVisual())
+  if (vis->GetType() == rendering::Visual::VT_MODEL)
   {
     modelName = this->entityName;
     // If model selected just take the first link
@@ -300,14 +293,8 @@ void ModelRightMenu::OnApplyWrench()
   }
   else
   {
-    modelName = this->entityName;
-    for(unsigned int i = 0; i < vis->GetChildCount(); i++){
-      rendering::VisualPtr currentChild = vis->GetChild(i);
-      if(currentChild->GetType() == rendering::Visual::VT_LINK){
-        linkName = currentChild->Name();
-        break;
-      }
-    }
+    modelName = this->entityName.substr(0, this->entityName.rfind("::"));
+    linkName = this->entityName;
   }
 
   applyWrenchDialog->Init(modelName, linkName);

--- a/worlds/multilink_shape.world
+++ b/worlds/multilink_shape.world
@@ -56,5 +56,56 @@
         </visual>
       </link>
     </model>
+    <model name="nested_outer">
+      <model name="nested_inner">
+        <pose>2 0 0.5 0 0 0</pose>
+        <link name="nested_box_link">
+          <pose>1 3 0 0 0 0</pose>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <script>
+                <uri>file://media/materials/scripts/gazebo.material</uri>
+                <name>Gazebo/Orange</name>
+              </script>
+            </material>
+          </visual>
+        </link>
+        <link name="nested_sphere_link">
+          <pose>-1.5 3 0 0 0 1.57</pose>
+          <collision name="collision">
+            <geometry>
+              <sphere>
+                <radius>0.5</radius>
+              </sphere>
+            </geometry>
+          </collision>
+          <visual name="visual">
+            <geometry>
+              <sphere>
+                <radius>0.5</radius>
+              </sphere>
+            </geometry>
+            <material>
+              <script>
+                <uri>file://media/materials/scripts/gazebo.material</uri>
+                <name>Gazebo/Blue</name>
+              </script>
+            </material>
+          </visual>
+        </link>
+      </model>
+    </model>
   </world>
 </sdf>

--- a/worlds/nested_multilink_shape.world
+++ b/worlds/nested_multilink_shape.world
@@ -56,5 +56,56 @@
         </visual>
       </link>
     </model>
+    <model name="nested_outer">
+      <model name="nested_inner">
+        <pose>2 0 0.5 0 0 0</pose>
+        <link name="nested_box_link">
+          <pose>1 3 0 0 0 0</pose>
+          <collision name="collision">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+          </collision>
+          <visual name="visual">
+            <geometry>
+              <box>
+                <size>1 1 1</size>
+              </box>
+            </geometry>
+            <material>
+              <script>
+                <uri>file://media/materials/scripts/gazebo.material</uri>
+                <name>Gazebo/Orange</name>
+              </script>
+            </material>
+          </visual>
+        </link>
+        <link name="nested_sphere_link">
+          <pose>-1.5 3 0 0 0 1.57</pose>
+          <collision name="collision">
+            <geometry>
+              <sphere>
+                <radius>0.5</radius>
+              </sphere>
+            </geometry>
+          </collision>
+          <visual name="visual">
+            <geometry>
+              <sphere>
+                <radius>0.5</radius>
+              </sphere>
+            </geometry>
+            <material>
+              <script>
+                <uri>file://media/materials/scripts/gazebo.material</uri>
+                <name>Gazebo/Blue</name>
+              </script>
+            </material>
+          </visual>
+        </link>
+      </model>
+    </model>
   </world>
 </sdf>


### PR DESCRIPTION
The following fixes were applied due to issues encountered when selecting `Apply Force/Torque` for nested models and its links from `ModelRightMenu`:
- `ModelRightMenu::Run()` previously set the `entityName` for nested models to be the model name before the first `::` delimiter, or the top-most parent model. This incorrectly initializes ApplyWrenchDialog for the top-most parent model rather than the nested model selected by the user. This was solved by setting `entityName` to the fully scoped name for all models.
- `ModelRightMenu::onApplyWrench()` previously made the assumption that the Visual for all models would be the RootVisual, however this is not the case for nested models. This was fixed by instead distinguishing models from links by their visual type: `Visual::VT_MODEL`.
- Unscoped link names within `ApplyWrenchDialog` were previously generated using `std::string::find()` with the `::` delimiter; however, this only removes the top-most parent model in nested models, leaving a partially-scoped link name. This is resolved by the using `std::string::find()` to locate the start of the model name within the scoped link name and then extracting the sub-string following the model name as the unscoped link name.
- The ComboBox for Links in the `ApplyWrenchDialog` previously included nested models within the list. This was fixed by type checking each Visual when generating the ComboBox to ensure each element is of type: `Visual::VT_LINK`.

The following changes were made for testing:
- A new world `nested_multilink_shape.world` was created to properly test the changes made. The existing "nested_model.world" could not be used since each model only has a single link, not allowing selecting multiple links from the Link ComboBox in `ApplyWrenchDialog`. The "multilink_shape.world" could also not be updated to add another nested model since other tests for `ModelListWidget` rely on it having only 1 model.
- The `ApplyWrenchDialog_TEST::ApplyForceTorqueFromDialog()` test was updated to use the `nested_multilink_shape.world` and was configured with a for-loop to apply the same exact tests to the nested model as are applied to the original model.

Tests were **not** included for the changes to `ModelRightMenu` since this class was previously un-tested and the effects of the code changes reside in private functions that are connected to private `QAction`s. In addition, the `QMenu` in which these actions reside is a local variable without a parent `QWidget` and is therefore inaccessible from any unit testing files. However, the formatting of the model name and link name in `ModelRightMenu::onApplyWrench()` can be seen to be of the same format as used for direct testing in `ApplyWrenchDialog_TEST::ApplyForceTorqueFromDialog()`.