### PR TITLE
Optionally disable "render back faces" for the shadow caster

### DIFF
--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -224,10 +224,6 @@ void World::Load(sdf::ElementPtr _sdf)
       this->dataPtr->sdf->GetElement("scene")->
         Get<std::string>("ignition:shadow_caster_material_name");
   }
-  else
-  {
-    this->dataPtr->shadowCasterMaterialName = "Gazebo/shadow_caster";
-  }
 
   if (this->dataPtr->sdf->GetElement("scene")->
       HasElement("ignition:shadow_caster_render_back_faces"))
@@ -235,10 +231,6 @@ void World::Load(sdf::ElementPtr _sdf)
     this->dataPtr->shadowCasterRenderBackFaces =
       this->dataPtr->sdf->GetElement("scene")->
         Get<bool>("ignition:shadow_caster_render_back_faces");
-  }
-  else
-  {
-    this->dataPtr->shadowCasterRenderBackFaces = true;
   }
 
   // The period at which messages are processed

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -229,6 +229,18 @@ void World::Load(sdf::ElementPtr _sdf)
     this->dataPtr->shadowCasterMaterialName = "Gazebo/shadow_caster";
   }
 
+  if (this->dataPtr->sdf->GetElement("scene")->
+      HasElement("ignition:shadow_caster_render_back_faces"))
+  {
+    this->dataPtr->shadowCasterRenderBackFaces =
+      this->dataPtr->sdf->GetElement("scene")->
+        Get<bool>("ignition:shadow_caster_render_back_faces");
+  }
+  else
+  {
+    this->dataPtr->shadowCasterRenderBackFaces = 1;
+  }
+
   // The period at which messages are processed
   this->dataPtr->processMsgsPeriod = common::Time(0, 200000000);
 
@@ -296,12 +308,21 @@ void World::Load(sdf::ElementPtr _sdf)
         << std::endl;
   }
 
-  std::string shadowCasterService("/shadow_caster_material_name");
-  if (!this->dataPtr->ignNode.Advertise(shadowCasterService,
-      &World::ShadowCasterService, this))
+  std::string shadowCasterMaterialNameService("/shadow_caster_material_name");
+  if (!this->dataPtr->ignNode.Advertise(shadowCasterMaterialNameService,
+      &World::ShadowCasterMaterialNameService, this))
   {
-    gzerr << "Error advertising service [" << shadowCasterService << "]"
-        << std::endl;
+    gzerr << "Error advertising service [" << 
+        shadowCasterMaterialNameService << "]" << std::endl;
+  }
+
+  std::string shadowCasterRenderBackFacesService(
+      "/shadow_caster_render_back_faces");
+  if (!this->dataPtr->ignNode.Advertise(shadowCasterRenderBackFacesService,
+      &World::ShadowCasterRenderBackFacesService, this))
+  {
+    gzerr << "Error advertising service [" << 
+        shadowCasterRenderBackFacesService << "]" << std::endl;
   }
 
   // This should come before loading of entities
@@ -3368,8 +3389,15 @@ bool World::PluginInfoService(const ignition::msgs::StringMsg &_req,
 }
 
 //////////////////////////////////////////////////
-bool World::ShadowCasterService(ignition::msgs::StringMsg &_res)
+bool World::ShadowCasterMaterialNameService(ignition::msgs::StringMsg &_res)
 {
   _res.set_data(this->dataPtr->shadowCasterMaterialName.c_str());
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool World::ShadowCasterRenderBackFacesService(ignition::msgs::Boolean &_res)
+{
+  _res.set_data(this->dataPtr->shadowCasterRenderBackFaces);
   return true;
 }

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -238,7 +238,7 @@ void World::Load(sdf::ElementPtr _sdf)
   }
   else
   {
-    this->dataPtr->shadowCasterRenderBackFaces = 1;
+    this->dataPtr->shadowCasterRenderBackFaces = true;
   }
 
   // The period at which messages are processed

