### PR TITLE
Use boost/bind/bind.hpp to fix warnings on Arch Linux

### DIFF
--- a/deps/opende/src/quickstep_util.h
+++ b/deps/opende/src/quickstep_util.h
@@ -57,7 +57,7 @@
 #ifdef USE_TPROW
 // added for threading per constraint rows
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include "gazebo/ode/odeinit.h"
 #endif
 

--- a/deps/opende/src/util.cpp
+++ b/deps/opende/src/util.cpp
@@ -26,7 +26,7 @@
 #include "joints/joint.h"
 #include "util.h"
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <gazebo/ode/timer.h>
 
 #undef REPORT_THREAD_TIMING

--- a/deps/threadpool/boost/threadpool/detail/pool_core.hpp
+++ b/deps/threadpool/boost/threadpool/detail/pool_core.hpp
@@ -35,7 +35,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/smart_ptr.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits.hpp>
 

--- a/deps/threadpool/boost/threadpool/detail/worker_thread.hpp
+++ b/deps/threadpool/boost/threadpool/detail/worker_thread.hpp
@@ -24,7 +24,7 @@
 #include <boost/thread.hpp>
 #include <boost/thread/exceptions.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 
 namespace boost { namespace threadpool { namespace detail 

--- a/gazebo/Master.cc
+++ b/gazebo/Master.cc
@@ -19,7 +19,7 @@
 #include <thread>
 #include <mutex>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
 #include <google/protobuf/descriptor.h>
 #include <set>

--- a/gazebo/Master.cc
+++ b/gazebo/Master.cc
@@ -87,6 +87,7 @@ void Master::Init(uint16_t _port)
 {
   try
   {
+    using namespace boost::placeholders;
     this->dataPtr->connection->Listen(_port,
           boost::bind(&Master::OnAccept, this, _1));
   }
@@ -136,6 +137,7 @@ void Master::OnAccept(transport::ConnectionPtr _newConnection)
     this->dataPtr->connections[index] = _newConnection;
 
     // Start reading from the connection
+    using namespace boost::placeholders;
     _newConnection->AsyncRead(
         boost::bind(&Master::OnRead, this, index, _1));
   }
@@ -156,6 +158,7 @@ void Master::OnRead(const unsigned int _connectionIndex,
   transport::ConnectionPtr conn = this->dataPtr->connections[_connectionIndex];
 
   // Read the next message
+  using namespace boost::placeholders;
   if (conn && conn->IsOpen())
     conn->AsyncRead(boost::bind(&Master::OnRead, this, _connectionIndex, _1));
 

--- a/gazebo/common/ModelDatabase.cc
+++ b/gazebo/common/ModelDatabase.cc
@@ -25,7 +25,7 @@
 #include <iostream>
 
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/function.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>

--- a/gazebo/common/MovingWindowFilter.hh
+++ b/gazebo/common/MovingWindowFilter.hh
@@ -23,7 +23,7 @@
 #include <map>
 
 #include <boost/function.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 

--- a/gazebo/common/WeakBind.hh
+++ b/gazebo/common/WeakBind.hh
@@ -19,7 +19,7 @@
 #define GAZEBO_COMMON_WEAKBIND_HH_
 
 #include <boost/shared_ptr.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace gazebo
 {

--- a/gazebo/common/common_pch.hh
+++ b/gazebo/common/common_pch.hh
@@ -29,7 +29,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>

--- a/gazebo/gazebo.cc
+++ b/gazebo/gazebo.cc
@@ -15,7 +15,7 @@
  *
  */
 #include <vector>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 #include <sdf/sdf.hh>
 

--- a/gazebo/gazebo.cc
+++ b/gazebo/gazebo.cc
@@ -15,7 +15,6 @@
  *
  */
 #include <vector>
-#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 #include <sdf/sdf.hh>
 

--- a/gazebo/gazebo_shared.cc
+++ b/gazebo/gazebo_shared.cc
@@ -59,6 +59,7 @@ bool gazebo_shared::setup(const std::string &_prefix, int _argc, char **_argv,
   gazebo::common::load();
 
   // The SDF find file callback.
+  using namespace boost::placeholders;
   sdf::setFindCallback(boost::bind(&gazebo::common::find_file, _1));
 
   // Initialize the informational logger. This will log warnings, and

--- a/gazebo/gui/InsertModelWidget.cc
+++ b/gazebo/gui/InsertModelWidget.cc
@@ -18,7 +18,7 @@
 #include <fstream>
 #include <cstdlib>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 #include <sdf/sdf.hh>

--- a/gazebo/gui/InsertModelWidget.cc
+++ b/gazebo/gui/InsertModelWidget.cc
@@ -128,6 +128,7 @@ InsertModelWidget::InsertModelWidget(QWidget *_parent)
           this, SLOT(OnDirectoryChanged(const QString &)));
 
   // Connect a callback to trigger when the model paths are updated.
+  using namespace boost::placeholders;
   this->connections.push_back(
           common::SystemPaths::Instance()->updateModelRequest.Connect(
             boost::bind(&InsertModelWidget::OnModelUpdateRequest, this, _1)));

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/transport/transport.hh"
 #include "gazebo/rendering/UserCamera.hh"

--- a/gazebo/gui/ModelRightMenu.cc
+++ b/gazebo/gui/ModelRightMenu.cc
@@ -34,6 +34,7 @@ using namespace gui;
 /////////////////////////////////////////////////
 ModelRightMenu::ModelRightMenu()
 {
+  using namespace boost::placeholders;
   KeyEventHandler::Instance()->AddReleaseFilter("ModelRightMenu",
         boost::bind(&ModelRightMenu::OnKeyRelease, this, _1));
 

--- a/gazebo/gui/QTestFixture.cc
+++ b/gazebo/gui/QTestFixture.cc
@@ -20,7 +20,7 @@
 # include <mach/mach.h>
 #endif  // __MACH__
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <unistd.h>
 
 #include "gazebo/common/Console.hh"

--- a/gazebo/gui/RenderWidget.cc
+++ b/gazebo/gui/RenderWidget.cc
@@ -97,6 +97,7 @@ RenderWidget::RenderWidget(QWidget *_parent)
   this->setLayout(mainLayout);
   this->layout()->setContentsMargins(0, 0, 0, 0);
 
+  using namespace boost::placeholders;
   this->connections.push_back(
       gui::Events::ConnectFollow(
         boost::bind(&RenderWidget::OnFollow, this, _1)));

--- a/gazebo/gui/RenderWidget.cc
+++ b/gazebo/gui/RenderWidget.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <iomanip>
 
 #include "gazebo/common/CommonIface.hh"

--- a/gazebo/gui/SpaceNav.cc
+++ b/gazebo/gui/SpaceNav.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <gazebo/gazebo_config.h>
 #ifdef HAVE_SPNAV
 #include <spnav.h>

--- a/gazebo/gui/ToolsWidget.cc
+++ b/gazebo/gui/ToolsWidget.cc
@@ -60,6 +60,7 @@ ToolsWidget::ToolsWidget(QWidget *_parent)
   this->setLayout(mainLayout);
 
   // Listen to entity selection events
+  using namespace boost::placeholders;
   this->connections.push_back(
       event::Events::ConnectSetSelectedEntity(
         boost::bind(&ToolsWidget::OnSetSelectedEntity, this, _1, _2)));

--- a/gazebo/gui/ToolsWidget.cc
+++ b/gazebo/gui/ToolsWidget.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/common/Events.hh"
 #include "gazebo/gui/JointControlWidget.hh"

--- a/gazebo/gui/building/BuildingEditor.cc
+++ b/gazebo/gui/building/BuildingEditor.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/gui/qt.h"
 #include "gazebo/gui/Actions.hh"

--- a/gazebo/gui/building/BuildingEditorPalette.cc
+++ b/gazebo/gui/building/BuildingEditorPalette.cc
@@ -261,6 +261,7 @@ BuildingEditorPalette::BuildingEditorPalette(QWidget *_parent)
   this->setLayout(scrollLayout);
 
   // Connections
+  using namespace boost::placeholders;
   this->dataPtr->connections.push_back(
       gui::editor::Events::ConnectSaveBuildingModel(
       boost::bind(&BuildingEditorPalette::OnSaveModel, this, _1)));

--- a/gazebo/gui/building/BuildingEditorPalette.cc
+++ b/gazebo/gui/building/BuildingEditorPalette.cc
@@ -17,7 +17,7 @@
  * thenounproject.com
  * Stairs designed by Brian Oppenlander from the thenounproject.com
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/gui/building/BuildingEditorPalettePrivate.hh"
 #include "gazebo/gui/building/BuildingEditorPalette.hh"

--- a/gazebo/gui/building/EditorView.cc
+++ b/gazebo/gui/building/EditorView.cc
@@ -15,8 +15,8 @@
  *
 */
 
+#include <functional>
 #include <sstream>
-#include <boost/bind.hpp>
 
 #include <ignition/math/Vector2.hh>
 
@@ -54,39 +54,39 @@ EditorView::EditorView(QWidget *_parent)
 
   this->connections.push_back(
       gui::editor::Events::ConnectCreateBuildingEditorItem(
-      boost::bind(&EditorView::OnCreateEditorItem, this, _1)));
+      std::bind(&EditorView::OnCreateEditorItem, this, std::placeholders::_1)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectColorSelected(
-      boost::bind(&EditorView::OnColorSelected, this, _1)));
+      std::bind(&EditorView::OnColorSelected, this, std::placeholders::_1)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectTextureSelected(
-      boost::bind(&EditorView::OnTextureSelected, this, _1)));
+      std::bind(&EditorView::OnTextureSelected, this, std::placeholders::_1)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectNewBuildingModel(
-      boost::bind(&EditorView::OnDiscardModel, this)));
+      std::bind(&EditorView::OnDiscardModel, this)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectAddBuildingLevel(
-      boost::bind(&EditorView::OnAddLevel, this)));
+      std::bind(&EditorView::OnAddLevel, this)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectDeleteBuildingLevel(
-      boost::bind(&EditorView::OnDeleteLevel, this)));
+      std::bind(&EditorView::OnDeleteLevel, this)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectChangeBuildingLevel(
-      boost::bind(&EditorView::OnChangeLevel, this, _1)));
+      std::bind(&EditorView::OnChangeLevel, this, std::placeholders::_1)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectShowFloorplan(
-      boost::bind(&EditorView::OnShowFloorplan, this)));
+      std::bind(&EditorView::OnShowFloorplan, this)));
 
   this->connections.push_back(
       gui::editor::Events::ConnectShowElements(
-      boost::bind(&EditorView::OnShowElements, this)));
+      std::bind(&EditorView::OnShowElements, this)));
 
   this->mousePressRotation = 0;
 

