### PR TITLE
ODEJoint: don't SetStiffnessDamping for gearbox

### DIFF
--- a/gazebo/physics/ode/ODEJoint.cc
+++ b/gazebo/physics/ode/ODEJoint.cc
@@ -1032,6 +1032,12 @@ void ODEJoint::SetStiffness(unsigned int _index, const double _stiffness)
 void ODEJoint::SetStiffnessDamping(unsigned int _index,
   double _stiffness, double _damping, double _reference)
 {
+  // Gearbox joints don't support this, so exit early in that case
+  if (this->HasType(Base::GEARBOX_JOINT))
+  {
+    return;
+  }
+
   if (_index < this->DOF())
   {
     this->stiffnessCoefficient[_index] = _stiffness;


### PR DESCRIPTION
The Gearbox joint does not support the stiffness and damping parameters, so exit ODEJoint::SetStiffnessDamping early if for Gearbox joints.

Without this change, simulations including a gearbox joint stream a prohibitive amount of unnecessary messages to a log file with complaints about APIs that are unsupported by the Gearbox joint. To confirm, load the [variable_gearbox_plugin.world](https://github.com/osrf/gazebo/blob/gazebo11/worlds/variable_gearbox_plugin.world) and check the size of the `~/.gazebo/server-11345/default.log` file after running for a few seconds of simulation time.