### PR TITLE
Wideanglecamera equidistant mapping bounding fix

### DIFF
--- a/media/materials/programs/wide_lens_map_fp.glsl
+++ b/media/materials/programs/wide_lens_map_fp.glsl
@@ -35,7 +35,13 @@ void main()
 {
   // calculate angle from optical axis based on the mapping function specified
   float param = r/(c1*f);
-  float theta = fun.x*asin(param)+fun.y*atan(param)+fun.z*param;
+  float theta = 0.0;
+  if(fun.x > 0)
+    theta = asin(param);
+  else if(fun.y > 0)
+    theta = atan(param);
+  else if(fun.z > 0)
+    theta = param;
   theta = (theta-c3)*c2;
 
   // compute the direction vector that will be used to sample from the cubemap

--- a/media/materials/scripts/gazebo.material
+++ b/media/materials/scripts/gazebo.material
@@ -1515,7 +1515,7 @@ fragment_program Gazebo/WideLensMapFS glsl
     param_named c2 float 1
     param_named c3 float 0
     param_named f float 1
-    param_named fun float3 0 1
+    param_named fun float3 0 0 1
     param_named cutOffAngle float 3.14
   }
 }


### PR DESCRIPTION
Currently when using a `wideanglecamera` sensor with a lens type of `equidistant`, the actual image data gets restricted to a small circular region with the rest of the image having a gray ring around it. See the images below for the image that is produced for an `equidistant` lens with an HFOV of 1.5708, 2.0, and 3.14159.
![equidistant_1p5708](https://user-images.githubusercontent.com/19412869/143073575-38b652b1-fdaf-4118-beb9-8ef3eb09fd9d.png) 
![equidistant_2p0](https://user-images.githubusercontent.com/19412869/143073596-a4f95f66-c01b-443f-b873-bcb61b3e389e.png)
![equidistant_3p14159](https://user-images.githubusercontent.com/19412869/143073611-8be5c79a-6f7a-4b4c-bd82-96c0b22aa417.png)

The issue appears to be in `wide_lens_map_fp.glsl` on Line 38. The value `theta` gets calculated with `asin(param)` driving the equation if `fun.x` is 1 (which is true for `equisolid_angle` and `orthographic` lens types). The way this equation is written becomes problematic for other lens types, though, when the `param > 1` since the resulting value of `asin(param)` becomes undefined.

This PR is to add a check for function type to avoid the undefined `asin` computation. See the images below for an `equidistant` lens with an HFOV of 1.5708, 2.0, and 3.14159 after this fix.
![equidistant_1p5708_fixed](https://user-images.githubusercontent.com/19412869/143073639-6aba5b2d-7552-45a4-a5ef-d5382c9e9fb8.png)
![equidistant_2p0_fixed](https://user-images.githubusercontent.com/19412869/143073678-454d18f0-6893-4262-a153-c033125a810d.png)
![equidistant_3p14159_fixed](https://user-images.githubusercontent.com/19412869/143073696-b6f5fb1b-7c60-4a21-860d-773c63436429.png)

