### PR TITLE
Avoid logging error when <empty> geometry is included

### DIFF
--- a/gazebo/msgs/msgs.cc
+++ b/gazebo/msgs/msgs.cc
@@ -2868,6 +2868,9 @@ namespace gazebo
           }
         }
       }
+      else if (_msg.type() == msgs::Geometry::EMPTY)
+      {
+      }
       else
       {
         gzerr << "Unrecognized geometry type" << std::endl;


### PR DESCRIPTION
This is a very small change to avoid an error message while using <empty> geometry in models. I simply added a check for the `msgs::Geometry::EMPTY` type with an empty statement to avoid writing an error message for "Unrecognized geometry type" in the default `else` statement. 

<empty> geometry is listed as a valid option the [SDF spec](http://sdformat.org/spec?ver=1.9&elem=geometry#geometry_empty), and is already supported by `GeometryFromSDF()`.