### PR TITLE
HeightmapLODPlugin: add server/gui params

### DIFF
--- a/gazebo/gui/MainWindow_TEST.cc
+++ b/gazebo/gui/MainWindow_TEST.cc
@@ -223,6 +223,7 @@ void MainWindow_TEST::SceneDestruction()
   QVERIFY(cam != NULL);
   gazebo::rendering::ScenePtr scene = cam->GetScene();
   QVERIFY(scene != NULL);
+  QVERIFY(!scene->IsServer());
 
   cam->Fini();
   mainWindow->close();

--- a/gazebo/rendering/Camera_TEST.cc
+++ b/gazebo/rendering/Camera_TEST.cc
@@ -38,6 +38,7 @@ TEST_F(Camera_TEST, Create)
   if (!scene)
     scene = gazebo::rendering::create_scene("default", false);
   ASSERT_TRUE(scene != nullptr);
+  EXPECT_TRUE(scene->IsServer());
 
   // test creating rgb camera
   {

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -3275,6 +3275,12 @@ void Scene::SetShadowsEnabled(bool _value)
 }
 
 /////////////////////////////////////////////////
+bool Scene::IsServer() const
+{
+  return this->dataPtr->isServer;
+}
+
+/////////////////////////////////////////////////
 bool Scene::ShadowsEnabled() const
 {
   return this->dataPtr->sdf->Get<bool>("shadows");

--- a/gazebo/rendering/Scene.hh
+++ b/gazebo/rendering/Scene.hh
@@ -406,6 +406,10 @@ namespace gazebo
       /// \param[in] _value True to enable shadows, False to disable
       public: void SetShadowsEnabled(const bool _value);
 
+      /// \brief Get whether this scene is in the server.
+      /// \return True if scene is in the server.
+      public: bool IsServer() const;
+
       /// \brief Get whether shadows are on or off
       /// \return True if shadows are enabled.
       public: bool ShadowsEnabled() const;

--- a/gazebo/rendering/Scene_TEST.cc
+++ b/gazebo/rendering/Scene_TEST.cc
@@ -33,6 +33,7 @@ TEST_F(Scene_TEST, AddRemoveCameras)
   // Get the scene
   gazebo::rendering::ScenePtr scene = gazebo::rendering::get_scene();
   ASSERT_TRUE(scene != nullptr);
+  EXPECT_TRUE(scene->IsServer());
 
   // verify no cameras are currently in the scene
   EXPECT_EQ(scene->CameraCount(), 0u);

--- a/plugins/HeightmapLODPlugin.cc
+++ b/plugins/HeightmapLODPlugin.cc
@@ -60,11 +60,38 @@ void HeightmapLODPlugin::Load(rendering::VisualPtr _visual,
     return;
   }
 
-  if (_sdf->HasElement("lod"))
-    this->dataPtr->lod = _sdf->Get<unsigned int>("lod");
-  if (_sdf->HasElement("skirt_length"))
-    this->dataPtr->skirtLength = _sdf->Get<double>("skirt_length");
+  auto scene = _visual->GetScene();
 
-  _visual->GetScene()->SetHeightmapLOD(this->dataPtr->lod);
-  _visual->GetScene()->SetHeightmapSkirtLength(this->dataPtr->skirtLength);
+  // Pointer to the <server/> or <gui/> element, depending on the result
+  // of scene->IsServer() or nullptr if they don't exist.
+  sdf::ElementPtr serverGui;
+  if (scene->IsServer() && _sdf->HasElement("server"))
+  {
+    serverGui = _sdf->GetElement("server");
+  }
+  else if (!scene->IsServer() && _sdf->HasElement("gui"))
+  {
+    serverGui = _sdf->GetElement("gui");
+  }
+
+  if (_sdf->HasElement("lod"))
+  {
+    this->dataPtr->lod = _sdf->Get<unsigned int>("lod");
+  }
+  else if (serverGui && serverGui->HasElement("lod"))
+  {
+    this->dataPtr->lod = serverGui->Get<unsigned int>("lod");
+  }
+
+  if (_sdf->HasElement("skirt_length"))
+  {
+    this->dataPtr->skirtLength = _sdf->Get<double>("skirt_length");
+  }
+  else if (serverGui && serverGui->HasElement("skirt_length"))
+  {
+    this->dataPtr->skirtLength = serverGui->Get<double>("skirt_length");
+  }
+
+  scene->SetHeightmapLOD(this->dataPtr->lod);
+  scene->SetHeightmapSkirtLength(this->dataPtr->skirtLength);
 }

--- a/plugins/HeightmapLODPlugin.hh
+++ b/plugins/HeightmapLODPlugin.hh
@@ -25,7 +25,48 @@ namespace gazebo
   // Forward declare private data class.
   class HeightmapLODPluginPrivate;
 
