### PR TITLE
Add mutex lock in World::Step and World::Fini to fix test

### DIFF
--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -966,6 +966,17 @@ void World::Fini()
 
   // Clean transport
   {
+    // Clear subscribers first
+    this->dataPtr->controlSub.reset();
+    this->dataPtr->factorySub.reset();
+    this->dataPtr->jointSub.reset();
+    this->dataPtr->lightFactorySub.reset();
+    this->dataPtr->lightModifySub.reset();
+    this->dataPtr->lightSub.reset();
+    this->dataPtr->modelSub.reset();
+    this->dataPtr->playbackControlSub.reset();
+    this->dataPtr->requestSub.reset();
+
     this->dataPtr->deleteEntity.clear();
     this->dataPtr->requestMsgs.clear();
     this->dataPtr->factoryMsgs.clear();
@@ -982,16 +993,6 @@ void World::Fini()
     this->dataPtr->modelPub.reset();
     this->dataPtr->lightPub.reset();
     this->dataPtr->lightFactoryPub.reset();
-
-    this->dataPtr->factorySub.reset();
-    this->dataPtr->controlSub.reset();
-    this->dataPtr->playbackControlSub.reset();
-    this->dataPtr->requestSub.reset();
-    this->dataPtr->jointSub.reset();
-    this->dataPtr->lightSub.reset();
-    this->dataPtr->lightFactorySub.reset();
-    this->dataPtr->lightModifySub.reset();
-    this->dataPtr->modelSub.reset();
 
     if (this->dataPtr->node)
       this->dataPtr->node->Fini();

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -182,6 +182,9 @@ namespace gazebo
       /// Entity::SetWorldPose to call Entity::setWorldPoseFunc
       public: std::mutex setWorldPoseMutex;
 
+      /// \brief Used in World::Step and World::Fini
+      public: std::mutex stepMutex;
+
       /// \brief Used by World classs in following calls:
       /// World::Step for then entire function
       /// World::StepWorld for changing World::stepInc,


### PR DESCRIPTION
Add a mutex to ensure that another thread is not in `World::Step` when `World::Fini` runs. This should fix the failure of `INTEGRATION_world_remove`. I also re-ordered some statements cleaning up transport objects to ensure that subscribers are cleared first so their callbacks will stop being triggered.

Fixes #3077 and is motivated by backtraces reported in that issue (https://github.com/osrf/gazebo/issues/3077#issuecomment-916317896).