### PR TITLE
Fix pkgconfig prefix with absolute CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -434,7 +434,7 @@ else (build_errors)
 
   file(RELATIVE_PATH
     PC_CONFIG_RELATIVE_PATH_TO_PREFIX
-    ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/pkgconfig
+    ${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig
     ${CMAKE_INSTALL_PREFIX}
   )
   foreach (pkgconfig ${pkgconfig_files})


### PR DESCRIPTION
#2879 introduced an assumption that `CMAKE_INSTALL_LIBDIR` is relative by concatenating it with `CMAKE_INSTALL_PREFIX`. Instead, this path should be formed using `CMAKE_INSTALL_FULL_LIBDIR`.

cc @Pro @scpeters