### PR TITLE
Fix Camera Distortion rounding

### DIFF
--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -191,7 +191,7 @@ void Distortion::SetCamera(CameraPtr _camera)
 
   // Half step-size vector to add to the value being placed in distortion map.
   // Necessary for compositor to correctly interpolate pixel values.
-  const auto halfStepVec =
+  const auto halfTexelSize =
       0.5 * ignition::math::Vector2d(rowStepSize, colStepSize);
 
   // initialize distortion map
@@ -284,13 +284,13 @@ void Distortion::SetCamera(CameraPtr _camera)
               currDistortedCoordinates.Distance(distortionCenterCoordinates))
           {
             this->dataPtr->distortionMap[distortedIdx] = normalizedLocation +
-              halfStepVec;
+              halfTexelSize;
           }
         }
         else
         {
           this->dataPtr->distortionMap[distortedIdx] = normalizedLocation +
-            halfStepVec;
+            halfTexelSize;
         }
       }
       // else: mapping is outside of the image bounds.


### PR DESCRIPTION
This PR makes a few small but necessary fixes to the distortion code.

The biggest issue is that there is a half-pixel shift applied to the entire image when distortion is active. You can see an example of that here, where k1 = -0.000005 and the rest of the distortion coefficients are 0. k1 is just large enough to have distortion enabled but not large enough to have any visible effects. But the top-side and left-side of the images have a dark-gray bar.

No distortion:
![distortion_rounding_no_distortion](https://user-images.githubusercontent.com/19412869/136106525-53812c6b-3bb3-4a91-adc9-f58fcfd318e0.png)

k1 = -0.000005:
![distortion_rounding_k1_n0p000005_test](https://user-images.githubusercontent.com/19412869/136106550-cd37f13c-3973-4ed2-b535-43285398c55d.png)

k1 = -0.000005 (zoomed in on top-left corner):
![distortion_rounding_k1_n0p000005_test_zoom1](https://user-images.githubusercontent.com/19412869/136106746-315824f7-f0e1-4b9e-9059-9f686e19fec0.png)

k1 = -0.000005 (zoomed in on left side in the middle of the checkerboard pattern):
![distortion_rounding_k1_n0p000005_test_zoom2](https://user-images.githubusercontent.com/19412869/136106917-1da2f4ac-8232-4e2c-9097-be3e40222515.png)

Note in the last image what appears to be an interpolation between the black & white squares (which does not exist in the non-distorted image). I believe this same interpolation is what is causing the gray bars on the top and left sides of the image, and I believe the cause is that the nested loop that populates the distortion map takes step sizes 0/IMAGE_SIZE, 1/IMAGE_SIZE, 2/IMAGE_SIZE, etc. When the distortion compositor gets this it tries to sample the pixels at the centers, which means the values in the distortion map should actually use step sizes 0.5/IMAGE_SIZE, 1.5/IMAGE_SIZE, 2.5/IMAGE_SIZE, etc.

Here is the resulting distorted image with k1 = -0.000005 with this change:
![distortion_rounding_k1_n0p000005_new_with_texside_for_loop_add_half_stepsizes_to_normalized_location](https://user-images.githubusercontent.com/19412869/136107352-bb756962-13eb-4c07-9fc8-cf80789f73c9.png)

There is no interpolation smoothing the entire image, and no visible distortion as we expect.

Another fix is rounding the distortion results. For a 2048x2048 image, k1 = -0.00075 should produce just enough distortion to distort the corners inwards diagonally by 1-pixel _if_ the resulting pixel locations post-distortion are rounded to the nearest integer, rather than rounding down (as is the current implementation prior to this fix). Here is a sample confirming this:
![distortion_rounding_k1_n0p00075_full_patch_no_interp_half_step_adding_test5](https://user-images.githubusercontent.com/19412869/136108473-4a30ac9c-d9b7-4663-a84e-e1e0a44d10b9.png)
(Note that to generate this image I manually removed the distortion map interpolation on lines 344-419. This doesn't affect the way the image gets distorted but it does make the test easier to see.)

The last fix is changing the distortion map size from texSide-1 by texSide-1 to just texSide by texSide. I don't know why there was the -1 before and it resulted in a distortion map that was not large enough to fill all the pixels of the image.

