### PR TITLE
SearchForStuff: Do not pass /usr/lib to PATH in qwt's find_library

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -845,7 +845,6 @@ find_path(QWT_INCLUDE_DIR NAMES qwt.h PATHS
 )
 
 find_library(QWT_LIBRARY NAMES qwt-qt5 qwt PATHS
-  /usr/lib
   /usr/local/lib
   /usr/local/lib/qwt.framework
   ${QWT_WIN_LIBRARY_DIR}


### PR DESCRIPTION
`/usr/lib` is already part of the paths in which `find_library` will search in). However, setting it in `PATHS` will find the library with maximum priority  there even if the library is also available in some other location (for example, when qwt is available in an activated conda environment).