### PR TITLE
Replace use of tbb::task with oneapi::tbb::task_group, where available

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
+Alex Dewar <alex.dewar@gmx.co.uk>
 Nate Koenig <nkoenig@osrfoundation.org>
 John Hsu <hsu@osrfoundation.org>

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -301,7 +301,7 @@ if (PKG_CONFIG_FOUND)
 
   #################################################
   # Find TBB
-  pkg_check_modules(TBB tbb<2021)
+  pkg_check_modules(TBB tbb)
   set (TBB_PKG_CONFIG "tbb")
   if (NOT TBB_FOUND)
     message(STATUS "TBB not found, attempting to detect manually")

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -326,6 +326,22 @@ if (PKG_CONFIG_FOUND)
     endif (NOT TBB_FOUND)
   endif (NOT TBB_FOUND)
 
+  # tbb::task was removed in tbb v2021.01, so in this case we must move to the
+  # newer tbb::task_group API. This could also be used with earlier versions of
+  # TBB, but we want to maintain ABI compatibility for Ubuntu 18.04 etc., so
+  # disable this by default.
+  if (NOT DEFINED USE_LEGACY_TBB_TASK)
+    if (${TBB_VERSION} VERSION_LESS 2021)
+      set (USE_LEGACY_TBB_TASK ON)
+    else (${TBB_VERSION} VERSION_LESS 2021)
+      set (USE_LEGACY_TBB_TASK OFF)
+    endif(${TBB_VERSION} VERSION_LESS 2021)
+  endif()
+  set(USE_LEGACY_TBB_TASK ${USE_LEGACY_TBB_TASK} CACHE BOOL "Whether to use the deprecated tbb::task class")
+  if (USE_LEGACY_TBB_TASK)
+    add_definitions(-DUSE_LEGACY_TBB_TASK)
+  endif (USE_LEGACY_TBB_TASK)
+
   #################################################
   # Find OGRE
 

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -326,22 +326,6 @@ if (PKG_CONFIG_FOUND)
     endif (NOT TBB_FOUND)
   endif (NOT TBB_FOUND)
 
-  # tbb::task was removed in tbb v2021.01, so in this case we must move to the
-  # newer tbb::task_group API. This could also be used with earlier versions of
-  # TBB, but we want to maintain ABI compatibility for Ubuntu 18.04 etc., so
-  # disable this by default.
-  if (NOT DEFINED USE_LEGACY_TBB_TASK)
-    if (${TBB_VERSION} VERSION_LESS 2021)
-      set (USE_LEGACY_TBB_TASK ON)
-    else (${TBB_VERSION} VERSION_LESS 2021)
-      set (USE_LEGACY_TBB_TASK OFF)
-    endif(${TBB_VERSION} VERSION_LESS 2021)
-  endif()
-  set(USE_LEGACY_TBB_TASK ${USE_LEGACY_TBB_TASK} CACHE BOOL "Whether to use the deprecated tbb::task class")
-  if (USE_LEGACY_TBB_TASK)
-    add_definitions(-DUSE_LEGACY_TBB_TASK)
-  endif (USE_LEGACY_TBB_TASK)
-
   #################################################
   # Find OGRE
 

