### PR TITLE
Distortion::RefreshCompositor check nonzero params

### DIFF
--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -433,6 +433,16 @@ void Distortion::SetCamera(CameraPtr _camera)
 //////////////////////////////////////////////////
 void Distortion::RefreshCompositor(CameraPtr _camera)
 {
+  // If no distortion is required, immediately return.
+  if (ignition::math::equal(this->dataPtr->k1, 0.0) &&
+      ignition::math::equal(this->dataPtr->k2, 0.0) &&
+      ignition::math::equal(this->dataPtr->k3, 0.0) &&
+      ignition::math::equal(this->dataPtr->p1, 0.0) &&
+      ignition::math::equal(this->dataPtr->p2, 0.0))
+  {
+    return;
+  }
+
   if (this->dataPtr->lensDistortionInstance) {
     Ogre::CompositorManager::getSingleton().removeCompositor(
       _camera->OgreViewport(), this->dataPtr->compositorName);


### PR DESCRIPTION
There is a small regression from the fix in #3060 when a camera has a `<distortion/>` block containing `k` and `p` parameters with all `0` values like the following:

~~~
            <distortion>
              <k1>0</k1>
              <k2>0</k2>
              <k3>0</k3>
              <p1>0</p1>
              <p2>0</p2>
              <center>0.5 0.5</center>
            </distortion>
~~~

In this case, the `Distortion::SetCamera` method will be called because the camera contains a `<distortion/>` element, but `SetCamera` will return early without creating a compositor instance. For consistency, add the same check to the `RefreshCompositor` method, otherwise a compositor will be added without any of the configuration done in `SetCamera`.