-  /// \brief Plugin that sets the heightmap LOD
+  /// \brief Plugin that sets the heightmap Level of Detail (LOD) parameters.
+  /// `lod`: a render-engine specific value used to compute Level of Detail.
+  /// `skirt_length`: length of skirts on LOD tiles.
+  /// These parameters can be set uniformly for all scenes in a simulation
+  /// by specifying the parameters directly under the <plugin /> element:
+  /** \verbatim
+    <plugin filename="libHeightmapLODPlugin.so" name="heightmap_lod">
+      <lod>5</lod>
+      <skirt_length>0.5</skirt_length>
+    </plugin>
+   \endverbatim */
+  /// Alternatively, you can specify distinct values for server scene used
+  /// for rendering camera sensors, and the gui scene used for gzclient's
+  /// graphical interface.
+  /** \verbatim
+    <plugin filename="libHeightmapLODPlugin.so" name="heightmap_lod">
+      <gui>
+        <lod>5</lod>
+        <skirt_length>1.5</skirt_length>
+      </gui>
+      <server>
+        <lod>0</lod>
+        <skirt_length>0.5</skirt_length>
+      </server>
+    </plugin>
+   \endverbatim */
+  /// Parameters specified in the root namespace have precedence. The
+  /// <server/> and <gui/> elements are only checked if parameters
+  /// are not set in the root namespace.
+  /** \verbatim
+    <plugin filename="libHeightmapLODPlugin.so" name="heightmap_lod">
+      <skirt_length>2.5</skirt_length>
+      <gui>
+        <lod>5</lod>
+        <skirt_length>1.5</skirt_length> <!-- this is ignored -->
+      </gui>
+      <server>
+        <lod>0</lod>
+        <skirt_length>0.5</skirt_length> <!-- this is ignored -->
+      </server>
+    </plugin>
+   \endverbatim */
   class GZ_PLUGIN_VISIBLE HeightmapLODPlugin : public VisualPlugin
   {
     /// \brief Constructor.

--- a/test/integration/heightmap.cc
+++ b/test/integration/heightmap.cc
@@ -79,6 +79,10 @@ class HeightmapTest : public ServerFixture,
   /// \brief Test loading a heightmap with an LOD visual plugin
   public: void LODVisualPlugin();
 
+  /// \brief Test loading a heightmap with an LOD visual plugin that has
+  /// different parameters for the Server and GUI.
+  public: void LODVisualPluginServerGUI();
+
 /// \brief Test loading a heightmap and verify cache files are created
   public: void HeightmapCache();
 
@@ -719,6 +723,36 @@ void HeightmapTest::LODVisualPlugin()
 }
 
 /////////////////////////////////////////////////
+void HeightmapTest::LODVisualPluginServerGUI()
+{
+  // load a heightmap with no visual
+  Load("worlds/heightmap_lod_plugin_server_gui.world", false);
+  physics::ModelPtr heightmap = GetModel("heightmap");
+  ASSERT_NE(heightmap, nullptr);
+
+  gazebo::rendering::ScenePtr scene = gazebo::rendering::get_scene("default");
+  ASSERT_NE(scene, nullptr);
+  EXPECT_TRUE(scene->IsServer());
+
+  // make sure scene is initialized and running
+  int sleep = 0;
+  int maxSleep = 30;
+  while (scene->SimTime().Double() < 2.0 && sleep++ < maxSleep)
+    common::Time::MSleep(100);
+
+  // check the heightmap lod via scene
+  EXPECT_EQ(scene->HeightmapLOD(), 0u);
+  // check skirt length param via scene
+  EXPECT_EQ(scene->HeightmapSkirtLength(), 0.5);
+
+  // get heightmap object and check lod params
+  rendering::Heightmap *h = scene->GetHeightmap();
+  EXPECT_NE(h, nullptr);
+  EXPECT_EQ(h->LOD(), 0u);
+  EXPECT_EQ(h->SkirtLength(), 0.5);
+}
+
+/////////////////////////////////////////////////
 void HeightmapTest::HeightmapCache()
 {
   // path to heightmap cache files
@@ -1171,6 +1205,12 @@ TEST_F(HeightmapTest, NoVisual)
 TEST_F(HeightmapTest, LODVisualPlugin)
 {
   LODVisualPlugin();
+}
+
+/////////////////////////////////////////////////
+TEST_F(HeightmapTest, LODVisualPluginServerGUI)
+{
+  LODVisualPluginServerGUI();
 }
 
 /////////////////////////////////////////////////

--- a/test/worlds/heightmap_lod_plugin_server_gui.world
+++ b/test/worlds/heightmap_lod_plugin_server_gui.world
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <include><uri>model://camera</uri></include>
+
+    <model name="heightmap">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <heightmap>
+              <uri>file://media/materials/textures/heightmap_bowl.png</uri>
+              <size>129 129 10</size>
+              <pos>0 0 0</pos>
+            </heightmap>
+          </geometry>
+        </collision>
+
+        <visual name="visual">
+          <geometry>
+            <heightmap>
+              <uri>file://media/materials/textures/heightmap_bowl.png</uri>
+              <size>129 129 10</size>
+              <pos>0 0 0</pos>
+            </heightmap>
+          </geometry>
+          <plugin name="lod" filename="libHeightmapLODPlugin.so">
+            <skirt_length>0.5</skirt_length>
+            <gui>
+              <lod>5</lod>
+            </gui>
+            <server>
+              <lod>0</lod>
+            </server>
+          </plugin>
+        </visual>
+      </link>
+    </model>
+  </world>
+</sdf>


### PR DESCRIPTION
This allows specifying separate Heightmap LOD parameters for a server and GUI rendering instances. This could allow using more accurate parameters in the server for camera sensors, while using coarser parameters in the GUI to reduce the computational burden.

An accessor for the `bool ScenePrivate::isServer` flag was added to `Scene.hh` in 2f8bbaa to support this feature.