### PR TITLE
Fix focal builds: use python3 with check_test_ran.py

### DIFF
--- a/cmake/GazeboTestUtils.cmake
+++ b/cmake/GazeboTestUtils.cmake
@@ -76,7 +76,7 @@ macro (gz_build_tests)
 
     # Check that the test produced a result and create a failure if it didn't.
     # Guards against crashed and timed out tests.
-    add_test(check_${BINARY_NAME} ${PROJECT_SOURCE_DIR}/tools/check_test_ran.py
+    add_test(check_${BINARY_NAME} ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/tools/check_test_ran.py
       ${CMAKE_BINARY_DIR}/test_results/${BINARY_NAME}.xml)
 
     if(GAZEBO_RUN_VALGRIND_TESTS AND VALGRIND_PROGRAM)

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -676,6 +676,13 @@ else()
 endif()
 
 ########################################
+# Find python3, which is used by tools/check_test_ran.py
+find_package(PythonInterp 3)
+if (NOT EXISTS ${PYTHON_EXECUTABLE})
+  BUILD_WARNING("python3 not found. The check_test_ran.py script will cause tests to fail.")
+endif()
+
+########################################
 # Find xsltproc, which is used by tools/check_test_ran.py
 find_program(XSLTPROC xsltproc)
 if (NOT EXISTS ${XSLTPROC})

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -677,7 +677,14 @@ endif()
 
 ########################################
 # Find python3, which is used by tools/check_test_ran.py
-find_package(PythonInterp 3)
+if (${CMAKE_VERSION} VERSION_LESS 3.12)
+  find_package(PythonInterp 3)
+else()
+  find_package(Python3 COMPONENTS Interpreter)
+  if (Python3_FOUND)
+    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+  endif()
+endif()
 if (NOT EXISTS ${PYTHON_EXECUTABLE})
   BUILD_WARNING("python3 not found. The check_test_ran.py script will cause tests to fail.")
 endif()


### PR DESCRIPTION
Fix for [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo11-focal-amd64-gpu-nvidia&build=6)](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-focal-amd64-gpu-nvidia/6/) https://build.osrfoundation.org/job/gazebo-ci-gazebo11-focal-amd64-gpu-nvidia/6/

~~~
test 614
    Start 614: check_INTEGRATION_visual_pose

614: Test command: /var/lib/jenkins/workspace/gazebo-ci-gazebo11-focal-amd64-gpu-nvidia/gazebo/tools/check_test_ran.py "/var/lib/jenkins/workspace/gazebo-ci-gazebo11-focal-amd64-gpu-nvidia/build/test_results/INTEGRATION_visual_pose.xml"
614: Test timeout computed to be: 10000000
614: /usr/bin/env: ���python���: No such file or directory
1/1 Test #614: check_INTEGRATION_visual_pose ....***Failed    0.00 sec
~~~