### PR TITLE
Load model plugins even after sensor timeout

### DIFF
--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -1051,9 +1051,18 @@ void Model::LoadPlugins(unsigned int _timeout)
       iterations++;
     }
 
-    // Load the plugins if the sensors have been loaded, or if there
-    // are no sensors attached to the model.
-    if (iterations < maxIterations)
+    // Print an error message if sensors still haven't been loaded.
+    if (iterations >= maxIterations)
+    {
+      gzerr << "Sensors failed to initialize when loading model["
+        << this->GetName() << "] via the factory mechanism."
+        << " Model plugins may not function properly."
+        << " Consider setting <ignition:model_plugin_loading_timeout/>"
+        << " to a value larger than " << _timeout << " in the world file."
+        << std::endl;
+    }
+
+    // Load the model plugins
     {
       // Load the plugins
       sdf::ElementPtr pluginElem = this->sdf->GetElement("plugin");
@@ -1062,12 +1071,6 @@ void Model::LoadPlugins(unsigned int _timeout)
         this->LoadPlugin(pluginElem);
         pluginElem = pluginElem->GetNextElement("plugin");
       }
-    }
-    else
-    {
-      gzerr << "Sensors failed to initialize when loading model["
-        << this->GetName() << "] via the factory mechanism."
-        << " Plugins for the model will not be loaded.\n";
     }
   }
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -52,6 +52,10 @@ set(tests
 )
 gz_build_tests(${tests} EXTRA_LIBS gazebo_test_fixture)
 
+add_dependencies(${TEST_TYPE}_3125_slow_loading_model_spawn
+                 SlowLoadingSensorPlugin
+                 WorldSpawnModelPlugin)
+
 set(display_tests
 )
 

--- a/test/worlds/slow_loading_model_spawn.world
+++ b/test/worlds/slow_loading_model_spawn.world
@@ -8,7 +8,7 @@
       <uri>model://sun</uri>
     </include>
 
-    <ignition:model_plugin_loading_timeout>30</ignition:model_plugin_loading_timeout>
+    <ignition:model_plugin_loading_timeout>5</ignition:model_plugin_loading_timeout>
     <plugin filename="libWorldSpawnModelPlugin.so" name="world_spawn_model">
       <sdf version="1.6">
         <model name="slow_loading_model">


### PR DESCRIPTION
Currently model plugins are not loaded in certain cases if it takes too long to initialize sensors. In #3126, we made the timeout configurable and added a test. This pull request changes the behavior to print an error message if the sensors fail to initialize before the timeout but to load the model plugins anyway.

The test is changed to use a very short timeout, so that we can confirm see the error message and confirm that the model plugins are still loaded.