--- a/gazebo/transport/CMakeLists.txt
+++ b/gazebo/transport/CMakeLists.txt
@@ -29,6 +29,7 @@ set (headers
   SubscribeOptions.hh
   Subscriber.hh
   SubscriptionTransport.hh
+  TaskGroup.hh
   TopicManager.hh
   TransportIface.hh
   TransportTypes.hh

--- a/gazebo/transport/Connection.hh
+++ b/gazebo/transport/Connection.hh
@@ -372,7 +372,7 @@ namespace gazebo
       private: boost::asio::ip::tcp::endpoint GetRemoteEndpoint() const;
 
       /// \brief Gets hostname
-      /// \param[in] _ep The end point to get the hostename of
+      /// \param[in] _ep The end point to get the hostname of
       private: static std::string GetHostname(
                    boost::asio::ip::tcp::endpoint _ep);
 

--- a/gazebo/transport/ConnectionManager.cc
+++ b/gazebo/transport/ConnectionManager.cc
@@ -27,17 +27,6 @@
 using namespace gazebo;
 using namespace transport;
 
-/// TBB task to process nodes.
-class TopicManagerProcessTask : public tbb::task
-{
-  /// Implements the necessary execute function
-  public: tbb::task *execute()
-          {
-            TopicManager::Instance()->ProcessNodes();
-            return NULL;
-          }
-};
-
 /// TBB task to establish subscriber to publisher connection.
 class TopicManagerConnectionTask : public tbb::task
 {
@@ -272,11 +261,6 @@ void ConnectionManager::RunUpdate()
   if (this->masterConn)
     this->masterConn->ProcessWriteQueue();
 
-  // Use TBB to process nodes. Need more testing to see if this makes
-  // a difference.
-  // TopicManagerProcessTask *task = new(tbb::task::allocate_root())
-  //   TopicManagerProcessTask();
-  // tbb::task::enqueue(*task);
   boost::recursive_mutex::scoped_lock lock(this->connectionMutex);
 
   TopicManager::Instance()->ProcessNodes();

--- a/gazebo/transport/ConnectionManager.hh
+++ b/gazebo/transport/ConnectionManager.hh
@@ -27,8 +27,9 @@
 #include "gazebo/msgs/msgs.hh"
 #include "gazebo/common/SingletonT.hh"
 
-#include "gazebo/transport/Publisher.hh"
 #include "gazebo/transport/Connection.hh"
+#include "gazebo/transport/Publisher.hh"
+#include "gazebo/transport/TaskGroup.hh"
 #include "gazebo/util/system.hh"
 
 /// \brief Explicit instantiation for typed SingletonT.
@@ -193,6 +194,9 @@ namespace gazebo
 
       /// \brief Condition used for synchronization
       private: boost::condition_variable namespaceCondition;
+               
+      /// \brief For managing asynchronous tasks with tbb
+      private: TaskGroup taskGroup;
 
       // Singleton implementation
       private: friend class SingletonT<ConnectionManager>;

--- a/gazebo/transport/Node.hh
+++ b/gazebo/transport/Node.hh
@@ -18,7 +18,6 @@
 #ifndef GAZEBO_TRANSPORT_NODE_HH_
 #define GAZEBO_TRANSPORT_NODE_HH_
 
-#include <tbb/task.h>
 #include <boost/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <map>
@@ -26,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "gazebo/transport/TaskGroup.hh"
 #include "gazebo/transport/TransportTypes.hh"
 #include "gazebo/transport/TopicManager.hh"
 #include "gazebo/util/system.hh"
@@ -36,7 +36,7 @@ namespace gazebo
   {
     /// \cond
     /// \brief Task used by Node::Publish to publish on a one-time publisher
-    class GZ_TRANSPORT_VISIBLE PublishTask : public tbb::task
+    class GZ_TRANSPORT_VISIBLE PublishTask
     {
       /// \brief Constructor
       /// \param[in] _pub Publisher to publish the message on.
@@ -49,16 +49,14 @@ namespace gazebo
         this->msg->CopyFrom(_message);
       }
 
-      /// \brief Overridden function from tbb::task that exectues the
-      /// publish task.
-      public: tbb::task *execute()
+      /// \brief Executes the publish task.
+      public: void operator()()
               {
                 this->pub->WaitForConnection();
                 this->pub->Publish(*this->msg, true);
                 this->pub->SendMessage();
                 delete this->msg;
                 this->pub.reset();
-                return NULL;
               }
 
       /// \brief Pointer to the publisher.
@@ -159,11 +157,7 @@ namespace gazebo
                   const google::protobuf::Message &_message)
               {
                 transport::PublisherPtr pub = this->Advertise<M>(_topic);
-                PublishTask *task = new(tbb::task::allocate_root())
-                  PublishTask(pub, _message);
-
-                tbb::task::enqueue(*task);
-                return;
+                this->taskGroup.run<PublishTask>(pub, _message);
               }
 
       /// \brief Advertise a topic
@@ -418,6 +412,9 @@ namespace gazebo
 
       /// \brief List of newly arrive messages
       private: std::map<std::string, std::list<MessagePtr> > incomingMsgsLocal;
+      
+      /// \brief For managing asynchronous tasks with tbb
+      private: TaskGroup taskGroup;
 
       private: boost::mutex publisherMutex;
       private: boost::mutex publisherDeleteMutex;

--- a/gazebo/transport/TaskGroup.hh
+++ b/gazebo/transport/TaskGroup.hh
@@ -18,12 +18,14 @@
 #define _TASK_GROUP_HH_
 
 #include <utility>
+#include <tbb/version.h>
 
-#ifndef USE_LEGACY_TBB_TASK
+// tbb::task was removed in v2021.01, so we need a workaround
+#if TBB_VERSION_MAJOR >= 2021
 
 // Emit is both a macro in Qt and a function defined by tbb
 #undef emit
-#include <oneapi/tbb/task_group.h>
+#include <tbb/task_group.h>
 #define emit
 
 namespace gazebo {
@@ -41,7 +43,7 @@ namespace gazebo {
         this->taskGroup.run(Functor(std::forward<Args>(args)...));
       }
 
-      private: oneapi::tbb::task_group taskGroup;
+      private: tbb::task_group taskGroup;
     };
   }
 }