--- a/gazebo/physics/World.hh
+++ b/gazebo/physics/World.hh
@@ -50,6 +50,7 @@ namespace ignition
   {
     class Plugin_V;
     class StringMsg;
+    class Boolean;
   }
 }
 
@@ -654,7 +655,16 @@ namespace gazebo
       /// \brief Callback for "<this_name>/shadow_caster_material_name" service.
       /// \param[out] _response Message containing shadow caster material name
       /// \return True if the info was successfully obtained.
-      private: bool ShadowCasterService(ignition::msgs::StringMsg &_response);
+      private: bool ShadowCasterMaterialNameService(
+          ignition::msgs::StringMsg &_response);
+
+      /// \brief Callback for "<this_name>/shadow_caster_render_back_faces" 
+      ///     service.
+      /// \param[out] _response Message containing shadow caster render back
+      ///     faces
+      /// \return True if the info was successfully obtained.
+      private: bool ShadowCasterRenderBackFacesService(
+          ignition::msgs::Boolean &_response);
 
       /// \internal
       /// \brief Private data pointer.

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -390,7 +390,7 @@ namespace gazebo
       public: std::unique_ptr<sdf::World> worldSDFDom;
 
       /// \brief Shadow caster material name from scene SDF
-      public: std::string shadowCasterMaterialName;
+      public: std::string shadowCasterMaterialName = "Gazebo/shadow_caster";
 
       /// \brief Shadow caster render back faces from scene SDF
       public: bool shadowCasterRenderBackFaces = true;

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -393,7 +393,7 @@ namespace gazebo
       public: std::string shadowCasterMaterialName;
 
       /// \brief Shadow caster render back faces from scene SDF
-      public: bool shadowCasterRenderBackFaces;
+      public: bool shadowCasterRenderBackFaces = true;
     };
   }
 }

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -391,6 +391,9 @@ namespace gazebo
 
       /// \brief Shadow caster material name from scene SDF
       public: std::string shadowCasterMaterialName;
+
+      /// \brief Shadow caster render back faces from scene SDF
+      public: bool shadowCasterRenderBackFaces;
     };
   }
 }

--- a/gazebo/rendering/RTShaderSystem.cc
+++ b/gazebo/rendering/RTShaderSystem.cc
@@ -788,7 +788,8 @@ void RTShaderSystem::UpdateShadows(ScenePtr _scene)
 #endif
 
   sceneMgr->setShadowTextureSelfShadow(false);
-  sceneMgr->setShadowCasterRenderBackFaces(true);
+  sceneMgr->setShadowCasterRenderBackFaces(
+      _scene->ShadowCasterRenderBackFaces());
 
   // TODO: We have two different shadow caster materials, both taken from
   // OGRE samples. They should be compared and tested.

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -207,24 +207,48 @@ Scene::Scene(const std::string &_name, const bool _enableVisualizations,
   this->dataPtr->sceneSimTimePosesApplied = common::Time();
   this->dataPtr->sceneSimTimePosesReceived = common::Time();
 
-  // Get shadow caster material name from physics::World
-  ignition::transport::Node node;
-  ignition::msgs::StringMsg rep;
-  const std::string serviceName = "/shadow_caster_material_name";
-  bool result;
-  unsigned int timeout = 5000;
-  bool executed = node.Request(serviceName,
-      timeout, rep, result);
-  if (executed)
   {
-    if (result)
-      this->dataPtr->shadowCasterMaterialName = rep.data();
+    // Get shadow caster material name from physics::World
+    ignition::transport::Node node;
+    ignition::msgs::StringMsg rep;
+    const std::string serviceName = "/shadow_caster_material_name";
+    bool result;
+    unsigned int timeout = 5000;
+    bool executed = node.Request(serviceName,
+        timeout, rep, result);
+    if (executed)
+    {
+      if (result)
+        this->dataPtr->shadowCasterMaterialName = rep.data();
+      else
+        gzerr << "Service call[" << serviceName << "] failed" << std::endl;
+    }
     else
-      gzerr << "Service call[" << serviceName << "] failed" << std::endl;
+    {
+      gzerr << "Service call[" << serviceName << "] timed out" << std::endl;
+    } 
   }
-  else
+
   {
-    gzerr << "Service call[" << serviceName << "] timed out" << std::endl;
+    // Get shadow caster render back faces from physics::World
+    ignition::transport::Node node;
+    ignition::msgs::Boolean rep;
+    const std::string serviceName = "/shadow_caster_render_back_faces";
+    bool result;
+    unsigned int timeout = 5000;
+    bool executed = node.Request(serviceName,
+        timeout, rep, result);
+    if (executed)
+    {
+      if (result)
+        this->dataPtr->shadowCasterRenderBackFaces = rep.data();
+      else
+        gzerr << "Service call[" << serviceName << "] failed" << std::endl;
+    }
+    else
+    {
+      gzerr << "Service call[" << serviceName << "] timed out" << std::endl;
+    } 
   }
 }
 
