### PR TITLE
make events threadsafe

### DIFF
--- a/gazebo/common/Event.hh
+++ b/gazebo/common/Event.hh
@@ -611,6 +611,7 @@ namespace gazebo
     template<typename T>
     EventT<T>::~EventT()
     {
+      std::lock_guard<std::mutex> lock(this->mutex);
       this->connections.clear();
     }
 

--- a/gazebo/common/Event.hh
+++ b/gazebo/common/Event.hh
@@ -593,7 +593,7 @@ namespace gazebo
       private: EvtConnectionMap connections;
 
       /// \brief A thread lock.
-      private: std::mutex mutex;
+      private: mutable std::mutex mutex;
 
       /// \brief List of connections to remove
       private: std::list<typename EvtConnectionMap::const_iterator>

--- a/gazebo/common/Event.hh
+++ b/gazebo/common/Event.hh
@@ -277,7 +277,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback0");
             iter.second->callback();
@@ -298,7 +298,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback1");
             iter.second->callback(_p);
@@ -320,7 +320,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback2");
             iter.second->callback(_p1, _p2);
@@ -343,7 +343,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback3");
             iter.second->callback(_p1, _p2, _p3);
@@ -368,7 +368,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback4");
             iter.second->callback(_p1, _p2, _p3, _p4);
@@ -395,7 +395,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback5");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5);
@@ -423,7 +423,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback6");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6);
@@ -452,7 +452,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback7");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6, _p7);
@@ -483,7 +483,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback8");
             iter.second->callback(_p1, _p2, _p3, _p4, _p5, _p6, _p7, _p8);
@@ -516,7 +516,7 @@ namespace gazebo
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback9");
             iter.second->callback(
@@ -544,14 +544,14 @@ namespace gazebo
                   const P4 &_p4, const P5 &_p5, const P6 &_p6, const P7 &_p7,
                   const P8 &_p8, const P9 &_p9, const P10 &_p10)
       {
+        IGN_PROFILE("Event::Signal");
+
         this->Cleanup();
 
         this->SetSignaled(true);
         for (const auto &iter: this->connections)
         {
-          IGN_PROFILE("Event::Signal");
-
-          if (iter.second->on)
+          if ((iter.second != NULL) && iter.second->on)
           {
             IGN_PROFILE_BEGIN("callback10");
             iter.second->callback(
@@ -619,6 +619,7 @@ namespace gazebo
     template<typename T>
     ConnectionPtr EventT<T>::Connect(const std::function<T> &_subscriber)
     {
+      std::lock_guard<std::mutex> lock(this->mutex);
       int index = 0;
       if (!this->connections.empty())
       {
@@ -634,6 +635,7 @@ namespace gazebo
     template<typename T>
     unsigned int EventT<T>::ConnectionCount() const
     {
+      std::lock_guard<std::mutex> lock(this->mutex);
       return this->connections.size();
     }
 
@@ -642,6 +644,7 @@ namespace gazebo
     template<typename T>
     void EventT<T>::Disconnect(int _id)
     {
+      std::lock_guard<std::mutex> lock(this->mutex);
       // Find the connection
       auto const &it = this->connections.find(_id);
 
@@ -653,6 +656,7 @@ namespace gazebo
     }
 
     /////////////////////////////////////////////
+    /// \brief Erases all connections from connectionsToRemove.
     template<typename T>
     void EventT<T>::Cleanup()
     {

--- a/gazebo/common/Event_TEST.cc
+++ b/gazebo/common/Event_TEST.cc
@@ -16,6 +16,8 @@
 */
 
 #include <functional>
+#include <future>
+#include <thread>
 #include <gtest/gtest.h>
 #include <gazebo/common/Time.hh>
 #include <gazebo/common/Event.hh>
@@ -219,6 +221,78 @@ TEST_F(EventTest, ManyChanges)
   EXPECT_EQ(g_callback, 3);
   EXPECT_EQ(g_callback1, 2);
 }
+
+
+/////////////////////////////////////////////////
+// Race condition helper functions
+void create_connections(event::EventT<void ()> & evt,
+                        std::future<void> exit_obj_add,
+                        std::list<event::ConnectionPtr> & connection_list)
+{
+  std::cout << "Start create connections thread" << std::endl;
+  while(exit_obj_add.wait_for(std::chrono::milliseconds(1)) ==
+        std::future_status::timeout) {
+    event::ConnectionPtr conn = evt.Connect(std::bind(&callback));
+    connection_list.push_front(conn);
+  }
+}
+
+void access_connections(event::EventT<void ()> & evt,
+                       std::future<void> exit_obj_add)
+{
+  std::cout << "Start access thread" << std::endl;
+  while(exit_obj_add.wait_for(std::chrono::milliseconds(1)) ==
+        std::future_status::timeout)
+    // just calling the method without any other intent
+    evt.ConnectionCount();
+}
+
+
+void remove_connections(event::EventT<void ()> & evt,
+                        std::list<event::ConnectionPtr> & connection_list)
+{
+  std::cout << "Start remove thread" << std::endl;
+  for (auto const& connection : connection_list) {
+    evt.Disconnect(connection->Id());
+  }
+}
+
+TEST_F(EventTest, RaceConditions)
+{
+  // Create three threads: 1) add_t to insert connections, 2) access_t to call
+  // the count method 3) remove_t
+  std::list<event::ConnectionPtr> connection_list;
+  event::EventT<void ()> evt;
+  std::promise<void> exit_signal;
+  std::promise<void> exit_signal2;
+  std::future<void> exit_obj_add = exit_signal.get_future();
+  std::future<void> exit_obj_access = exit_signal2.get_future();
+  // Run threads 1 and 2
+  std::thread add_t(create_connections, std::ref(evt),
+                    std::move(exit_obj_add),
+                    std::ref(connection_list));
+  std::thread access_t(access_connections, std::ref(evt),
+                       std::move(exit_obj_access));
+  // Give 1 second to adding and accessing threads and start the remove thread
+  // leave all them working for 2 seconds.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  std::thread remove_t(remove_connections,
+                      std::ref(evt),
+                      std::ref(connection_list));
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  // Enable the event, call connection count and destroy it trying to make a
+  // possible race condition to appear.
+  evt();
+  evt.ConnectionCount();
+  evt.~EventT();
+
+  exit_signal.set_value();
+  add_t.join();
+  exit_signal2.set_value();
+  access_t.join();
+  remove_t.join();
+}
+
 
 /////////////////////////////////////////////////
 int main(int argc, char **argv)


### PR DESCRIPTION

Fixes Per issue #2874, race conditions can occur between `EventT::Connect` and `EventT::Signal`. In order to address this, add lock on `Connect`.

However, this only keeps thread-safety between `Connect` (insert) and the `Cleanup` (delete) referenced from `Signal`. There is still potential race condition between the rest of `Signal` (access) and `Connect` (insert). Adding a mutex lock guard here however will lock up the program as there appears to be a `Connect` call from a callback, and using recursive mutexes will impact performance to some extent.

Instead, since the conflict occurs between connection insertion and access, add a null check before accessing to each `Signal` definition.