### PR TITLE
CMake exports: remove -std=c++11 flag

### DIFF
--- a/cmake/gazebo-config.cmake.in
+++ b/cmake/gazebo-config.cmake.in
@@ -134,10 +134,6 @@ if (GAZEBO_HAS_DART)
   list(APPEND @PKG_NAME@_LIBRARIES ${DART_LIBRARIES})
 endif()
 
-# Visual Studio enables c++11 support by default
-if (NOT MSVC)
-  list(APPEND @PKG_NAME@_CXX_FLAGS -std=c++11)
-endif()
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND
     "${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
   set(@PKG_NAME@_CXX_FLAGS "${@PKG_NAME@_CXX_FLAGS} -stdlib=libc++")


### PR DESCRIPTION
Hello,

Currently, this package exports a `GAZEBO_CXX_FLAGS` containing `-std=c++11`. 
This looks obsolete, as it downgrade the default setting of most compilers for dependent packages.