### PR TITLE
Fix duplicate vertex program name crash

### DIFF
--- a/media/materials/scripts/shadow_caster_ignore_heightmap.program
+++ b/media/materials/scripts/shadow_caster_ignore_heightmap.program
@@ -1,4 +1,4 @@
-vertex_program shadow_caster_vp_glsl glsl
+vertex_program shadow_caster_ignore_heightmap_vp_glsl glsl
 {
   source shadow_caster_vp.glsl
 
@@ -29,7 +29,7 @@ material Gazebo/shadow_caster_ignore_heightmap
     // all this will do is write depth and depth*depth to red and green
     pass
     {
-      vertex_program_ref shadow_caster_vp_glsl
+      vertex_program_ref shadow_caster_ignore_heightmap_vp_glsl
       {
       }
 


### PR DESCRIPTION
I'm on Windows 10, using Ogre 1.12.9.

On launch, Gazebo crashes due to the following error, which I found in the logs:
```
[D:\vcpkg\buildtrees\gazebo11\src\gazebo\server_main.cc:57] Ogre Error:Ogre::ItemIdentityException::ItemIdentityException: HighLevelGpuProgram with the name shadow_caster_vp_glsl already exists. in ResourceManager::add at D:\vcpkg\buildtrees\ogre\src\OgreMain\src\OgreResourceManager.cpp (line 149)
```
I was able to determine that it started occurring after https://github.com/osrf/gazebo/pull/3051. However, the file causing the issue was changed because it couldn't find the vertex program with that name, brought up [here](https://github.com/osrf/gazebo/pull/3051#issuecomment-983361516).

In order to fix both issues, I renamed the vertex program to be unique. This fixes my crash, but I'm not familiar with Ogre and how it handles shaders, so I'm not sure if it'll fix the original issue as well. I'm assuming if the CI looks good, it means it worked? If there's a better way to address this issue, I'm happy to do that as well.