--- a/gazebo/gui/gui_pch.hh
+++ b/gazebo/gui/gui_pch.hh
@@ -22,7 +22,7 @@
  *    grep --include="*.hh" --include="*.cc" --no-filename -r "#include <" | sort -u
  */
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/function.hpp>
 #include <boost/lexical_cast.hpp>

--- a/gazebo/gui/model/ModelEditor.cc
+++ b/gazebo/gui/model/ModelEditor.cc
@@ -272,6 +272,7 @@ ModelEditor::ModelEditor(MainWindow *_mainWindow)
   connect(this->dataPtr->modelPalette->ModelCreator()->JointMaker(),
       SIGNAL(JointAdded()), this, SLOT(OnJointAdded()));
 
+  using namespace boost::placeholders;
   this->dataPtr->connections.push_back(
       gui::Events::ConnectCreateEntity(
         boost::bind(&ModelEditor::OnCreateEntity, this, _1, _2)));

--- a/gazebo/gui/model/ModelEditor.cc
+++ b/gazebo/gui/model/ModelEditor.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <string>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/gui/model/ModelTreeWidget.cc
+++ b/gazebo/gui/model/ModelTreeWidget.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <boost/version.hpp>
 

--- a/gazebo/gui/terrain/TerrainEditorPalette.cc
+++ b/gazebo/gui/terrain/TerrainEditorPalette.cc
@@ -240,6 +240,7 @@ void TerrainEditorPalette::SetState(const std::string &_state)
 
     // Add an event filter, which allows the TerrainEditor to capture
     // mouse events.