@@ -3309,6 +3333,12 @@ unsigned int Scene::ShadowTextureSize() const
 std::string Scene::ShadowCasterMaterialName() const
 {
   return this->dataPtr->shadowCasterMaterialName;
+}
+
+/////////////////////////////////////////////////
+bool Scene::ShadowCasterRenderBackFaces() const
+{
+  return this->dataPtr->shadowCasterRenderBackFaces;
 }
 
 /////////////////////////////////////////////////

--- a/gazebo/rendering/Scene.hh
+++ b/gazebo/rendering/Scene.hh
@@ -424,6 +424,10 @@ namespace gazebo
       /// \return Name of the shadow caster material
       public: std::string ShadowCasterMaterialName() const;
 
+      /// \brief Get the shadow caster render back faces
+      /// \return Shadow caster render back faces
+      public: bool ShadowCasterRenderBackFaces() const;
+
       /// \brief Add a visual to the scene
       /// \param[in] _vis Visual to add.
       public: void AddVisual(VisualPtr _vis);

--- a/gazebo/rendering/ScenePrivate.hh
+++ b/gazebo/rendering/ScenePrivate.hh
@@ -381,7 +381,7 @@ namespace gazebo
       public: std::string shadowCasterMaterialName = "Gazebo/shadow_caster";
 
       /// \brief Shadow caster render back faces
-      public: bool shadowCasterRenderBackFaces = 1;
+      public: bool shadowCasterRenderBackFaces = true;
     };
   }
 }

--- a/gazebo/rendering/ScenePrivate.hh
+++ b/gazebo/rendering/ScenePrivate.hh
@@ -379,6 +379,9 @@ namespace gazebo
 
       /// \brief Shadow caster material name
       public: std::string shadowCasterMaterialName = "Gazebo/shadow_caster";
