### PR TITLE
Add more profiling hooks in physics, rendering

### DIFF
--- a/gazebo/gui/building/BuildingMaker.cc
+++ b/gazebo/gui/building/BuildingMaker.cc
@@ -695,7 +695,7 @@ void BuildingMaker::GenerateSDF()
   modelElem->GetElement("pose")->Set(modelOrigin);
 
   // loop through all model manips
-  for (const auto itemsIt : this->dataPtr->allItems)
+  for (const auto &itemsIt : this->dataPtr->allItems)
   {
     visualNameStream.str("");
     collisionNameStream.str("");

--- a/gazebo/gui/model/ModelCreator.cc
+++ b/gazebo/gui/model/ModelCreator.cc
@@ -1013,7 +1013,7 @@ bool ModelCreator::SaveModelFiles()
     QString msg("The edited model was automatically converted to SDFormat 1.7."
         " The resulting model had the following errors.\n\n");
 
-    for (const auto err : errors)
+    for (const auto &err : errors)
     {
       msg.append("* " + QString::fromStdString(err.Message()) + "\n");
       gzerr << err.Message() << "\n";

--- a/gazebo/gui/plot/Palette_TEST.cc
+++ b/gazebo/gui/plot/Palette_TEST.cc
@@ -47,6 +47,18 @@ void Palette_TEST::TopicsTab()
   QVERIFY(topicsModel != nullptr);
 
   // Check the model has as many rows as there are topics
+  if (topicsModel->rowCount() > count)
+  {
+    // Recount the number of topics being advertised
+    count = 0;
+    msgTopics = gazebo::transport::getAdvertisedTopics();
+    for (auto msgTopic : msgTopics)
+    {
+      for (auto topic : msgTopic.second)
+        count++;
+    }
+  }
+
   QCOMPARE(topicsModel->rowCount(), count);
 
   delete palette;

--- a/gazebo/physics/JointController.cc
+++ b/gazebo/physics/JointController.cc
@@ -113,6 +113,7 @@ void JointController::Reset()
 /////////////////////////////////////////////////
 void JointController::Update()
 {
+  IGN_PROFILE("JointController::Update");
   common::Time currTime = this->dataPtr->model->GetWorld()->SimTime();
   common::Time stepTime = currTime - this->dataPtr->prevUpdateTime;
   this->dataPtr->prevUpdateTime = currTime;
@@ -123,6 +124,7 @@ void JointController::Update()
   // TODO: fix this when World::ResetTime is improved
   if (stepTime > 0)
   {
+    IGN_PROFILE_BEGIN("forces");
     if (!this->dataPtr->forces.empty())
     {
       std::map<std::string, double>::iterator iter;
@@ -132,7 +134,9 @@ void JointController::Update()
         this->dataPtr->joints[iter->first]->SetForce(0, iter->second);
       }
     }
+    IGN_PROFILE_END();
 
+    IGN_PROFILE_BEGIN("positions");
     if (!this->dataPtr->positions.empty())
     {
       std::map<std::string, double>::iterator iter;
@@ -146,7 +150,9 @@ void JointController::Update()
         this->dataPtr->joints[iter->first]->SetForce(0, cmd);
       }
     }
+    IGN_PROFILE_END();
 
+    IGN_PROFILE_BEGIN("velocities");
     if (!this->dataPtr->velocities.empty())
     {
       std::map<std::string, double>::iterator iter;
@@ -160,6 +166,7 @@ void JointController::Update()
         this->dataPtr->joints[iter->first]->SetForce(0, cmd);
       }
     }
+    IGN_PROFILE_END();
   }
 
   /* enable below if we want to set position kinematically

--- a/gazebo/physics/Link.cc
+++ b/gazebo/physics/Link.cc
@@ -586,7 +586,9 @@ void Link::SetLaserRetro(float _retro)
 //////////////////////////////////////////////////
 void Link::Update(const common::UpdateInfo & /*_info*/)
 {
+  IGN_PROFILE("Link::Update");
 #ifdef HAVE_OPENAL
+  IGN_PROFILE_BEGIN("audio");
   if (this->dataPtr->audioSink)
   {
     this->dataPtr->audioSink->SetPose(this->WorldPose());
@@ -601,6 +603,7 @@ void Link::Update(const common::UpdateInfo & /*_info*/)
     (*iter)->SetPose(this->WorldPose());
     (*iter)->SetVelocity(this->WorldLinearVel());
   }
+  IGN_PROFILE_END();
 #endif
 
   // FIXME: race condition on factory-based model loading!!!!!
@@ -610,6 +613,7 @@ void Link::Update(const common::UpdateInfo & /*_info*/)
      this->dataPtr->enabledSignal(this->dataPtr->enabled);
    }*/
 
