### PR TITLE
Add SIGINT signal handlers for Windows

### DIFF
--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -643,9 +643,11 @@ void Server::Fini()
 /////////////////////////////////////////////////
 void Server::Run()
 {
-#ifndef _WIN32
   // Now that we're about to run, install a signal handler to allow for
   // graceful shutdown on Ctrl-C.
+#ifdef _WIN32
+  signal(SIGINT, Server::SigInt);
+#else
   struct sigaction sigact;
   sigact.sa_flags = 0;
   sigact.sa_handler = Server::SigInt;

--- a/gazebo/gazebo_main.cc
+++ b/gazebo/gazebo_main.cc
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #else
 #include <process.hpp>
+#include <signal.h>
 #endif
 
 #include "gazebo/common/Console.hh"
@@ -227,6 +228,11 @@ int main(int _argc, char **_argv)
 
 std::atomic<bool> g_shouldExit = false;
 
+void sig_handler(int /*signo*/)
+{
+  g_shouldExit = true;
+}
+
 int main(int _argc, char **_argv)
 {
   if (_argc >= 2 &&
@@ -234,6 +240,8 @@ int main(int _argc, char **_argv)
     help();
     return 0;
   }
+
+  signal(SIGINT, sig_handler);
 
   std::vector<std::string> argvServer;
   std::vector<std::string> argvClient;
@@ -272,7 +280,6 @@ int main(int _argc, char **_argv)
     {
       g_shouldExit = true;
     }
-
   }
 
   // Cleanup

--- a/gazebo/gui/GuiIface.cc
+++ b/gazebo/gui/GuiIface.cc
@@ -408,9 +408,11 @@ bool gui::run(int _argc, char **_argv)
 
   mainWindow->RenderWidget()->AddPlugins(g_plugins_to_load);
 
-#ifndef _WIN32
   // Now that we're about to run, install a signal handler to allow for
   // graceful shutdown on Ctrl-C.
+#ifdef _WIN32
+  signal(SIGINT, signal_handler);
+#else
   struct sigaction sigact;
   sigact.sa_flags = 0;
   sigact.sa_handler = signal_handler;


### PR DESCRIPTION
This makes ctrl+c more reliable at actually killing the process.