+
+      /// \brief Shadow caster render back faces
+      public: bool shadowCasterRenderBackFaces = 1;
     };
   }
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -99,6 +99,7 @@ set(tests
   sensor.cc
   sdf_frame_semantics.cc
   server_fixture.cc
+  shadow_caster_render_back_faces.cc
   sim_events.cc
   speed.cc
   speed_thread_islands.cc

--- a/test/integration/shadow_caster_render_back_faces.cc
+++ b/test/integration/shadow_caster_render_back_faces.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "gazebo/test/ServerFixture.hh"
+#include "gazebo/sensors/sensors.hh"
+
+using namespace gazebo;
+class ShadowCasterRenderBackFacesTest : public ServerFixture
+{
+  /// \brief Test rendering back faces
+  public: void ShadowCasterBackFaces();
+
+  /// \brief Test rendering without back face
+  public: void ShadowCasterNoBackFaces();
+
+  /// \brief Counter for the numbder of image messages received.
+  public: unsigned int imageCount = 0u;
+
+  /// \brief Depth data buffer.
+  public: unsigned char* imageBuffer = nullptr;
+
+  /// \brief Camera image callback
+  /// \param[in] _msg Message with image data containing raw image values.
+  public: void OnImage(ConstImageStampedPtr &_msg);
+};
+
+/////////////////////////////////////////////////
+void ShadowCasterRenderBackFacesTest::OnImage(ConstImageStampedPtr &_msg)
+{
+  unsigned int imageSamples = _msg->image().width() *_msg->image().height() * 3;
+  memcpy(this->imageBuffer, _msg->image().data().c_str(), imageSamples);
+  this->imageCount++;
+}
+
+/////////////////////////////////////////////////
+// \brief The shadow caster will render back faces; The plane in the world will
+/// cast a shadow
+void ShadowCasterRenderBackFacesTest::ShadowCasterBackFaces()
+{
+  this->Load("worlds/shadow_caster_back_faces.world");
+
+  // Make sure the render engine is available.
+  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
+      rendering::RenderEngine::NONE)
+  {
+    gzerr << "No rendering engine, unable to run camera test\n";
+    return;
+  }
+
+  sensors::CameraSensorPtr sensor =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(
+      sensors::get_sensor("camera_normal"));
+  EXPECT_TRUE(sensor != nullptr);
+  EXPECT_TRUE(sensor->IsActive());
+
+  unsigned int width  = 320;
+  unsigned int height = 240;
+
+  this->imageCount = 0;
+  this->imageBuffer = new unsigned char[width * height*3];
+
+  transport::NodePtr node(new transport::Node());
+  node->Init();
+
+  std::string topic = sensor->Topic();
+  EXPECT_TRUE(!topic.empty());
+
+  transport::SubscriberPtr sub = node->Subscribe(topic,
+      &ShadowCasterRenderBackFacesTest::OnImage, this);
+
+  // wait for a few images
+  int i = 0;
+  while (this->imageCount < 10 && i < 300)
+  {
+    common::Time::MSleep(10);
+    i++;
+  }
+  EXPECT_LT(i, 300);
+
+  for (unsigned int x = 0; x < 320 * 240; x += 600) {
+    EXPECT_GT(50, this->imageBuffer[3 * x]);
+    EXPECT_GT(50, this->imageBuffer[3 * x + 1]);
+    EXPECT_GT(50, this->imageBuffer[3 * x + 2]);
+  }
+
+  delete this->imageBuffer;
+}
+
+/////////////////////////////////////////////////
+TEST_F(ShadowCasterRenderBackFacesTest, ShadowCasterBackFaces)
+{
+  ShadowCasterBackFaces();
+}
+
+/////////////////////////////////////////////////
+// \brief The shadow caster will not render back faces; The plane in the world 
+/// will not cast a shadow
+void ShadowCasterRenderBackFacesTest::ShadowCasterNoBackFaces()
+{
+  this->Load("worlds/shadow_caster_no_back_faces.world");
+
+  // Make sure the render engine is available.
+  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
+      rendering::RenderEngine::NONE)
+  {
+    gzerr << "No rendering engine, unable to run camera test\n";
+    return;
+  }
+
+  sensors::CameraSensorPtr sensor =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(
+      sensors::get_sensor("camera_normal"));
+  EXPECT_TRUE(sensor != nullptr);
+  EXPECT_TRUE(sensor->IsActive());
+
+  unsigned int width  = 320;
+  unsigned int height = 240;
+
+  this->imageCount = 0;
+  this->imageBuffer = new unsigned char[width * height*3];
+
+  transport::NodePtr node(new transport::Node());
+  node->Init();
+
+  std::string topic = sensor->Topic();
+  EXPECT_TRUE(!topic.empty());
+
+  transport::SubscriberPtr sub = node->Subscribe(topic,
+      &ShadowCasterRenderBackFacesTest::OnImage, this);
+
+  // wait for a few images
+  int i = 0;
+  while (this->imageCount < 10 && i < 300)
+  {
+    common::Time::MSleep(10);
+    i++;
+  }
+  EXPECT_LT(i, 300);
+
+  for (unsigned int x = 0; x < 320 * 240; x += 600) {
+    EXPECT_LT(50, this->imageBuffer[3 * x]);
+    EXPECT_LT(50, this->imageBuffer[3 * x + 1]);
+    EXPECT_LT(50, this->imageBuffer[3 * x + 2]);
+  }
+
+  delete this->imageBuffer;
+}
+
+/////////////////////////////////////////////////
+TEST_F(ShadowCasterRenderBackFacesTest, ShadowCasterNoBackFaces)
+{
+  ShadowCasterNoBackFaces();
+}
+
+/////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/test/worlds/default_shadow_caster.world
+++ b/test/worlds/default_shadow_caster.world
@@ -35,7 +35,7 @@
             <image>
               <width>320</width>
               <height>240</height>