+    using namespace boost::placeholders;
     MouseEventHandler::Instance()->AddPressFilter("terrain",
         boost::bind(&TerrainEditorPalette::OnMousePress, this, _1));
 

--- a/gazebo/gui/terrain/TerrainEditorPalette.cc
+++ b/gazebo/gui/terrain/TerrainEditorPalette.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/rendering/Heightmap.hh"
 #include "gazebo/rendering/Scene.hh"

--- a/gazebo/physics/Entity.cc
+++ b/gazebo/physics/Entity.cc
@@ -199,6 +199,7 @@ void Entity::SetAnimation(common::PoseAnimationPtr _anim)
   this->prevAnimationTime = this->world->SimTime();
   this->animation = _anim;
   this->onAnimationComplete.clear();
+  using namespace boost::placeholders;
   this->animationConnection = event::Events::ConnectWorldUpdateBegin(
       boost::bind(&Entity::UpdateAnimation, this, _1));
 }
@@ -212,6 +213,7 @@ void Entity::SetAnimation(const common::PoseAnimationPtr &_anim,
   this->prevAnimationTime = this->world->SimTime();
   this->animation = _anim;
   this->onAnimationComplete = _onComplete;
+  using namespace boost::placeholders;
   this->animationConnection = event::Events::ConnectWorldUpdateBegin(
       boost::bind(&Entity::UpdateAnimation, this, _1));
 }