+  IGN_PROFILE_BEGIN("wrenches");
   if (!this->IsStatic() && !this->dataPtr->wrenchMsgs.empty())
   {
     std::vector<msgs::Wrench> messages;
@@ -624,12 +628,15 @@ void Link::Update(const common::UpdateInfo & /*_info*/)
       this->ProcessWrenchMsg(it);
     }
   }
+  IGN_PROFILE_END();
 
   // Update the batteries.
+  IGN_PROFILE_BEGIN("batteries");
   for (auto &battery : this->dataPtr->batteries)
   {
     battery->Update();
   }
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////
@@ -1251,6 +1258,8 @@ void Link::SetPublishData(bool _enable)
 /////////////////////////////////////////////////
 void Link::PublishData()
 {
+  IGN_PROFILE("Link::PublishData");
+  IGN_PROFILE_BEGIN("publish");
   if (this->dataPtr->publishData && this->dataPtr->dataPub->HasConnections())
   {
     msgs::Set(this->dataPtr->linkDataMsg.mutable_time(),
@@ -1262,6 +1271,7 @@ void Link::PublishData()
         this->WorldAngularVel());
     this->dataPtr->dataPub->Publish(this->dataPtr->linkDataMsg);
   }
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/Link.cc
+++ b/gazebo/physics/Link.cc
@@ -1426,7 +1426,7 @@ void Link::ParseVisuals()
 {
   this->UpdateVisualMsg();
 
-  for (auto const it : this->visuals)
+  for (auto const &it : this->visuals)
     this->visPub->Publish(it.second);
 }
 

--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -349,18 +349,28 @@ void Model::Init()
 //////////////////////////////////////////////////
 void Model::Update()
 {
+  IGN_PROFILE("Model::Update");
   if (this->IsStatic())
     return;
 
+  IGN_PROFILE_BEGIN("lockMutex");
   boost::recursive_mutex::scoped_lock lock(this->updateMutex);
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("jointUpdate");
   for (Joint_V::iterator jiter = this->joints.begin();
        jiter != this->joints.end(); ++jiter)
+  {
     (*jiter)->Update();
+  }
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("jointControllerUpdate");
   if (this->jointController)
     this->jointController->Update();
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("jointAnimations");
   if (!this->jointAnimations.empty())
   {
     common::NumericKeyFrame kf(0);
@@ -396,9 +406,12 @@ void Model::Update()
     }
     this->prevAnimationTime = this->world->SimTime();
   }
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("nestedModelUpdate");
   for (auto &model : this->models)
     model->Update();
+  IGN_PROFILE_END();
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -1218,7 +1218,7 @@ ModelPtr World::LoadModel(sdf::ElementPtr _sdf , BasePtr _parent)
   if (_sdf->GetName() == "model")
   {
     std::string modelName = _sdf->Get<std::string>("name");
-    for (auto const m : this->dataPtr->models)
+    for (auto const &m : this->dataPtr->models)
     {
       if (m->GetName() == modelName)
       {

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -733,11 +733,13 @@ void World::Step()
 
   DIAG_TIMER_LAP("World::Step", "publishWorldStats");
 
-  IGN_PROFILE_BEGIN("sleepOffset");
+  IGN_PROFILE_BEGIN("waitForSensors");
   if (this->dataPtr->waitForSensors)
     this->dataPtr->waitForSensors(this->dataPtr->simTime.Double(),
         this->dataPtr->physicsEngine->GetMaxStepSize());
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("sleepOffset");
   double updatePeriod = this->dataPtr->physicsEngine->GetUpdatePeriod();
   // sleep here to get the correct update rate
   common::Time tmpTime = common::Time::GetWallTime();
@@ -797,14 +799,17 @@ void World::Step()
   }
   IGN_PROFILE_END();
 
-  IGN_PROFILE_BEGIN("Step");
-
+  IGN_PROFILE_BEGIN("IntrospectionManager->NotifyUpdates");
   gazebo::util::IntrospectionManager::Instance()->NotifyUpdates();
+  IGN_PROFILE_END();
 
+  IGN_PROFILE_BEGIN("ProcessMessages");
   this->ProcessMessages();
+  IGN_PROFILE_END();
 
   DIAG_TIMER_STOP("World::Step");
 
+  IGN_PROFILE_BEGIN("ClearModels");
   if (g_clearModels)
     this->ClearModels();
   IGN_PROFILE_END();

--- a/gazebo/physics/ode/ODEJoint.cc
+++ b/gazebo/physics/ode/ODEJoint.cc
@@ -1167,10 +1167,19 @@ double ODEJoint::GetForce(unsigned int _index)
 //////////////////////////////////////////////////
 void ODEJoint::ApplyStiffnessDamping()
 {
+  IGN_PROFILE("ODEJoint::ApplyStiffnessDamping");
   if (this->useImplicitSpringDamper)
+  {
+    IGN_PROFILE_BEGIN("implicit");
     this->ApplyImplicitStiffnessDamping();
+    IGN_PROFILE_END();
+  }
   else
+  {
+    IGN_PROFILE_BEGIN("explicit");
     this->ApplyExplicitStiffnessDamping();
+    IGN_PROFILE_END();
+  }
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/InertiaVisual_TEST.cc
+++ b/gazebo/rendering/InertiaVisual_TEST.cc
@@ -97,7 +97,7 @@ TEST_F(InertiaVisual_TEST, InertiaRotation)
     event::Events::postRender();
 
     bool found = true;
-    for (const auto name : inertiaVisualNames)
+    for (const auto &name : inertiaVisualNames)
     {
       auto visual = scene->GetVisual(name);
       if (visual == nullptr)
@@ -118,7 +118,7 @@ TEST_F(InertiaVisual_TEST, InertiaRotation)
   // expect bounding box of size 0.1 x 0.4 x 0.9
   const ignition::math::AxisAlignedBox box(-0.05, -0.2, -0.45,
                                             0.05,  0.2,  0.45);
-  for (const auto name : inertiaVisualNames)
+  for (const auto &name : inertiaVisualNames)
   {
     gzdbg << "Check bounding box for "
           << name

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -2809,7 +2809,7 @@ bool Scene::ProcessVisualMsg(ConstVisualPtr &_msg, Visual::VisualType _type)
           if (matMsg.has_script())
           {
             auto scriptMsg = matMsg.script();
-            for (auto const uri : scriptMsg.uri())
+            for (auto const &uri : scriptMsg.uri())
             {
               if (!uri.empty())
                 RenderEngine::Instance()->AddResourcePath(uri);

--- a/plugins/FollowerPlugin.cc
+++ b/plugins/FollowerPlugin.cc
@@ -203,7 +203,7 @@ void FollowerPlugin::FindJoints()
 bool FollowerPlugin::FindSensor(const physics::ModelPtr &_model)
 {
   // loop through links to find depth sensor
-  for (const auto l : _model->GetLinks())
+  for (const auto &l : _model->GetLinks())
   {
     for (unsigned int i = 0; i < l->GetSensorCount(); ++i)
     {

--- a/plugins/JointControlPlugin.cc
+++ b/plugins/JointControlPlugin.cc
@@ -137,7 +137,7 @@ void JointControlPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
               gzwarn << "No joints found matching \""
                      << grandchild->Get<std::string>() << "\".\n";
             }
-            for (const auto match : matches)
+            for (const auto &match : matches)
             {
               msg.set_name(match);
               jointPub.Publish(msg);

--- a/tools/gz_marker.cc
+++ b/tools/gz_marker.cc
@@ -227,7 +227,7 @@ void MarkerCommand::List()
         data[ns].push_back(std::make_tuple(id, layer, type));
       }
 
-      for (auto const d : data)
+      for (auto const &d : data)
       {
         std::cout << "NAMESPACE " << d.first << std::endl;
         for (auto const m : d.second)


### PR DESCRIPTION
This adds more `IGN_PROFILE*` hooks in the physics and rendering functions that are part of the update loops.

I've also added a fix for a flaky test and some compiler warnings:

* `UNIT_Palette_TEST` loads a widget with a row for each advertised topic and expects the number of rows to match the number of advertised topics. This test has a race condition because new topics can be advertised in separate threads, leading to counting different numbers of topics (see [example failure](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-homebrew-amd64/95/testReport/(root)/Palette_TEST/TopicsTab/)). In 5a0022b, a recount is initiated if the initial count of topics doesn't match the number of rows in the widget, which improves the reliability of the test in local testing for me.
* there are several instances of clang [-Wrange-loop-construct](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-homebrew-amd64/95/clang/category.-1132560568/) warnings that can be fixed by creating `auto` variables in for-loops as references (0e6a48a)