### PR TITLE
Revert boost/bind.hpp changes in header files and bump to 11.10.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set (GAZEBO_MINOR_VERSION 10)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.
-set (GAZEBO_PATCH_VERSION 0)
+set (GAZEBO_PATCH_VERSION 1)
 
 set (GAZEBO_VERSION ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION})
 set (GAZEBO_VERSION_FULL ${GAZEBO_MAJOR_VERSION}.${GAZEBO_MINOR_VERSION}.${GAZEBO_PATCH_VERSION})

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 1. Revert boost/bind.hpp changes in header files
     * [Pull request #3160](https://github.com/osrf/gazebo/pull/3160)
 
+1. Fix duplicate vertex program name Ogre crash
+    * [Pull request #3161](https://github.com/osrf/gazebo/pull/3161)
+
 ## Gazebo 11.10.0 (2022-01-12)
 
 1. Use boost/bind/bind.hpp to fix warnings on Arch Linux

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Gazebo 11
 
-## Gazebo 11.10.1 (2022-01-13)
+## Gazebo 11.10.1 (2022-01-19)
 
 1. Revert boost/bind.hpp changes in header files
     * [Pull request #3160](https://github.com/osrf/gazebo/pull/3160)

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,34 +3,34 @@
 ## Gazebo 11.10.1 (2022-01-13)
 
 1. Revert boost/bind.hpp changes in header files
-    * [Pull request #3160](https://github.com/ignitionrobotics/gazebo/pull/3160)
+    * [Pull request #3160](https://github.com/osrf/gazebo/pull/3160)
 
 ## Gazebo 11.10.0 (2022-01-12)
 
 1. Use boost/bind/bind.hpp to fix warnings on Arch Linux
-    * [Pull request #3156](https://github.com/ignitionrobotics/gazebo/pull/3156)
+    * [Pull request #3156](https://github.com/osrf/gazebo/pull/3156)
     * Inspired by a contribution from Alex Dewar <alex.dewar@gmx.co.uk>
 
 1. Fix focal builds: use python3 with check_test_ran.py
-    * [Pull request #3155](https://github.com/ignitionrobotics/gazebo/pull/3155)
+    * [Pull request #3155](https://github.com/osrf/gazebo/pull/3155)
 
 1. Load model plugins even after sensor timeout
-    * [Pull request #3154](https://github.com/ignitionrobotics/gazebo/pull/3154)
+    * [Pull request #3154](https://github.com/osrf/gazebo/pull/3154)
 
 1. CMake exports: remove -std=c++11 flag
-    * [Pull request #3050](https://github.com/ignitionrobotics/gazebo/pull/3050)
+    * [Pull request #3050](https://github.com/osrf/gazebo/pull/3050)
     * A contribution from Guilhem Saurel <guilhem.saurel@laas.fr>
 
 1. Create github action ci
-    * [Pull request #3049](https://github.com/ignitionrobotics/gazebo/pull/3049)
+    * [Pull request #3049](https://github.com/osrf/gazebo/pull/3049)
     * A contribution from Tal Regev <tal.regev@gmail.com>
 
 1. Fix Windows build when using vcpkg
-    * [Pull request #3132](https://github.com/ignitionrobotics/gazebo/pull/3132)
+    * [Pull request #3132](https://github.com/osrf/gazebo/pull/3132)
     * A contribution from Akash Munagala <akash.munagala@gmail.com>
 
 1. Point light shadows
-    * [Pull request #3051](https://github.com/ignitionrobotics/gazebo/pull/3051)
+    * [Pull request #3051](https://github.com/osrf/gazebo/pull/3051)
 
 ## Gazebo 11.9.1 (2021-12-02)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Gazebo 11
 
+## Gazebo 11.10.1 (2022-01-13)
+
+1. Revert boost/bind.hpp changes in header files
+    * [Pull request #3160](https://github.com/ignitionrobotics/gazebo/pull/3160)
+
 ## Gazebo 11.10.0 (2022-01-12)
 
 1. Use boost/bind/bind.hpp to fix warnings on Arch Linux

--- a/gazebo/common/MovingWindowFilter.hh
+++ b/gazebo/common/MovingWindowFilter.hh
@@ -22,8 +22,12 @@
 #include <vector>
 #include <map>
 
-#include <boost/function.hpp>
+// This fixes compiler warnings, see #3147 and #3160
+#ifndef BOOST_BIND_GLOBAL_PLACEHOLDERS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
 #include <boost/bind.hpp>
+#include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 

--- a/gazebo/common/MovingWindowFilter.hh
+++ b/gazebo/common/MovingWindowFilter.hh
@@ -23,7 +23,7 @@
 #include <map>
 
 #include <boost/function.hpp>
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 

--- a/gazebo/common/WeakBind.hh
+++ b/gazebo/common/WeakBind.hh
@@ -19,7 +19,7 @@
 #define GAZEBO_COMMON_WEAKBIND_HH_
 
 #include <boost/shared_ptr.hpp>
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 
 namespace gazebo
 {

--- a/gazebo/common/WeakBind.hh
+++ b/gazebo/common/WeakBind.hh
@@ -18,8 +18,12 @@
 #ifndef GAZEBO_COMMON_WEAKBIND_HH_
 #define GAZEBO_COMMON_WEAKBIND_HH_
 
-#include <boost/shared_ptr.hpp>
+// This fixes compiler warnings, see #3147 and #3160
+#ifndef BOOST_BIND_GLOBAL_PLACEHOLDERS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
 #include <boost/bind.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace gazebo
 {

--- a/gazebo/transport/Connection.hh
+++ b/gazebo/transport/Connection.hh
@@ -20,6 +20,10 @@
 #include <tbb/task.h>
 #include <google/protobuf/message.h>
 
+// This fixes compiler warnings, see #3147 and #3160
+#ifndef BOOST_BIND_GLOBAL_PLACEHOLDERS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/function.hpp>

--- a/gazebo/transport/Connection.hh
+++ b/gazebo/transport/Connection.hh
@@ -21,7 +21,7 @@
 #include <google/protobuf/message.h>
 
 #include <boost/asio.hpp>
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/thread.hpp>
 #include <boost/tuple/tuple.hpp>

--- a/gazebo/transport/Node.hh
+++ b/gazebo/transport/Node.hh
@@ -19,7 +19,7 @@
 #define GAZEBO_TRANSPORT_NODE_HH_
 
 #include <tbb/task.h>
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <map>
 #include <list>

--- a/gazebo/transport/Node.hh
+++ b/gazebo/transport/Node.hh
@@ -19,6 +19,11 @@
 #define GAZEBO_TRANSPORT_NODE_HH_
 
 #include <tbb/task.h>
+
+// This fixes compiler warnings, see #3147 and #3160
+#ifndef BOOST_BIND_GLOBAL_PLACEHOLDERS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
 #include <boost/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <map>

--- a/gazebo/transport/TopicManager.hh
+++ b/gazebo/transport/TopicManager.hh
@@ -17,6 +17,10 @@
 #ifndef GAZEBO_TRANSPORT_TOPICMANAGER_HH_
 #define GAZEBO_TRANSPORT_TOPICMANAGER_HH_
 
+// This fixes compiler warnings, see #3147 and #3160
+#ifndef BOOST_BIND_GLOBAL_PLACEHOLDERS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
 #include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <map>

--- a/gazebo/transport/TopicManager.hh
+++ b/gazebo/transport/TopicManager.hh
@@ -17,7 +17,7 @@
 #ifndef GAZEBO_TRANSPORT_TOPICMANAGER_HH_
 #define GAZEBO_TRANSPORT_TOPICMANAGER_HH_
 
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <map>
 #include <list>

--- a/gazebo/transport/TransportIface.hh
+++ b/gazebo/transport/TransportIface.hh
@@ -17,6 +17,10 @@
 #ifndef _GAZEBO_TRANSPORTIFACE_HH_
 #define _GAZEBO_TRANSPORTIFACE_HH_
 
+// This fixes compiler warnings, see #3147 and #3160
+#ifndef BOOST_BIND_GLOBAL_PLACEHOLDERS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
 #include <boost/bind.hpp>
 #include <string>
 #include <list>

--- a/gazebo/transport/TransportIface.hh
+++ b/gazebo/transport/TransportIface.hh
@@ -17,7 +17,7 @@
 #ifndef _GAZEBO_TRANSPORTIFACE_HH_
 #define _GAZEBO_TRANSPORTIFACE_HH_
 
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 #include <string>
 #include <list>
 #include <map>


### PR DESCRIPTION
As noted in https://github.com/osrf/gazebo/pull/3156#issuecomment-1012404375, the changes in #3156 to header files have the potential to break downstream software. This pull request reverts the changes to header files and bumps the patch version to 11.10.1, so we can make a quick release and unbreak downstream software.

cc @traversaro (apologies to @alexdewar )

Update: I started wondering if this would affect gazebo_ros_pkgs, since I see `_1` in [gazebo_ros_api_plugin on `noetic-devel`](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/2.9.2/gazebo_ros/src/gazebo_ros_api_plugin.cpp#L158), but it didn't fail its latest CI job (using Ubuntu 20.04):

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ros_gazebo_pkgs-ci-default_noetic-focal-amd64&build=24)](https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_noetic-focal-amd64/24/) https://build.osrfoundation.org/job/ros_gazebo_pkgs-ci-default_noetic-focal-amd64/24/

I believe this is because `boost/thread.hpp` provides an opportunistic include of `boost/bind.hpp` for boost 1.72 and earlier (see https://github.com/boostorg/thread/compare/boost-1.72.0...boost-1.73.0#diff-c94867ed785b09487490187250e85510d4ac8698e7fa22dc56906baeb83423d0L33), so this does not affect Ubuntu 20.04, which uses boost 1.71. That's also why the homebrew CI failed in #3156 but not the Ubuntu CI.

So I still support the changes in this pull request, but I've convinced myself that it is not as dire as it sounded, since it does not affect Ubuntu 20.04.