### PR TITLE
GaussianNoiseModel: fix for unspecified biasStdDev

### DIFF
--- a/gazebo/sensors/GaussianNoiseModel.cc
+++ b/gazebo/sensors/GaussianNoiseModel.cc
@@ -219,13 +219,16 @@ double GaussianNoiseModel::GetBias() const
 //////////////////////////////////////////////////
 void GaussianNoiseModel::SampleBias()
 {
-  this->bias =
-      ignition::math::Rand::DblNormal(this->biasMean, this->biasStdDev);
-  // With equal probability, we pick a negative bias (by convention,
-  // rateBiasMean should be positive, though it would work fine if
-  // negative).
-  if (ignition::math::Rand::DblUniform() < 0.5)
-    this->bias = -this->bias;
+  if(this->biasStdDev)
+  {
+    this->bias =
+        ignition::math::Rand::DblNormal(this->biasMean, this->biasStdDev);
+    // With equal probability, we pick a negative bias (by convention,
+    // rateBiasMean should be positive, though it would work fine if
+    // negative).
+    if (ignition::math::Rand::DblUniform() < 0.5)
+      this->bias = -this->bias;
+  }
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Fix #3015 

before it would result in a division by 0 if bias_stddev was not
specified, now it checks if it's > 0 before sampling