### PR TITLE
Workaround for wrong distortion material applied to some cameras

### DIFF
--- a/gazebo/rendering/Distortion.cc
+++ b/gazebo/rendering/Distortion.cc
@@ -101,7 +101,7 @@ namespace gazebo
         // to this active material.
         _material->getTechnique(0)->getPass(_passId)->getTextureUnitState(1)->
           setTexture(distortionTexture);
-      
+
         // @todo Explore more efficent implementations as it is run every frame
         Ogre::GpuProgramParametersSharedPtr params =
             _material->getTechnique(0)->getPass(_passId)


### PR DESCRIPTION
When using stereo cameras with different distortion parameters and attaching other Ogre compositors to the cameras, the same distortion parameters will be applied to both cameras. This PR implements a workaround.

It looks to me like Distortion.cc tries to do the right thing by using a unique Ogre::CompositorInstance for each camera. Unfortunately, it looks like these CompositorInstances share the same CompositionTechnique inside Ogre, causing passes and materials to get stomped from one CompositorInstance to the next. This stomping only happens if you add compositors to your cameras in addition to the distortion compositor.