### PR TITLE
Backport qwt 6.2 build fix to gazebo9

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -303,7 +303,7 @@ if (PKG_CONFIG_FOUND)
 
   #################################################
   # Find TBB
-  pkg_check_modules(TBB tbb)
+  pkg_check_modules(TBB tbb<2021)
   set (TBB_PKG_CONFIG "tbb")
   if (NOT TBB_FOUND)
     message(STATUS "TBB not found, attempting to detect manually")

--- a/gazebo/gui/GLWidget.cc
+++ b/gazebo/gui/GLWidget.cc
@@ -1369,7 +1369,7 @@ void GLWidget::SetMouseEventButtons(const Qt::MouseButtons &_buttons)
         this->dataPtr->mouseEvent.Buttons() | 0x0);
   }
 
-  if (_buttons & Qt::MidButton)
+  if (_buttons & Qt::MiddleButton)
   {
     this->dataPtr->mouseEvent.SetButtons(
         this->dataPtr->mouseEvent.Buttons() | common::MouseEvent::MIDDLE);
@@ -1388,6 +1388,6 @@ void GLWidget::SetMouseEventButton(const Qt::MouseButton &_button)
     this->dataPtr->mouseEvent.SetButton(common::MouseEvent::LEFT);
   else if (_button == Qt::RightButton)
     this->dataPtr->mouseEvent.SetButton(common::MouseEvent::RIGHT);
-  else if (_button == Qt::MidButton)
+  else if (_button == Qt::MiddleButton)
     this->dataPtr->mouseEvent.SetButton(common::MouseEvent::MIDDLE);
 }

--- a/gazebo/gui/plot/IncrementalPlot.cc
+++ b/gazebo/gui/plot/IncrementalPlot.cc
@@ -195,7 +195,7 @@ IncrementalPlot::IncrementalPlot(QWidget *_parent)
   // box zoom
   this->dataPtr->zoomer = new QwtPlotZoomer(this->canvas());
   this->dataPtr->zoomer->setMousePattern(QwtEventPattern::MouseSelect1,
-      Qt::MidButton);
+      Qt::MiddleButton);
   this->dataPtr->zoomer->setMousePattern(QwtEventPattern::MouseSelect2,
       Qt::RightButton, Qt::ControlModifier);
   this->dataPtr->zoomer->setMousePattern(QwtEventPattern::MouseSelect3,

--- a/gazebo/gui/plot/qwt_gazebo.h
+++ b/gazebo/gui/plot/qwt_gazebo.h
@@ -24,6 +24,7 @@
 #pragma clang diagnostic ignored "-Wfloat-equal"
 
 #include <qwt/qwt_curve_fitter.h>
+#include <qwt/qwt_global.h>
 #include <qwt/qwt_legend.h>
 #include <qwt/qwt_painter.h>
 #include <qwt/qwt_picker_machine.h>
@@ -38,6 +39,7 @@
 #include <qwt/qwt_plot_panner.h>
 #include <qwt/qwt_plot_zoomer.h>
 #include <qwt/qwt_scale_engine.h>
+#include <qwt/qwt_scale_map.h>
 #include <qwt/qwt_scale_widget.h>
 #include <qwt/qwt_symbol.h>
 #include <qwt/qwt_plot_renderer.h>


### PR DESCRIPTION
Backport #3047 to gazebo9 to fix build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo9-homebrew-amd64&build=205)](https://build.osrfoundation.org/job/gazebo-ci-gazebo9-homebrew-amd64/205/) https://build.osrfoundation.org/job/gazebo-ci-gazebo9-homebrew-amd64/205/

* IncrementalPlot.cc: include qwt_scale_map.h
* Use Qt::MiddleButton to fix deprecation warning
* PlotCurve: add private helper for renamed members

In qwt 6.2, they have renamed all member variables,
so create helper functions to minimize the ifdefs we will need
to support both versions.

* PlotCurve: add ifdefs to support qwt 6.2.0

Remember to use Rebase and Merge.