### PR TITLE
Add colcon.pkg with hook for setup.bash

### DIFF
--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,8 @@
+# Configuration file for colcon (https://colcon.readthedocs.io).
+#
+# Please see the doc for the details of the spec:
+#   - https://colcon.readthedocs.io/en/released/user/configuration.html#colcon-pkg-files
+
+{
+    "hooks": ["share/gazebo/setup.bash"]
+}


### PR DESCRIPTION
This will cause gazebo's relocatable setup.bash script (recently added in #3061) to be sourced automatically when sourcing a colcon setup.bash script.