### PR TITLE
Fix slow loading of spawned model with plugins

### DIFF
--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -1034,11 +1034,12 @@ void Model::LoadPlugins()
   if (this->GetPluginCount() > 0)
   {
     int iterations = 0;
+    const int maxIterations = 500;
 
     // Wait for the sensors to be initialized before loading
     // plugins, if there are any sensors
     while (this->GetSensorCount() > 0 && !this->world->SensorsInitialized() &&
-           iterations < 50)
+           iterations < maxIterations)
     {
       common::Time::MSleep(100);
       iterations++;
@@ -1046,7 +1047,7 @@ void Model::LoadPlugins()
 
     // Load the plugins if the sensors have been loaded, or if there
     // are no sensors attached to the model.
-    if (iterations < 50)
+    if (iterations < maxIterations)
     {
       // Load the plugins
       sdf::ElementPtr pluginElem = this->sdf->GetElement("plugin");

--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -1030,7 +1030,7 @@ std::vector<std::string> Model::SensorScopedName(
 //////////////////////////////////////////////////
 void Model::LoadPlugins()
 {
-  this->LoadPlugins(5);
+  this->LoadPlugins(30);
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -1030,11 +1030,17 @@ std::vector<std::string> Model::SensorScopedName(
 //////////////////////////////////////////////////
 void Model::LoadPlugins()
 {
+  this->LoadPlugins(5);
+}
+
+//////////////////////////////////////////////////
+void Model::LoadPlugins(unsigned int _timeout)
+{
   // Check to see if we need to load any model plugins
   if (this->GetPluginCount() > 0)
   {
     int iterations = 0;
-    const int maxIterations = 500;
+    const int maxIterations = _timeout * 10;
 
     // Wait for the sensors to be initialized before loading
     // plugins, if there are any sensors
@@ -1066,7 +1072,7 @@ void Model::LoadPlugins()
   }
 
   for (auto &model : this->models)
-    model->LoadPlugins();
+    model->LoadPlugins(_timeout);
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/Model.hh
+++ b/gazebo/physics/Model.hh
@@ -349,6 +349,14 @@ namespace gazebo
       /// Load all plugins specified in the SDF for the model.
       public: void LoadPlugins();
 
+      /// \brief Load all plugins with a configurable timeout.
+      /// This waits for sensors to be loaded before loading model plugins
+      /// with a configurable timeout.
+      ///
+      /// Load all plugins specified in the SDF for the model.
+      /// \param[in] _timeout Seconds to wait for sensors to initialize.
+      public: void LoadPlugins(unsigned int _timeout);
+
       /// \brief Get the number of plugins this model has.
       /// \return Number of plugins associated with this model.
       public: unsigned int GetPluginCount() const;

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -2141,6 +2141,7 @@ void World::ProcessLightFactoryMsgs()
 //////////////////////////////////////////////////
 void World::ProcessFactoryMsgs()
 {
+  IGN_PROFILE("World::ProcessFactoryMsgs");
   std::list<sdf::ElementPtr> modelsToLoad, lightsToLoad;
 
   std::list<msgs::Factory> factoryMsgsCopy;

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -233,6 +233,15 @@ void World::Load(sdf::ElementPtr _sdf)
         Get<bool>("ignition:shadow_caster_render_back_faces");
   }
 
+  {
+    const std::string kElementName = "ignition:model_plugin_loading_timeout";
+    if (this->dataPtr->sdf->HasElement(kElementName))
+    {
+      this->dataPtr->modelPluginLoadingTimeout =
+        this->dataPtr->sdf->Get<unsigned int>(kElementName);
+    }
+  }
+
   // The period at which messages are processed
   this->dataPtr->processMsgsPeriod = common::Time(0, 200000000);
 
@@ -1774,7 +1783,7 @@ void World::LoadPlugins()
     {
       ModelPtr model = boost::static_pointer_cast<Model>(
           this->dataPtr->rootElement->GetChild(i));
-      model->LoadPlugins();
+      model->LoadPlugins(this->dataPtr->modelPluginLoadingTimeout);
     }
   }
 }
@@ -2334,7 +2343,7 @@ void World::ProcessFactoryMsgs()
       if (model != nullptr)
       {
         model->Init();
-        model->LoadPlugins();
+        model->LoadPlugins(this->dataPtr->modelPluginLoadingTimeout);
       }
     }
     catch(...)
@@ -2460,7 +2469,7 @@ void World::SetState(const WorldState &_state)
         {
           model->Init();
           if (!util::LogPlay::Instance()->IsOpen())
-            model->LoadPlugins();
+            model->LoadPlugins(this->dataPtr->modelPluginLoadingTimeout);
         }
       }
       catch(...)

--- a/gazebo/physics/World.hh
+++ b/gazebo/physics/World.hh
@@ -299,17 +299,17 @@ namespace gazebo
       public: void SetState(const WorldState &_state);
 
       /// \brief Insert a model from an SDF file.
-      /// Spawns a model into the world base on and SDF file.
+      /// Spawns a model into the world based on an SDF file.
       /// \param[in] _sdfFilename The name of the SDF file (including path).
       public: void InsertModelFile(const std::string &_sdfFilename);
 
       /// \brief Insert a model from an SDF string.
-      /// Spawns a model into the world base on and SDF string.
+      /// Spawns a model into the world based on an SDF string.
       /// \param[in] _sdfString A string containing valid SDF markup.
       public: void InsertModelString(const std::string &_sdfString);
 
       /// \brief Insert a model using SDF.
-      /// Spawns a model into the world base on and SDF object.
+      /// Spawns a model into the world based on an SDF object.
       /// \param[in] _sdf A reference to an SDF object.
       public: void InsertModelSDF(const sdf::SDF &_sdf);
 

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -196,6 +196,9 @@ namespace gazebo
       /// \brief The world's current SDF description.
       public: sdf::ElementPtr sdf;
 
+      /// \brief Timeout for Model::LoadPlugins in seconds.
+      public: unsigned int modelPluginLoadingTimeout = 5;
+
       /// \brief All the plugins.
       public: std::vector<WorldPluginPtr> plugins;
 

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -197,7 +197,7 @@ namespace gazebo
       public: sdf::ElementPtr sdf;
 
       /// \brief Timeout for Model::LoadPlugins in seconds.
-      public: unsigned int modelPluginLoadingTimeout = 5;
+      public: unsigned int modelPluginLoadingTimeout = 30;
 
       /// \brief All the plugins.
       public: std::vector<WorldPluginPtr> plugins;

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -99,7 +99,6 @@ set(tests
   sensor.cc
   sdf_frame_semantics.cc
   server_fixture.cc
-  shadow_caster_render_back_faces.cc
   sim_events.cc
   speed.cc
   speed_thread_islands.cc
@@ -135,6 +134,7 @@ if (NOT APPLE)
   set(tests
     ${tests}
     custom_shadow_caster.cc
+    shadow_caster_render_back_faces.cc
   )
 endif()
 

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -27,7 +27,9 @@ set (plugins
   Issue1208Plugin
   ModelTrajectoryTestPlugin
   PluginInterfaceTest
+  SlowLoadingSensorPlugin
   SpringTestPlugin
+  WorldSpawnModelPlugin
 )
 
 foreach (src ${plugins})

--- a/test/plugins/SlowLoadingSensorPlugin.cc
+++ b/test/plugins/SlowLoadingSensorPlugin.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "SlowLoadingSensorPlugin.hh"
+
+namespace gazebo
+{
+  /// \brief Private data class for SlowLoadingSensorPluginPrivate
+  class SlowLoadingSensorPluginPrivate
+  {
+  };
+}
+
+using namespace gazebo;
+
+GZ_REGISTER_SENSOR_PLUGIN(SlowLoadingSensorPlugin)
+
+/////////////////////////////////////////////////
+SlowLoadingSensorPlugin::SlowLoadingSensorPlugin()
+  : dataPtr(new SlowLoadingSensorPluginPrivate)
+{
+}
+
+/////////////////////////////////////////////////
+SlowLoadingSensorPlugin::~SlowLoadingSensorPlugin()
+{
+}
+
+/////////////////////////////////////////////////
+void SlowLoadingSensorPlugin::Load(sensors::SensorPtr /*_sensor*/,
+                                   sdf::ElementPtr _sdf)
+{
+  if (!_sdf->HasElement("load_seconds"))
+  {
+    gzerr << "No model <load_seconds/> detected. No wait will occur."
+          << std::endl;
+    return;
+  }
+
+  double loadSeconds = _sdf->Get<double>("load_seconds");
+
+  gzmsg << "SlowLoadingSensorPlugin: sleeping for " << loadSeconds << " seconds"
+        << std::endl;
+  common::Time::Sleep(common::Time(loadSeconds));
+}

--- a/test/plugins/SlowLoadingSensorPlugin.hh
+++ b/test/plugins/SlowLoadingSensorPlugin.hh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GAZEBO_TEST_PLUGINS_SLOWLOADINGSENSORPLUGIN_HH_
+#define GAZEBO_TEST_PLUGINS_SLOWLOADINGSENSORPLUGIN_HH_
+
+#include <memory>
+
+#include <gazebo/common/Plugin.hh>
+
+namespace gazebo
+{
+  class SlowLoadingSensorPluginPrivate;
+
+  /// \brief A sensor plugin that sleeps a specified amount of time
+  /// during Load.
+  ///
+  /// The plugin requires the following parameter:
+  /// <load_seconds>     Number of seconds to sleep during load
+  class GAZEBO_VISIBLE SlowLoadingSensorPlugin : public SensorPlugin
+  {
+    /// \brief Constructor.
+    public: SlowLoadingSensorPlugin();
+
+    /// \brief Destructor.
+    public: virtual ~SlowLoadingSensorPlugin();
+
+    /// \brief Load the plugin.
+    /// \param[in] _sensor Pointer to sensor
+    /// \param[in] _sdf Pointer to the SDF configuration.
+    public: virtual void Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf);
+
+    /// \brief Pointer to private data.
+    private: std::unique_ptr<SlowLoadingSensorPluginPrivate> dataPtr;
+  };
+}
+
+#endif

--- a/test/plugins/WorldSpawnModelPlugin.cc
+++ b/test/plugins/WorldSpawnModelPlugin.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "WorldSpawnModelPlugin.hh"
+
+namespace gazebo
+{
+  /// \brief Private data class for WorldSpawnModelPlugin
+  class WorldSpawnModelPluginPrivate
+  {
+  };
+}
+
+using namespace gazebo;
+
+GZ_REGISTER_WORLD_PLUGIN(WorldSpawnModelPlugin)
+
+/////////////////////////////////////////////////
+WorldSpawnModelPlugin::WorldSpawnModelPlugin()
+  : dataPtr(new WorldSpawnModelPluginPrivate)
+{
+}
+
+/////////////////////////////////////////////////
+void WorldSpawnModelPlugin::Load(physics::WorldPtr _world, sdf::ElementPtr _sdf)
+{
+  if (!_sdf->HasElement("sdf"))
+  {
+    gzerr << "No <sdf> detected. Nothing will be spawned." << std::endl;
+    return;
+  }
+
+  sdf::ElementPtr sdfElem = _sdf->GetElement("sdf");
+  if (!sdfElem->HasElement("model"))
+  {
+    gzerr << "No <model> detected in <sdf>. Nothing will be spawned."
+          << std::endl;
+    return;
+  }
+  sdf::ElementPtr modelElem = sdfElem->GetElement("model");
+
+  std::string modelName;
+  if (modelElem->HasAttribute("name"))
+  {
+    modelName = modelElem->Get<std::string>("name");
+  }
+
+  gzmsg << "Spawning model with name [" << modelName << "]" << std::endl;
+  _world->InsertModelString(sdfElem->ToString(""));
+}

--- a/test/plugins/WorldSpawnModelPlugin.hh
+++ b/test/plugins/WorldSpawnModelPlugin.hh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef GAZEBO_TEST_PLUGINS_WORLDSPAWNMODELPLUGIN_HH_
+#define GAZEBO_TEST_PLUGINS_WORLDSPAWNMODELPLUGIN_HH_
+
+#include <memory>
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/physics/World.hh>
+#include "gazebo/util/system.hh"
+
+namespace gazebo
+{
+  /// \brief Forward declarations
+  class WorldSpawnModelPluginPrivate;
+
+  /// \brief A plugin that spawns a model in the attached World.
+  ///
+  /// The plugin requires the following parameter:
+  /// <sdf>     SDFormat description of model to load
+  class GZ_PLUGIN_VISIBLE WorldSpawnModelPlugin : public WorldPlugin
+  {
+    /// \brief Constructor.
+    public: WorldSpawnModelPlugin();
+
+    /// \brief Load the plugin.
+    /// \param[in] _world Pointer to world
+    /// \param[in] _sdf Pointer to the SDF configuration.
+    public: virtual void Load(physics::WorldPtr _world, sdf::ElementPtr _sdf);
+
+    /// \brief Pointer to private data.
+    private: std::unique_ptr<WorldSpawnModelPluginPrivate> dataPtr;
+  };
+}
+#endif

--- a/test/regression/3125_slow_loading_model_spawn.cc
+++ b/test/regression/3125_slow_loading_model_spawn.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "gazebo/test/ServerFixture.hh"
+#include "gazebo/physics/physics.hh"
+
+using namespace gazebo;
+
+class Issue3125Test : public ServerFixture
+{
+};
+
+////////////////////////////////////////////////////////////////////////
+TEST_F(Issue3125Test, SlowLoadingModelSpawn)
+{
+  Load("worlds/slow_loading_model_spawn.world", true);
+  physics::WorldPtr world = physics::get_world();
+  ASSERT_NE(world , nullptr);
+
+  // Wait up to 20 seconds for model to spawn
+  const std::string modelName = "slow_loading_model";
+  auto model = world->ModelByName(modelName);
+  int waitIteration = 0;
+  const int maxWaitIterations = 200;
+  while (!model && waitIteration < maxWaitIterations)
+  {
+    common::Time::MSleep(100);
+    model = world->ModelByName(modelName);
+    ++waitIteration;
+  }
+  ASSERT_NE(model, nullptr);
+
+  // Initial pose
+  const ignition::math::Pose3d expectedInitialPose(0, 0, 0.45, 0, 0, 0);
+  EXPECT_EQ(expectedInitialPose, model->WorldPose());
+
+  // Take 1 step and expect an initial velocity from the plugin
+  world->Step(1);
+  const ignition::math::Vector3d expectedInitialLinearVel(-1, -1, 4.9902);
+  const ignition::math::Vector3d expectedInitialAngularVel(0.1, 5.0, 0.1);
+  EXPECT_EQ(expectedInitialLinearVel, model->WorldLinearVel());
+  EXPECT_EQ(expectedInitialAngularVel, model->WorldAngularVel());
+}

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -48,6 +48,7 @@ set(tests
   2875_connect_pub_to_sub_crash.cc
   2896_gazebo_subnamespace.cc
   2902_performance_metrics_deadlock.cc
+  3125_slow_loading_model_spawn.cc
 )
 gz_build_tests(${tests} EXTRA_LIBS gazebo_test_fixture)
 

--- a/test/worlds/slow_loading_model_spawn.world
+++ b/test/worlds/slow_loading_model_spawn.world
@@ -1,0 +1,75 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <plugin filename="libWorldSpawnModelPlugin.so" name="world_spawn_model">
+      <sdf version="1.6">
+        <model name="slow_loading_model">
+          <pose>0 0 0.45 0 0 0</pose>
+          <link name="box">
+            <inertial>
+              <mass>12</mass>
+              <inertia>
+                <ixx>0.97</ixx>
+                <iyy>0.82</iyy>
+                <izz>0.17</izz>
+                <ixy>0</ixy>
+                <ixz>0</ixz>
+                <iyz>0</iyz>
+              </inertia>
+            </inertial>
+            <collision name="collision">
+              <geometry>
+                <box>
+                  <size>0.1 0.4 0.9</size>
+                </box>
+              </geometry>
+            </collision>
+            <visual name="visual">
+              <geometry>
+                <box>
+                  <size>0.1 0.4 0.9</size>
+                </box>
+              </geometry>
+              <material>
+                <script>
+                  <uri>file://media/materials/scripts/gazebo.material</uri>
+                  <name>Gazebo/Grey</name>
+                </script>
+              </material>
+            </visual>
+            <sensor name='box_camera' type='camera'>
+              <camera>
+                <horizontal_fov>1.047</horizontal_fov>
+                <image>
+                  <width>320</width>
+                  <height>240</height>
+                  <format>R8G8B8</format>
+                </image>
+                <clip>
+                  <near>0.1</near>
+                  <far>100</far>
+                </clip>
+              </camera>
+              <always_on>1</always_on>
+              <update_rate>10</update_rate>
+              <plugin filename="libSlowLoadingSensorPlugin.so" name="slow_load">
+                <load_seconds>15</load_seconds>
+              </plugin>
+            </sensor>
+          </link>
+          <plugin name="large_wz" filename="libInitialVelocityPlugin.so">
+            <linear>-1 -1 5</linear>
+            <angular>0.1 5.0 0.1</angular>
+          </plugin>
+        </model>
+      </sdf>
+    </plugin>
+  </world>
+</sdf>

--- a/test/worlds/slow_loading_model_spawn.world
+++ b/test/worlds/slow_loading_model_spawn.world
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
-  <world name="default">
+  <world name='default' xmlns:ignition="http://ignitionrobotics.org/schema">
     <include>
       <uri>model://ground_plane</uri>
     </include>
@@ -8,6 +8,7 @@
       <uri>model://sun</uri>
     </include>
 
+    <ignition:model_plugin_loading_timeout>30</ignition:model_plugin_loading_timeout>
     <plugin filename="libWorldSpawnModelPlugin.so" name="world_spawn_model">
       <sdf version="1.6">
         <model name="slow_loading_model">


### PR DESCRIPTION
As reported in #3125, since #3121 was recently merged I have noticed a problem with some models that are slow to load. Specifically, if a model is spawned that contains a sensor plugin that is slow to load, it is possible that model plugins will fail to load, with the following error message:

~~~
[Err] [Model.cc:1061] Sensors failed to initialize when loading model[...] via the factory mechanism. Plugins for the model will not be loaded.
~~~

I believe this is caused by [this logic](https://github.com/osrf/gazebo/blob/gazebo11_11.8.1/gazebo/physics/Model.cc#L1025-L1036) in `Model::LoadPlugins` that skips loading of model plugins if the sensors take longer than 5 seconds to initialize, which includes the time required to load sensor plugins. I have increased this timeout to 50 seconds in https://github.com/osrf/gazebo/commit/2589d13b05919d58102ebb0ae5e8c435fa2ba57d, though I am open to suggestions for how to make this a configurable parameter.

I have added a regression test that loads a world file along with two test plugins to reproduce the failure. The world has a `WorldSpawnModelPlugin` that spawns a model that has a single box with a camera sensor using the `SlowLoadingSensorPlugin` and the `InitialVelocityPlugin` as a model plugin. The box should be given an initial velocity after loading.