-              <format>R8G8B8</format>\
+              <format>R8G8B8</format>
             </image>
             <clip>
               <near>0.1</near>

--- a/test/worlds/shadow_caster_back_faces.world
+++ b/test/worlds/shadow_caster_back_faces.world
@@ -15,7 +15,7 @@
     </include>
 
     <scene>
-      <ignition:shadow_caster_material_name>Gazebo/shadow_caster_ignore_heightmap</ignition:shadow_caster_material_name>
+      <ignition:shadow_caster_render_back_faces>true</ignition:shadow_caster_render_back_faces>
       <background>0.0 0.0 0.0 1</background>
     </scene>
 
@@ -51,20 +51,20 @@
 
     <model name="box">
       <static>true</static>
-      <pose>0 0 1.0 0 0 0</pose>
+      <pose>0 0 1.0 0 2.0 0</pose>
       <link name="link">
         <collision name="collision">
           <geometry>
-            <box>
+            <plane>
               <size>1 1 1</size>
-            </box>
+            </plane>
           </geometry>
         </collision>
         <visual name="visual">
           <geometry>
-            <box>
+            <plane>
               <size>1 1 1</size>
-            </box>
+            </plane>
           </geometry>
         </visual>
       </link>

--- a/test/worlds/shadow_caster_no_back_faces.world
+++ b/test/worlds/shadow_caster_no_back_faces.world
@@ -15,7 +15,7 @@
     </include>
 
     <scene>
-      <ignition:shadow_caster_material_name>Gazebo/shadow_caster_ignore_heightmap</ignition:shadow_caster_material_name>
+      <ignition:shadow_caster_render_back_faces>false</ignition:shadow_caster_render_back_faces>
       <background>0.0 0.0 0.0 1</background>
     </scene>
 
@@ -51,20 +51,20 @@
 
     <model name="box">
       <static>true</static>
-      <pose>0 0 1.0 0 0 0</pose>
+      <pose>0 0 1.0 0 2.0 0</pose>
       <link name="link">
         <collision name="collision">
           <geometry>
-            <box>
+            <plane>
               <size>1 1 1</size>
-            </box>
+            </plane>
           </geometry>
         </collision>
         <visual name="visual">
           <geometry>
-            <box>
+            <plane>
               <size>1 1 1</size>
-            </box>
+            </plane>
           </geometry>
         </visual>
       </link>


### PR DESCRIPTION
Added a new SDF parameter `ignition:shadow_caster_render_back_faces` to specify if back faces should be rendered by the shadow caster.

```
<scene>
  <ignition:shadow_caster_render_back_faces>0</ignition:shadow_caster_render_back_faces>
  <background>0.0 0.0 0.0 1</background>
</scene>
```

Currently, the scene is hard-coded to always render back faces.


Based off pull request: #3048 