--- a/gazebo/physics/Entity.cc
+++ b/gazebo/physics/Entity.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 

--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -19,7 +19,7 @@
 #include <tbb/blocked_range.h>
 #include <float.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <ignition/math/Pose3.hh>

--- a/gazebo/physics/bullet/BulletJoint.cc
+++ b/gazebo/physics/bullet/BulletJoint.cc
@@ -19,7 +19,7 @@
  * Date: 15 May 2009
  */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <string>
 
 #include "gazebo/common/Assert.hh"

--- a/gazebo/physics/dart/DARTFixedJoint.cc
+++ b/gazebo/physics/dart/DARTFixedJoint.cc
@@ -15,7 +15,6 @@
  *
 */
 
-#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/dart/DARTFixedJoint.cc
+++ b/gazebo/physics/dart/DARTFixedJoint.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/dart/DARTHingeJoint.cc
+++ b/gazebo/physics/dart/DARTHingeJoint.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/dart/DARTJoint.cc
+++ b/gazebo/physics/dart/DARTJoint.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/common/Assert.hh"
 #include "gazebo/common/Console.hh"

--- a/gazebo/physics/dart/DARTScrewJoint.cc
+++ b/gazebo/physics/dart/DARTScrewJoint.cc
@@ -16,7 +16,7 @@
  */
 
 #include <string>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/dart/DARTSliderJoint.cc
+++ b/gazebo/physics/dart/DARTSliderJoint.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODEFixedJoint.cc
+++ b/gazebo/physics/ode/ODEFixedJoint.cc
@@ -15,7 +15,6 @@
  *
 */
 
-#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODEFixedJoint.cc
+++ b/gazebo/physics/ode/ODEFixedJoint.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODEGearboxJoint.cc
+++ b/gazebo/physics/ode/ODEGearboxJoint.cc
@@ -15,7 +15,6 @@
  *
 */
 
-#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODEGearboxJoint.cc
+++ b/gazebo/physics/ode/ODEGearboxJoint.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODEHingeJoint.cc
+++ b/gazebo/physics/ode/ODEHingeJoint.cc
@@ -19,7 +19,6 @@
  * Date: 21 May 2003
  */
 
-#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODEHingeJoint.cc
+++ b/gazebo/physics/ode/ODEHingeJoint.cc
@@ -19,7 +19,7 @@
  * Date: 21 May 2003
  */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODEJoint.cc
+++ b/gazebo/physics/ode/ODEJoint.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include "gazebo/common/Exception.hh"
 #include "gazebo/common/Console.hh"
 #include "gazebo/common/Assert.hh"

--- a/gazebo/physics/ode/ODEScrewJoint.cc
+++ b/gazebo/physics/ode/ODEScrewJoint.cc
@@ -19,7 +19,7 @@
  * Date: 21 May 2003
  */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include <string>

--- a/gazebo/physics/ode/ODEScrewJoint.cc
+++ b/gazebo/physics/ode/ODEScrewJoint.cc
@@ -19,7 +19,6 @@
  * Date: 21 May 2003
  */
 
