### PR TITLE
Parse ode_quiet physics parameter from SDFormat

### DIFF
--- a/test/regression/351_world_step.cc
+++ b/test/regression/351_world_step.cc
@@ -35,4 +35,21 @@ TEST_F(Issue351Test, WorldStep)
 
   // Take 500 steps; it passes if it doesn't seg-fault
   world->Step(500);
+
+  // Confirm that ode_quiet has been set to true.
+  physics::PhysicsEnginePtr physics = world->Physics();
+  ASSERT_TRUE(physics != nullptr);
+  EXPECT_EQ(physics->GetType(), "ode");
+  {
+    std::string solver;
+    EXPECT_NO_THROW(
+      solver = boost::any_cast<std::string>(physics->GetParam("solver_type")));
+    EXPECT_EQ("world", solver);
+  }
+  {
+    bool odeQuiet = false;
+    EXPECT_NO_THROW(
+      odeQuiet = boost::any_cast<bool>(physics->GetParam("ode_quiet")));
+    EXPECT_TRUE(odeQuiet);
+  }
 }

--- a/test/worlds/world_step.world
+++ b/test/worlds/world_step.world
@@ -3,6 +3,7 @@
     <physics type="ode">
       <gravity>0.000000 0.000000 -9.810000</gravity>
       <ode>
+        <ode_quiet>1</ode_quiet>
         <solver>
           <type>world</type>
           <iters>250</iters>


### PR DESCRIPTION
The ODE `world`-step solver has a tendency to spam the console with `LCP Internal Error` messages (try loading `test/worlds/world_step.world` with `--verbose` to see for yourself). We added an `ode_quiet` parameter to the `SetParam` and `GetParam` APIs for `ODEPhysics` in [bitbucket pull request 2512](https://osrf-migration.github.io/gazebo-gh-pages/#!/osrf/gazebo/pull-requests/2512/page/1) (merged in dacd9151a198562061ce013d0a70776f821a6ea7), but at that time it was only accessible from the C++ API.

I had thought that the `gazebo::physics::PresetManager` might be able to aid in parsing this parameter if it was added to a `<physics>` block, but when I tried that in https://github.com/osrf/gazebo/commit/e7ce5279c1ee5c106b61aaa15fabe19267b5ac0f, it gives an error message:

~~~
[Err] [ODEPhysics.cc:1577] SetParam(ode_quiet) std::any_cast error: bad any cast
[Wrn] [PresetManager.cc:82] Couldn't set parameter [ode_quiet] in physics engine
~~~

I have now realized that this is because while `SetParam` tries to cast to a `bool`, libsdformat is treating its value as a string, which is the default behavior when parsing elements that are not part of the SDFormat spec. With this in mind, I've added logic in https://github.com/osrf/gazebo/commit/f75611d4f14d9de75388b48229a917b9f526ba27 to try parsing the `ode_quiet` value as a `string` if it fails to cast to a `bool`, and then use an `sdf::Param` object to convert the string to a `bool` using code from libsdformat's [Param_TEST.cc](https://github.com/ignitionrobotics/sdformat/blob/sdformat12_12.3.0/src/Param_TEST.cc#L56-L80) as an example.