### PR TITLE
Scene: support deletion of Heightmap Visuals

### DIFF
--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -300,6 +300,7 @@ void Scene::Clear()
 
   delete this->dataPtr->terrain;
   this->dataPtr->terrain = NULL;
+  this->dataPtr->terrainVisualId.reset();
 
   while (!this->dataPtr->visuals.empty())
     this->RemoveVisual(this->dataPtr->visuals.begin()->first);
@@ -2847,6 +2848,7 @@ bool Scene::ProcessVisualMsg(ConstVisualPtr &_msg, Visual::VisualType _type)
         m.clear_material();
         visual->Load(msgs::VisualToSDF(m));
 
+        this->dataPtr->terrainVisualId.emplace(visual->GetId());
         this->dataPtr->terrain = new Heightmap(shared_from_this());
         // check the material fields and set material if it is specified
         if (_msg->has_material())
@@ -3407,6 +3409,14 @@ void Scene::RemoveVisual(uint32_t _id)
   if (iter != this->dataPtr->visuals.end())
   {
     VisualPtr vis = iter->second;
+    // Remove the terrain object if this is the heightmap visual
+    if (this->dataPtr->terrainVisualId &&
+        *this->dataPtr->terrainVisualId == _id)
+    {
+      delete this->dataPtr->terrain;
+      this->dataPtr->terrain = NULL;
+      this->dataPtr->terrainVisualId.reset();
+    }
     // Remove all projectors attached to the visual
     auto piter = this->dataPtr->projectors.begin();
     while (piter != this->dataPtr->projectors.end())

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -2866,9 +2866,17 @@ bool Scene::ProcessVisualMsg(ConstVisualPtr &_msg, Visual::VisualType _type)
           visual.reset(new Visual(_msg->name(), this->dataPtr->worldVisual));
         }
 
-        auto m = *_msg.get();
-        m.clear_material();
-        visual->Load(msgs::VisualToSDF(m));
+        {
+          // Copy the const _msg so that we can clear materials before
+          // loading from message
+          msgs::Visual *msgMutable = new msgs::Visual(*_msg.get());
+          msgMutable->clear_material();
+
+          // assign ownership of the copy to a const shared_ptr so it will be
+          // deleted when exiting this scope
+          ConstVisualPtr msgShared(static_cast<const msgs::Visual*>(msgMutable));
+          visual->LoadFromMsg(msgShared);
+        }
 
         // Store VisualId corresponding to terrain
         this->dataPtr->terrainVisualId.emplace(visual->GetId());

--- a/gazebo/rendering/Scene.cc
+++ b/gazebo/rendering/Scene.cc
@@ -2826,89 +2826,6 @@ bool Scene::ProcessVisualMsg(ConstVisualPtr &_msg, Visual::VisualType _type)
     return true;
   }
 
-  // Creating heightmap
-  // FIXME: A bit of a hack.
-  if (_msg->has_geometry() &&
-      _msg->geometry().type() == msgs::Geometry::HEIGHTMAP &&
-      _type != Visual::VT_COLLISION)
-  {
-    if (this->dataPtr->terrain)
-    {
-      // Only one Heightmap can be created per Scene
-      return true;
-    }
-    else
-    {
-      if (!this->dataPtr->terrain)
-      {
-        // create a dummy visual for loading heightmap visual plugin
-        // TODO make heightmap a visual to avoid special treatment here?
-        VisualPtr visual;
-
-        // If the visual has a parent which is not the name of the scene...
-        if (_msg->has_parent_name() && _msg->parent_name() != this->Name())
-        {
-          // Make sure the parent visual exists before trying to add a child
-          // visual
-          VisualPtr parent = this->GetVisual(_msg->parent_name());
-          if (!parent)
-            return false;
-
-          visual.reset(new Visual(_msg->name(), parent));
-        }
-        else
-        {
-          // Make sure the world visual exists before trying to add a child visual
-          if (!this->dataPtr->worldVisual)
-            return false;
-
-          // Add a visual that is attached to the scene root
-          visual.reset(new Visual(_msg->name(), this->dataPtr->worldVisual));
-        }
-
-        {
-          // Copy the const _msg so that we can clear materials before
-          // loading from message
-          msgs::Visual *msgMutable = new msgs::Visual(*_msg.get());
-          msgMutable->clear_material();
-
-          // assign ownership of the copy to a const shared_ptr so it will be
-          // deleted when exiting this scope
-          ConstVisualPtr msgShared(static_cast<const msgs::Visual*>(msgMutable));
-          visual->LoadFromMsg(msgShared);
-        }
-
-        // Store VisualId corresponding to terrain
-        this->dataPtr->terrainVisualId.emplace(visual->GetId());
-
-        this->dataPtr->terrain = new Heightmap(shared_from_this());
-        // check the material fields and set material if it is specified
-        if (_msg->has_material())
-        {
-          auto matMsg = _msg->material();
-          if (matMsg.has_script())
-          {
-            auto scriptMsg = matMsg.script();
-            for (auto const &uri : scriptMsg.uri())
-            {
-              if (!uri.empty())
-                RenderEngine::Instance()->AddResourcePath(uri);
-            }
-            std::string matName = scriptMsg.name();
-            this->dataPtr->terrain->SetMaterial(matName);
-          }
-        }
-        this->dataPtr->terrain->SetLOD(this->dataPtr->heightmapLOD);
-        const double skirtLen = this->dataPtr->heightmapSkirtLength;
-        this->dataPtr->terrain->SetSkirtLength(skirtLen);
-        this->dataPtr->terrain->LoadFromMsg(_msg);
-
-        this->dataPtr->visuals[visual->GetId()] = visual;
-      }
-    }
-    return true;
-  }
-
   // Creating collision
   if (_type == Visual::VT_COLLISION)
   {
@@ -2932,6 +2849,20 @@ bool Scene::ProcessVisualMsg(ConstVisualPtr &_msg, Visual::VisualType _type)
 
     return true;
   }