-#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include <string>

--- a/gazebo/physics/ode/ODESliderJoint.cc
+++ b/gazebo/physics/ode/ODESliderJoint.cc
@@ -18,7 +18,7 @@
  * Author: Nate Koenig, Andrew Howard
  * Date: 21 May 2003
  */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/ode/ODESliderJoint.cc
+++ b/gazebo/physics/ode/ODESliderJoint.cc
@@ -18,7 +18,6 @@
  * Author: Nate Koenig, Andrew Howard
  * Date: 21 May 2003
  */
-#include <boost/bind/bind.hpp>
 #include <ignition/math/Helpers.hh>
 
 #include "gazebo/gazebo_config.h"

--- a/gazebo/physics/physics_pch.hh
+++ b/gazebo/physics/physics_pch.hh
@@ -25,7 +25,7 @@
 #include <atomic>
 #include <boost/algorithm/string.hpp>
 #include <boost/any.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>
 #include <boost/range/adaptor/reversed.hpp>

--- a/gazebo/physics/simbody/SimbodyLink.cc
+++ b/gazebo/physics/simbody/SimbodyLink.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 
 #include "gazebo/common/Assert.hh"

--- a/gazebo/rendering/CameraVisual.cc
+++ b/gazebo/rendering/CameraVisual.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <ignition/common/Profiler.hh>
 

--- a/gazebo/rendering/ContactVisual.cc
+++ b/gazebo/rendering/ContactVisual.cc
@@ -17,7 +17,7 @@
 /* Desc: Contact Visualization Class
  * Author: Nate Koenig
  */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <ignition/common/Profiler.hh>
 

--- a/gazebo/rendering/LaserVisual.cc
+++ b/gazebo/rendering/LaserVisual.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/common/Profiler.hh>
 
 #include "gazebo/common/MeshManager.hh"

--- a/gazebo/rendering/Projector.cc
+++ b/gazebo/rendering/Projector.cc
@@ -19,7 +19,7 @@
  * Author: Jared Duke, John Hsu, Nate Koenig
  */
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/rendering/RTShaderSystem.hh"
 

--- a/gazebo/rendering/TransmitterVisual.cc
+++ b/gazebo/rendering/TransmitterVisual.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <ignition/common/Profiler.hh>
 

--- a/gazebo/rendering/UserCamera.cc
+++ b/gazebo/rendering/UserCamera.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/Color.hh>
 #include <ignition/math/Vector2.hh>

--- a/gazebo/rendering/VideoVisual.cc
+++ b/gazebo/rendering/VideoVisual.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <ignition/common/Profiler.hh>
 

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/lexical_cast.hpp>
 

--- a/gazebo/rendering/WrenchVisual.cc
+++ b/gazebo/rendering/WrenchVisual.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <ignition/common/Profiler.hh>
 

--- a/gazebo/rendering/rendering_pch.hh
+++ b/gazebo/rendering/rendering_pch.hh
@@ -24,7 +24,7 @@
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/assign/list_of.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/function.hpp>

--- a/gazebo/sensors/Noise_TEST.cc
+++ b/gazebo/sensors/Noise_TEST.cc
@@ -363,6 +363,7 @@ TEST_F(NoiseTest, OnApplyNoise)
   ASSERT_TRUE(noise != nullptr);
   EXPECT_TRUE(noise->GetNoiseType() == sensors::Noise::CUSTOM);
 
+  using namespace boost::placeholders;
   noise->SetCustomNoiseCallback(
     boost::bind(&OnApplyCustomNoise, _1));
 

--- a/gazebo/sensors/Noise_TEST.cc
+++ b/gazebo/sensors/Noise_TEST.cc
@@ -21,7 +21,7 @@
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
 #include <boost/accumulators/statistics/variance.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <ignition/math/Rand.hh>
 

--- a/gazebo/sensors/SensorManager.cc
+++ b/gazebo/sensors/SensorManager.cc
@@ -1008,6 +1008,7 @@ bool SensorManager::ImageSensorContainer::WaitForPrerendered(double _timeoutsec)
 /////////////////////////////////////////////////
 SimTimeEventHandler::SimTimeEventHandler()
 {
+  using namespace boost::placeholders;
   this->updateConnection = event::Events::ConnectWorldUpdateBegin(
       boost::bind(&SimTimeEventHandler::OnUpdate, this, _1));
 }

