### PR TITLE
Initialize default shadow caster name in Scene

### DIFF
--- a/gazebo/rendering/ScenePrivate.hh
+++ b/gazebo/rendering/ScenePrivate.hh
@@ -378,7 +378,7 @@ namespace gazebo
       public: std::map<int32_t, bool> layerState;
 
       /// \brief Shadow caster material name
-      public: std::string shadowCasterMaterialName;
+      public: std::string shadowCasterMaterialName = "Gazebo/shadow_caster";
     };
   }
 }


### PR DESCRIPTION
Since #3048, we can now specify the name of a shadow caster material to be used in a scene. This is parsed from the SDFormat world file by `gazebo::physics::World` and exposed to `gazebo::rendering::Scene` by an ion-transport service. If the service call fails, however, the `Scene` does not have a valid name for the shadow caster material. This sets the default value for the shadow caster material name in the `Scene` to match the default value in [World.cc](https://github.com/osrf/gazebo/blob/17c693050d43c8348e2e64a149ac4f3e6bd93daa/gazebo/physics/World.cc#L229).