### PR TITLE
Bump to 11.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set (GAZEBO_MINOR_VERSION 8)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.
-set (GAZEBO_PATCH_VERSION 0)
+set (GAZEBO_PATCH_VERSION 1)
 
 set (GAZEBO_VERSION ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION})
 set (GAZEBO_VERSION_FULL ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION}.${GAZEBO_PATCH_VERSION})

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## Gazebo 11
 
+## Gazebo 11.8.1 (2021-08-24)
+
+1. Fixes for shadow caster shaders
+    * [Pull request #3070](https://github.com/osrf/gazebo/pull/3070)
+
+1. Distortion::RefreshCompositor check nonzero params
+    * [Pull request #3071](https://github.com/osrf/gazebo/pull/3071)
+
 ## Gazebo 11.8.0 (2021-08-17)
 
 1. Find tbb version lower than 2021 with pkg-config


### PR DESCRIPTION
Quick patch release with two fixes needed by VIPER. Diff since 11.8.0: https://github.com/osrf/gazebo/compare/gazebo11_11.8.0...gazebo11