--- a/gazebo/sensors/SensorManager.cc
+++ b/gazebo/sensors/SensorManager.cc
@@ -16,7 +16,7 @@
 */
 
 #include <functional>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/physics/Link.hh"
 #include "gazebo/physics/Model.hh"

--- a/gazebo/test/ServerFixture.cc
+++ b/gazebo/test/ServerFixture.cc
@@ -531,6 +531,7 @@ void ServerFixture::GetFrame(const std::string &_cameraName,
   this->imgData = _imgData;
 
   this->gotImage = 0;
+  using namespace boost::placeholders;
   event::ConnectionPtr c =
     camSensor->Camera()->ConnectNewImageFrame(
         boost::bind(&ServerFixture::OnNewFrame,

--- a/gazebo/transport/Connection.cc
+++ b/gazebo/transport/Connection.cc
@@ -289,6 +289,7 @@ void Connection::StopRead()
 //////////////////////////////////////////////////
 void Connection::EnqueueMsg(const std::string &_buffer, bool _force)
 {
+  using namespace boost::placeholders;
   this->EnqueueMsg(_buffer, boost::bind(&dummy_callback_fn, _1), 0, _force);
 }
 

--- a/gazebo/transport/Connection.cc
+++ b/gazebo/transport/Connection.cc
@@ -49,7 +49,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/lexical_cast.hpp>
 

--- a/gazebo/transport/Connection.hh
+++ b/gazebo/transport/Connection.hh
@@ -21,7 +21,7 @@
 #include <google/protobuf/message.h>
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>

--- a/gazebo/transport/ConnectionManager.cc
+++ b/gazebo/transport/ConnectionManager.cc
@@ -87,6 +87,7 @@ bool ConnectionManager::Init(const std::string &_masterHost,
   this->serverConn.reset(new Connection());
 
   // Create a new TCP server on a free port
+  using namespace boost::placeholders;
   this->serverConn->Listen(0,
       boost::bind(&ConnectionManager::OnAccept, this, _1));
 
@@ -326,6 +327,7 @@ bool ConnectionManager::IsRunning() const
 //////////////////////////////////////////////////
 void ConnectionManager::OnMasterRead(const std::string &_data)
 {
+  using namespace boost::placeholders;
   if (this->masterConn && this->masterConn->IsOpen())
     this->masterConn->AsyncRead(
         boost::bind(&ConnectionManager::OnMasterRead, this, _1));
@@ -448,6 +450,7 @@ void ConnectionManager::ProcessMessage(const std::string &_data)
 //////////////////////////////////////////////////
 void ConnectionManager::OnAccept(ConnectionPtr _newConnection)
 {
+  using namespace boost::placeholders;
   _newConnection->AsyncRead(
       boost::bind(&ConnectionManager::OnRead, this, _newConnection, _1));
 
@@ -463,6 +466,7 @@ void ConnectionManager::OnRead(ConnectionPtr _connection,
   if (_data.empty())
   {
     gzerr << "Data was empty, try again\n";
+    using namespace boost::placeholders;
     _connection->AsyncRead(
         boost::bind(&ConnectionManager::OnRead, this, _connection, _1));
     return;

--- a/gazebo/transport/ConnectionManager.cc
+++ b/gazebo/transport/ConnectionManager.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "gazebo/msgs/msgs.hh"
 #include "gazebo/common/Console.hh"

--- a/gazebo/transport/IOManager.cc
+++ b/gazebo/transport/IOManager.cc
@@ -15,7 +15,7 @@
  *
 */
 #include <atomic>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/thread.hpp>
 #include <iostream>
 #include "gazebo/transport/IOManager.hh"

--- a/gazebo/transport/Node.cc
+++ b/gazebo/transport/Node.cc
@@ -15,7 +15,7 @@
  *
 */
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include "gazebo/transport/TransportIface.hh"
 #include "gazebo/transport/Node.hh"
 

--- a/gazebo/transport/Node.cc
+++ b/gazebo/transport/Node.cc
@@ -250,6 +250,7 @@ void Node::ProcessIncoming()
           for (liter = cbIter->second.begin();
               liter != cbIter->second.end(); ++liter)
           {
+            using namespace boost::placeholders;
             (*liter)->HandleData(*msgIter,
                 boost::bind(&dummy_callback_fn, _1), 0);
           }
@@ -312,6 +313,7 @@ void Node::InsertLatchedMsg(const std::string &_topic, const std::string &_msg)
     {
       if ((*liter)->GetLatching())
       {
+        using namespace boost::placeholders;
         (*liter)->HandleData(_msg, boost::bind(&dummy_callback_fn, _1), 0);
         (*liter)->SetLatching(false);
       }

--- a/gazebo/transport/Node.hh
+++ b/gazebo/transport/Node.hh
@@ -247,6 +247,7 @@ namespace gazebo
         ops.template Init<M>(decodedTopic, shared_from_this(), _latching);
 
         {
+          using namespace boost::placeholders;
           boost::recursive_mutex::scoped_lock lock(this->incomingMutex);
           this->callbacks[decodedTopic].push_back(CallbackHelperPtr(
                 new CallbackHelperT<M>(boost::bind(_fp, _obj, _1), _latching)));
@@ -306,6 +307,7 @@ namespace gazebo
         ops.Init(decodedTopic, shared_from_this(), _latching);
 
         {
+          using namespace boost::placeholders;
           boost::recursive_mutex::scoped_lock lock(this->incomingMutex);
           this->callbacks[decodedTopic].push_back(CallbackHelperPtr(
                 new RawCallbackHelper(boost::bind(_fp, _obj, _1))));

--- a/gazebo/transport/Node.hh
+++ b/gazebo/transport/Node.hh
@@ -19,7 +19,7 @@
 #define GAZEBO_TRANSPORT_NODE_HH_
 
 #include <tbb/task.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <map>
 #include <list>

--- a/gazebo/transport/Publication.cc
+++ b/gazebo/transport/Publication.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include "gazebo/common/WeakBind.hh"
 #include "SubscriptionTransport.hh"

--- a/gazebo/transport/Publication.cc
+++ b/gazebo/transport/Publication.cc
@@ -136,6 +136,7 @@ void Publication::AddTransport(const PublicationTransportPtr &_publink)
   // Don't add a duplicate transport
   if (add)
   {
+    using namespace boost::placeholders;
     _publink->AddCallback(common::weakBind(&Publication::LocalPublish,
                 this->shared_from_this(), _1));
     this->transports.push_back(_publink);
@@ -276,6 +277,7 @@ void Publication::LocalPublish(const std::string &_data)
     {
       if ((*cbIter)->IsLocal())
       {
+        using namespace boost::placeholders;
         if ((*cbIter)->HandleData(_data,
               boost::bind(&dummy_callback_fn, _1), 0))
           ++cbIter;

--- a/gazebo/transport/PublicationTransport.cc
+++ b/gazebo/transport/PublicationTransport.cc
@@ -69,6 +69,7 @@ void PublicationTransport::Init(const ConnectionPtr &_conn, bool _latched)
 
   // Put this in PublicationTransportPtr
   // Start reading messages from the remote publisher
+  using namespace boost::placeholders;
   this->connection->AsyncRead(common::weakBind(&PublicationTransport::OnPublish,
         this->shared_from_this(), _1));
 }
@@ -86,6 +87,7 @@ void PublicationTransport::OnPublish(const std::string &_data)
 {
   if (this->connection && this->connection->IsOpen())
   {
+    using namespace boost::placeholders;
     this->connection->AsyncRead(
         common::weakBind(&PublicationTransport::OnPublish,
             this->shared_from_this(), _1));

--- a/gazebo/transport/PublicationTransport.cc
+++ b/gazebo/transport/PublicationTransport.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include "gazebo/transport/TopicManager.hh"
 #include "gazebo/transport/ConnectionManager.hh"

--- a/gazebo/transport/PublicationTransport.cc
+++ b/gazebo/transport/PublicationTransport.cc
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
 */
-#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include "gazebo/transport/TopicManager.hh"
 #include "gazebo/transport/ConnectionManager.hh"

--- a/gazebo/transport/Publisher.cc
+++ b/gazebo/transport/Publisher.cc
@@ -17,7 +17,6 @@
 /* Desc: Handles pushing messages out on a named topic
  * Author: Nate Koenig
  */
-#include <boost/bind/bind.hpp>
 
 #include <ignition/math/Helpers.hh>
 

--- a/gazebo/transport/Publisher.cc
+++ b/gazebo/transport/Publisher.cc
@@ -212,6 +212,7 @@ void Publisher::SendMessage()
       // calling of OnPublishComplete() happens asynchronously though
       // (the subscriber callback SubscriptionTransport::HandleData() only
       // enqueues the message!).
+      using namespace boost::placeholders;
       int result = this->publication->Publish(*iter,
           common::weakBind(&Publisher::OnPublishComplete,
               this->shared_from_this(), _1), *pubIter);

--- a/gazebo/transport/Publisher.cc
+++ b/gazebo/transport/Publisher.cc
@@ -17,7 +17,7 @@
 /* Desc: Handles pushing messages out on a named topic
  * Author: Nate Koenig
  */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <ignition/math/Helpers.hh>
 

--- a/gazebo/transport/SubscriptionTransport.cc
+++ b/gazebo/transport/SubscriptionTransport.cc
@@ -48,6 +48,7 @@ bool SubscriptionTransport::HandleMessage(MessagePtr _newMsg)
 {
   std::string data;
   _newMsg->SerializeToString(&data);
+  using namespace boost::placeholders;
   return this->HandleData(data, boost::bind(&dummy_callback_fn, _1), 0);
 }
 

--- a/gazebo/transport/SubscriptionTransport.cc
+++ b/gazebo/transport/SubscriptionTransport.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
 */
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include "gazebo/transport/ConnectionManager.hh"
 #include "gazebo/transport/SubscriptionTransport.hh"

--- a/gazebo/transport/TopicManager.hh
+++ b/gazebo/transport/TopicManager.hh
@@ -17,7 +17,7 @@
 #ifndef GAZEBO_TRANSPORT_TOPICMANAGER_HH_
 #define GAZEBO_TRANSPORT_TOPICMANAGER_HH_
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <map>
 #include <list>

--- a/gazebo/transport/TransportIface.hh
+++ b/gazebo/transport/TransportIface.hh
@@ -17,7 +17,7 @@
 #ifndef _GAZEBO_TRANSPORTIFACE_HH_
 #define _GAZEBO_TRANSPORTIFACE_HH_
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <string>
 #include <list>
 #include <map>

--- a/gazebo/transport/transport_pch.hh
+++ b/gazebo/transport/transport_pch.hh
@@ -23,7 +23,7 @@
  */
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>
 #include <boost/interprocess/sync/interprocess_semaphore.hpp>

--- a/test/integration/model_database.cc
+++ b/test/integration/model_database.cc
@@ -20,6 +20,7 @@
 #include "test_config.h"
 
 using namespace gazebo;
+using namespace boost::placeholders;
 
 int g_onModels = 0;
 int g_onModels1 = 0;

--- a/tools/gz.cc
+++ b/tools/gz.cc
@@ -150,6 +150,7 @@ bool Command::Run(int _argc, char **_argv)
   }
 
   // The SDF find file callback.
+  using namespace boost::placeholders;
   sdf::setFindCallback(boost::bind(&gazebo::common::find_file, _1));
 
   // Hidden options


### PR DESCRIPTION
It was previously reported in #2757 that there were numerous compiler warnings complaining about using boost bind placeholders (like `_1`) in the global namespace, since that practice is deprecated. This was fixed in #2809 for purposes of our CI machines, but as noted in #3147 it is still an issue for some users.

This takes an alternative approach to #3147 by avoiding use of the `boost/bind.hpp` header file in favor of `boost/bind/bind.hpp`, as recommended in [boost/bind.hpp](https://github.com/boostorg/bind/blob/boost-1.78.0/include/boost/bind.hpp#L24) itself. This worked directly for all files except `gazebo/gui/building/EditorView.cc`, which had some arcane compiler errors. Since it was only one file; I migrated it to use `std::bind` with `std::placeholders::_1` in https://github.com/osrf/gazebo/commit/4614ef9ccee0a3ce3e0c2367468f272074a56f46.

cc @alexdewar