### PR TITLE
Convert OGRE_RESOURCE_PATH with TO_CMAKE_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ set(OGRE_RESOURCE_PATH ${OGRE_PLUGINDIR})
 # Seems that OGRE_PLUGINDIR can end in a newline, which will cause problems when
 # we pass it to the compiler later.
 string(REPLACE "\n" "" OGRE_RESOURCE_PATH ${OGRE_RESOURCE_PATH})
+FILE(TO_CMAKE_PATH "${OGRE_RESOURCE_PATH}" OGRE_RESOURCE_PATH)
 
 
 # Check for DRI capable Display


### PR DESCRIPTION
For consistency with `GAZEBO_PLUGIN_PATH`, `GAZEBO_MODEL_PATH` and `GAZEBO_RESOURCE_PATH` that were converted with `TO_CMAKE_PATH` in https://github.com/osrf/gazebo/pull/3132, this PR also converts `OGRE_RESOURCE_PATH` with `TO_CMAKE_PATH`.

Problem spotted in https://github.com/conda-forge/gazebo-feedstock/issues/112 .

