### PR TITLE
Suppress boost warnings about global placeholders

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -625,6 +625,9 @@ if (NOT Boost_FOUND)
   BUILD_ERROR ("Boost not found. Please install thread system filesystem program_options regex iostreams date_time boost version ${MIN_BOOST_VERSION} or higher.")
 endif()
 
+# Suppress warnings from boost/bind.hpp about use of global placeholders (e.g. _1, _2 etc.)
+add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
+
 ########################################
 # Find libdl
 find_path(libdl_include_dir dlfcn.h /usr/include /usr/local/include)


### PR DESCRIPTION
When building Gazebo, my build log is spammed with messages like the following:
```
[981/1131] Building CXX object plugins/CMakeFiles/FlashLightPlugin.dir/FlashLightPlugin.cc.o
In file included from /usr/include/boost/smart_ptr/detail/sp_thread_sleep.hpp:22,
                 from /usr/include/boost/smart_ptr/detail/yield_k.hpp:23,
                 from /usr/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp:14,
                 from /usr/include/boost/smart_ptr/detail/spinlock.hpp:42,
                 from /usr/include/boost/smart_ptr/detail/spinlock_pool.hpp:25,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:29,
                 from /usr/include/boost/shared_ptr.hpp:17,
                 from /home/alex/code/gazebo/gazebo/common/CommonTypes.hh:24,
                 from /home/alex/code/gazebo/gazebo/common/Plugin.hh:36,
                 from /home/alex/code/gazebo/plugins/FlashLightPlugin.cc:24:
/usr/include/boost/bind.hpp:36:1: note: ‘#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’
```

Though it might make sense to follow the suggestion in the error message and *not* have these symbols in the global namespace, for now suppress this warning by defining ``BOOST_GLOBAL_PLACEHOLDERS`` so the build log is actually readable.