+
+  // Exit early if a heightmap already exists
+  bool hasHeightmap = false;
+  if (_msg->has_geometry() &&
+      _msg->geometry().type() == msgs::Geometry::HEIGHTMAP)
+  {
+    hasHeightmap = true;
+    if (this->dataPtr->terrain)
+    {
+      // Only one Heightmap can be created per Scene
+      return true;
+    }
+  }
+
 
   // All other visuals
   VisualPtr visual;
@@ -2960,7 +2891,51 @@ bool Scene::ProcessVisualMsg(ConstVisualPtr &_msg, Visual::VisualType _type)
   if (_msg->has_id())
     visual->SetId(_msg->id());
 
-  visual->LoadFromMsg(_msg);
+  if (!hasHeightmap)
+  {
+    visual->LoadFromMsg(_msg);
+  }
+  else
+  // Creating heightmap
+  // FIXME: A bit of a hack.
+  {
+    {
+      // Copy the const _msg so that we can clear materials before
+      // loading from message
+      msgs::Visual *msgMutable = new msgs::Visual(*_msg.get());
+      msgMutable->clear_material();
+
+      // assign ownership of the copy to a const shared_ptr so it will be
+      // deleted when exiting this scope
+      ConstVisualPtr msgShared(static_cast<const msgs::Visual*>(msgMutable));
+      visual->LoadFromMsg(msgShared);
+    }
+
+    // Store VisualId corresponding to terrain
+    this->dataPtr->terrainVisualId.emplace(visual->GetId());
+
+    this->dataPtr->terrain = new Heightmap(shared_from_this());
+    // check the material fields and set material if it is specified
+    if (_msg->has_material())
+    {
+      auto matMsg = _msg->material();
+      if (matMsg.has_script())
+      {
+        auto scriptMsg = matMsg.script();
+        for (auto const &uri : scriptMsg.uri())
+        {
+          if (!uri.empty())
+            RenderEngine::Instance()->AddResourcePath(uri);
+        }
+        std::string matName = scriptMsg.name();
+        this->dataPtr->terrain->SetMaterial(matName);
+      }
+    }
+    this->dataPtr->terrain->SetLOD(this->dataPtr->heightmapLOD);
+    const double skirtLen = this->dataPtr->heightmapSkirtLength;
+    this->dataPtr->terrain->SetSkirtLength(skirtLen);
+    this->dataPtr->terrain->LoadFromMsg(_msg);
+  }
   visual->SetType(_type);
 
   this->dataPtr->visuals[visual->GetId()] = visual;

--- a/gazebo/rendering/ScenePrivate.hh
+++ b/gazebo/rendering/ScenePrivate.hh
@@ -22,6 +22,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -308,6 +309,9 @@ namespace gazebo
 
       /// \brief True if this scene is running on the server.
       public: bool isServer;
+
+      /// \brief Terrain Visual Id.
+      public: std::optional<uint32_t> terrainVisualId;
 
       /// \brief The heightmap, if any.
       public: Heightmap *terrain = nullptr;


### PR DESCRIPTION
As noted in #3159, removing a model containing a heightmap causes its collision shape to be remove from the physics subsystem in `gzserver`, but the heightmap visual remains in `gzclient`. This pull request fixes that so that height map visuals should now disappear from `gzclient` when a heightmap model is deleted. The sequence of commits is described below:

* https://github.com/osrf/gazebo/commit/1445ab1d995cfbcaa425936768b4dce9e0cd5504: This was my first simple attempt to support removing the visual by storing the visual Id associated with the heightmap / terrain and adding logic in `Scene::RemoveVisual` to delete the terrain object when a visual matching `terrainVisualId` is removed. This didn't actually work.
* https://github.com/osrf/gazebo/commit/e497d4d41ae87ba5c2c613f684b1d14b480a60c7: This includes two fixes needed to allow removal of the heightmap visual: using a proper parent visual and adding the visual to the `dataPtr::visuals` vector. This code was already present elsewhere in `ProcessVisualMsg`, so I duplicated it to apply to the heightmap codepath. I didn't like this code duplication, so I worked to eliminate that in the following two commits.
* https://github.com/osrf/gazebo/commit/f3eaaeee12bdb884eb37fb8567045fae6f679015: This changes the Heightmap visual loading to use `Visual::LoadFromMsg` for consistency with the latter parts of `ProcessVisualMsg`. It requires construction of an extra `boost::shared_ptr` but I think the consistency is worth it.
* https://github.com/osrf/gazebo/commit/77bbc8c0814d6fb6d1d2c359696f6b9e860fe08c: This deduplicates the code by moving much of the heightmap processing code to the end of `ProcessVisualMsg` so it can share the existing portions that it had duplicated. This commit has a net reduction of 25 lines. 