### PR TITLE
👩‍🌾 Remove bitbucket-pipelines

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,7 +1,0 @@
-image: ubuntu:bionic
-
-pipelines:
-  default:
-    - step:
-        script:
-          - apt-get update


### PR DESCRIPTION
Fixes https://github.com/ignition-tooling/release-tools/issues/203

This will make CI default to Bionic, so nothing would change.

Targeting `gazebo11` because the `gazebo9` branch doesn't have a `bitbucket-pipelines.yml` already.

---

https://github.com/osrf/buildfarmer/issues/224