### PR TITLE
Backport PR #3030 to Gazebo9 for CURL fixes

### DIFF
--- a/gazebo/CMakeLists.txt
+++ b/gazebo/CMakeLists.txt
@@ -16,7 +16,6 @@ link_directories(
   ${SDFormat_LIBRARY_DIRS}
   ${PROJECT_BINARY_DIR}/test
   ${TBB_LIBRARY_DIR}
-  ${CURL_LIBDIR}
   ${IGNITION-MSGS_LIBRARY_DIRS}
 )
 

--- a/gazebo/common/CMakeLists.txt
+++ b/gazebo/common/CMakeLists.txt
@@ -17,14 +17,6 @@ if (HAVE_GDAL)
   include_directories(${GDAL_INCLUDE_DIR})
 endif()
 
-if (CURL_FOUND)
-  include_directories(${CURL_INCLUDEDIR})
-  link_directories(${CURL_LIBDIR})
-  if (WIN32)
-    add_definitions(-DCURL_STATICLIB)
-  endif()
-endif()
-
 include_directories(${tinyxml_INCLUDE_DIRS})
 link_directories(${tinyxml_LIBRARY_DIRS})
 

--- a/gazebo/common/CMakeLists.txt
+++ b/gazebo/common/CMakeLists.txt
@@ -304,7 +304,7 @@ target_link_libraries(gazebo_common
   ${libavformat_LIBRARIES}
   ${libavutil_LIBRARIES}
   ${libavdevice_LIBRARIES}
-  ${CURL_LIBRARIES}
+  CURL::libcurl
   ${libswscale_LIBRARIES}
   ${libtar_LIBRARIES}
   ${TBB_LIBRARIES}

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -23,7 +23,6 @@ if(WIN32 AND NOT UNIX)
 endif()
 
 include_directories(SYSTEM
-  ${CURL_INCLUDEDIR}
   ${PROJECT_SOURCE_DIR}
   ${PROTOBUF_INCLUDE_DIR}
   ${SDFormat_INCLUDE_DIRS}
@@ -48,15 +47,11 @@ include_directories(SYSTEM
 # failures in clang.
 link_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${CURL_LIBDIR}
   ${CCD_LIBRARY_DIRS}
   ${SDFormat_LIBRARY_DIRS}
   ${tinyxml_LIBRARY_DIRS}
 )
 
-if (WIN32)
-  add_definitions(-DCURL_STATICLIB)
-endif()
 add_definitions(${Qt5Core_DEFINITIONS})
 set (CMAKE_AUTOMOC ON)
 
@@ -188,6 +183,8 @@ target_include_directories(SimpleTrackedVehiclePlugin SYSTEM PRIVATE
         ${CMAKE_SOURCE_DIR}/deps/opende/include)
 target_link_libraries(SimpleTrackedVehiclePlugin TrackedVehiclePlugin)
 add_dependencies(SimpleTrackedVehiclePlugin TrackedVehiclePlugin)
+
+target_link_libraries(StaticMapPlugin CURL::libcurl)
 
 target_link_libraries(WheelTrackedVehiclePlugin TrackedVehiclePlugin)
 add_dependencies(WheelTrackedVehiclePlugin TrackedVehiclePlugin)

--- a/plugins/rest_web/CMakeLists.txt
+++ b/plugins/rest_web/CMakeLists.txt
@@ -41,7 +41,10 @@ include_directories(
 )
 
 add_library(RestWebPlugin SHARED ${server_src} )
-target_link_libraries(RestWebPlugin ${GAZEBO_libraries} gazebo_msgs)
+target_link_libraries(RestWebPlugin
+  CURL::libcurl
+  ${GAZEBO_libraries}
+  gazebo_msgs)
 install (TARGETS RestWebPlugin DESTINATION ${GAZEBO_PLUGIN_INSTALL_DIR})
 gz_install_includes("plugins" ${server_inc})
 

--- a/plugins/rest_web/RestUiLoginDialog.cc
+++ b/plugins/rest_web/RestUiLoginDialog.cc
@@ -16,7 +16,6 @@
 */
 
 #include <iostream>
-#include <curl/curl.h>
 
 #include "RestUiLoginDialog.hh"
 #include "RestUiWidget.hh"

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -24,14 +24,6 @@ if (HAVE_DART)
   link_directories(${DART_LIBRARY_DIRS})
 endif()
 
-if (CURL_FOUND)
-  include_directories(${CURL_INCLUDEDIR})
-  link_directories(${CURL_LIBDIR})
-  if (WIN32)
-    add_definitions(-DCURL_STATICLIB)
-  endif()
-endif()
-
 if(NOT WIN32)
   # gz_TEST and gz_log_TEST use fork(), that is not available on Windows
   set (test_sources


### PR DESCRIPTION
Gazebo9 on Windows is currently failing with problems related to linking of CURL
against .dll instead of using .lib. Seems to me the name problem described and 
solved by https://github.com/osrf/gazebo/pull/3030.

This PR backports the code to gazebo9 branch.
