### PR TITLE
Fix gzclient starting with black screen

### DIFF
--- a/gazebo/physics/World.hh
+++ b/gazebo/physics/World.hh
@@ -651,6 +651,11 @@ namespace gazebo
       private: bool PluginInfoService(const ignition::msgs::StringMsg &_request,
           ignition::msgs::Plugin_V &_plugins);
 
+      /// \brief Callback for "<this_name>/scene_info" service.
+      /// \param[out] _response Message containing scene info
+      /// \return True if the info was successfully obtained.
+      private: bool SceneInfoService(msgs::Scene &_response);
+
       /// \brief Callback for "<this_name>/shadow_caster_material_name" service.
       /// \param[out] _response Message containing shadow caster material name
       /// \return True if the info was successfully obtained.

--- a/gazebo/physics/dart/DARTJointPrivate.hh
+++ b/gazebo/physics/dart/DARTJointPrivate.hh
@@ -76,7 +76,11 @@ namespace gazebo
 
         mFuncs.clear();
 
+#if DART_VERSION_AT_LEAST(6, 10, 0)
+        this->dtJoint->setLimitEnforcement(true);
+ #else
         this->dtJoint->setPositionLimitEnforced(true);
+ #endif
       }
 
       /// \brief Return true if DART Joint is initialized

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -454,7 +454,6 @@ void Scene::Init()
 
   // Get scene info from physics::World with ignition transport service
   ignition::transport::Node node;
-  ignition::msgs::Scene sceneInfo;
   const std::string serviceName = "/scene_info";
   std::vector<ignition::transport::ServicePublisher> publishers;
   if (!node.ServiceInfo(serviceName, publishers) ||

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -123,7 +123,6 @@ Scene::Scene(const std::string &_name, const bool _enableVisualizations,
   this->dataPtr->transparent = false;
   this->dataPtr->wireframe = false;
 
-  this->dataPtr->requestMsg = NULL;
   this->dataPtr->enableVisualizations = _enableVisualizations;
   this->dataPtr->node = transport::NodePtr(new transport::Node());
   this->dataPtr->node->Init(_name);
@@ -331,8 +330,7 @@ Scene::~Scene()
 {
   this->Clear();
 
-  delete this->dataPtr->requestMsg;
-  this->dataPtr->requestMsg = NULL;
+  this->dataPtr->requestMsg.reset(nullptr);
   delete this->dataPtr->receiveMutex;
   this->dataPtr->receiveMutex = NULL;
 
@@ -442,7 +440,7 @@ void Scene::Init()
            << " falling back to gazebo transport [scene_info] request."
            << std::endl;
     this->dataPtr->requestPub->WaitForConnection();
-    this->dataPtr->requestMsg = msgs::CreateRequest("scene_info");
+    this->dataPtr->requestMsg.reset(msgs::CreateRequest("scene_info"));
     this->dataPtr->requestPub->Publish(*this->dataPtr->requestMsg);
   }
 
@@ -2496,7 +2494,7 @@ void Scene::OnResponse(ConstResponsePtr &_msg)
   sceneMsg.ParseFromString(_msg->serialized_data());
   this->OnSceneInfo(sceneMsg, true);
 
-  this->dataPtr->requestMsg = NULL;
+  this->dataPtr->requestMsg.reset(nullptr);
 }
 
 /////////////////////////////////////////////////

--- a/gazebo/rendering/Scene.hh
+++ b/gazebo/rendering/Scene.hh
@@ -657,6 +657,12 @@ namespace gazebo
       /// \param[in] _msg The message.
       private: void OnScene(ConstScenePtr &_msg);
 
+      /// \brief Called when the scene info service replies with the scene
+      /// message.
+      /// \param[in] _msg The message.
+      /// \param[in] _result Flag indicating if service call succeeded.
+      private: void OnSceneInfo(const msgs::Scene &_msg, const bool _result);
+
       /// \brief Response callback
       /// \param[in] _msg The message data.
       private: void OnResponse(ConstResponsePtr &_msg);

--- a/gazebo/rendering/ScenePrivate.hh
+++ b/gazebo/rendering/ScenePrivate.hh
@@ -17,12 +17,13 @@
 #ifndef GAZEBO_RENDERING_SCENE_PRIVATE_HH_
 #define GAZEBO_RENDERING_SCENE_PRIVATE_HH_
 
+#include <condition_variable>
 #include <list>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
-#include <mutex>
-#include <condition_variable>
 
 #include <boost/unordered/unordered_map.hpp>
 
@@ -300,7 +301,7 @@ namespace gazebo
       public: std::string selectionMode;
 
       /// \brief Keep around our request message.
-      public: msgs::Request *requestMsg = nullptr;
+      public: std::unique_ptr<msgs::Request> requestMsg;
 
       /// \brief True if visualizations should be rendered.
       public: bool enableVisualizations;

--- a/test/integration/info_services.cc
+++ b/test/integration/info_services.cc
@@ -205,6 +205,36 @@ TEST_F(InfoServicesTest, ModelPlugins)
 }
 
 /////////////////////////////////////////////////
+// Request info about scene
+TEST_F(InfoServicesTest, Scene)
+{
+  this->Load("worlds/empty.world");
+
+  ignition::transport::Node ignNode;
+
+  std::string sceneInfoService("/scene_info");
+
+  std::vector<ignition::transport::ServicePublisher> publishers;
+  ASSERT_TRUE(ignNode.ServiceInfo(sceneInfoService, publishers));
+
+  gazebo::msgs::Scene scene;
+  unsigned int timeout = 5000;
+  bool result;
+  EXPECT_TRUE(ignNode.Request(sceneInfoService, timeout, scene, result));
+  EXPECT_TRUE(result);
+
+  EXPECT_EQ("default", scene.name());
+
+  ASSERT_EQ(1, scene.model_size());
+  auto model = scene.model(0);
+  EXPECT_EQ("ground_plane", model.name());
+
+  ASSERT_EQ(1, scene.light_size());
+  auto light = scene.light(0);
+  EXPECT_EQ("sun", light.name());
+}
+
+/////////////////////////////////////////////////
 // Main
 int main(int argc, char **argv)
 {

--- a/tools/gz_marker.cc
+++ b/tools/gz_marker.cc
@@ -230,7 +230,7 @@ void MarkerCommand::List()
       for (auto const &d : data)
       {
         std::cout << "NAMESPACE " << d.first << std::endl;
-        for (auto const m : d.second)
+        for (auto const &m : d.second)
         {
           uint64_t id = std::get<0>(m);
           std::cout << "  ID " << id;


### PR DESCRIPTION
There is a longstanding issue (#681) in which `gzclient` occasionally starts with a black screen, failing to ever display the scene. Opening a second `gzclient` instance often works properly, suggesting a race condition in initialization. I highly suspect much of the non-determinism comes from the use of the `~/request` topic with gazebo-transport to communicate `scene_info` from `gazebo::physics::World` to `gazebo::rendering::Scene`. It is more reliable to use an ignition-transport service, so I have added a `/scene_info` ignition-transport service to `World` and changed `Scene` to prefer calling this service instead of using the `~/request` topic. If the ignition service is unavailable or fails, it will fall back to the current method using `~/request`, which should preserve backwards compatibility between old and new instances of `gzserver` and `gzclient`.

I've added a test for the new service to `INTEGRATION_info_services`. I've also fixed a few compiler warnings in ab57017.