--- a/gazebo/transport/TaskGroup.hh
+++ b/gazebo/transport/TaskGroup.hh
@@ -18,16 +18,14 @@
 #define _TASK_GROUP_HH_
 
 #include <utility>
-#include <tbb/version.h>
-
-// tbb::task was removed in v2021.01, so we need a workaround
-#if TBB_VERSION_MAJOR >= 2021
 
 // Emit is both a macro in Qt and a function defined by tbb
 #undef emit
-#include <tbb/task_group.h>
+#include <tbb/tbb.h>
 #define emit
 
+// tbb::task was removed in v2021.01, so we need a workaround
+#if TBB_VERSION_MAJOR >= 2021
 namespace gazebo {
   namespace transport {
     class TaskGroup
@@ -48,8 +46,6 @@ namespace gazebo {
   }
 }
 #else
-#include <tbb/task.h>
-
 namespace gazebo {
   namespace transport {
     class TaskGroup

--- a/gazebo/transport/TaskGroup.hh
+++ b/gazebo/transport/TaskGroup.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Alex Dewar
+ * Copyright (C) 2021 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gazebo/transport/TaskGroup.hh
+++ b/gazebo/transport/TaskGroup.hh
@@ -19,7 +19,7 @@
 
 #include <utility>
 
-#if __has_include(<oneapi/tbb/task_group.h>)
+#ifndef USE_LEGACY_TBB_TASK
 
 // Emit is both a macro in Qt and a function defined by tbb
 #undef emit

--- a/gazebo/transport/TaskGroup.hh
+++ b/gazebo/transport/TaskGroup.hh
@@ -72,7 +72,7 @@ namespace gazebo {
 
       public: template<class Functor, class... Args> void run(Args&&... args)
               {
-                auto *task = new (tbb::task::allocate_root())
+                TaskWrapper<Functor> *task = new (tbb::task::allocate_root())
                     TaskWrapper<Functor>(std::forward<Args>(args)...);
                 tbb::task::enqueue(*task);
               }

--- a/gazebo/transport/TaskGroup.hh
+++ b/gazebo/transport/TaskGroup.hh
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 Alex Dewar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef _TASK_GROUP_HH_
+#define _TASK_GROUP_HH_
+
+#include <utility>
+
+#if __has_include(<oneapi/tbb/task_group.h>)
+
+// Emit is both a macro in Qt and a function defined by tbb
+#undef emit
+#include <oneapi/tbb/task_group.h>
+#define emit
+
+namespace gazebo {
+  namespace transport {
+    class TaskGroup
+    {
+      public: ~TaskGroup() noexcept
+              {
+                // Wait for running tasks to finish
+                this->taskGroup.wait();
+              }
+
+      public: template<class Functor, class... Args> void run(Args&&... args)
+      {
+        this->taskGroup.run(Functor(std::forward<Args>(args)...));
+      }
+
+      private: oneapi::tbb::task_group taskGroup;
+    };
+  }
+}
+#else
+#include <tbb/task.h>
+
+namespace gazebo {
+  namespace transport {
+    class TaskGroup
+    {
+      /// \brief A helper class which provides the requisite execute() method
+      /// required by tbb.
+      private: template<class T> class TaskWrapper : public tbb::task
+      {
+        public: template<class... Args> TaskWrapper<T>(Args&&... args)
+          : functor(std::forward<Args>(args)...)
+        {
+        }
+
+        public: tbb::task *execute()
+                {
+                  this->functor();
+                  return nullptr;
+                }
+        
+        private: T functor;
+      };
+
+      public: template<class Functor, class... Args> void run(Args&&... args)
+              {
+                auto *task = new (tbb::task::allocate_root())
+                    TaskWrapper<Functor>(std::forward<Args>(args)...);
+                tbb::task::enqueue(*task);
+              }
+    };
+  }
+}
+
+#endif
+#endif

--- a/gazebo/transport/transport_pch.hh
+++ b/gazebo/transport/transport_pch.hh
@@ -46,12 +46,12 @@
 #include <string>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
-#if __has_include(<oneapi/tbb/task_group.h>)
+#ifdef USE_LEGACY_TBB_TASK
+#include <tbb/task.h>
+#else
 #undef emit
 #include <oneapi/tbb/task_group.h>
 #define emit
-#else
-#include <tbb/task.h>
 #endif
 #include <utility>
 #include <vector>

--- a/gazebo/transport/transport_pch.hh
+++ b/gazebo/transport/transport_pch.hh
@@ -46,11 +46,12 @@
 #include <string>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
-#ifdef USE_LEGACY_TBB_TASK
+#include <tbb/version.h>
+#if TBB_MAJOR_VERSION < 2021
 #include <tbb/task.h>
 #else
 #undef emit
-#include <oneapi/tbb/task_group.h>
+#include <tbb/task_group.h>
 #define emit
 #endif
 #include <utility>

--- a/gazebo/transport/transport_pch.hh
+++ b/gazebo/transport/transport_pch.hh
@@ -46,6 +46,12 @@
 #include <string>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
+#if __has_include(<oneapi/tbb/task_group.h>)
+#undef emit
+#include <oneapi/tbb/task_group.h>
+#define emit
+#else
 #include <tbb/task.h>
+#endif
 #include <utility>
 #include <vector>

--- a/gazebo/transport/transport_pch.hh
+++ b/gazebo/transport/transport_pch.hh
@@ -44,15 +44,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
-#include <tbb/blocked_range.h>
-#include <tbb/parallel_for.h>
-#include <tbb/version.h>
-#if TBB_MAJOR_VERSION < 2021
-#include <tbb/task.h>
-#else
 #undef emit
-#include <tbb/task_group.h>
+#include <tbb/tbb.h>
 #define emit
-#endif
 #include <utility>
 #include <vector>


### PR DESCRIPTION
As of TBB 2021.01, ``tbb::task`` has been removed: #2867.

Accordingly, I have implemented a wrapper class, ``TaskGroup``, which makes use of ``oneapi::tbb::task_group`` where it is available but falls back on ``tbb::task`` otherwise. Note that the ``tbb::task_group`` class has been around for a while now (predating the rebranding as oneTBB), so we could be less conservative and essentially use this code path for some older versions of TBB which still have ``tbb::task``.

Resolves #2867.