### PR TITLE
Fix compatibility with FFmpeg 5.0

### DIFF
--- a/gazebo/common/VideoEncoder.cc
+++ b/gazebo/common/VideoEncoder.cc
@@ -224,7 +224,6 @@ bool VideoEncoder::Start(const std::string &_format,
 
   // The remainder of this function handles FFMPEG initialization of a video
   // stream
-  AVOutputFormat *outputFormat = nullptr;
 
   // This 'if' and 'free' are just for safety. We chech the value of formatCtx
   // below.
@@ -236,6 +235,11 @@ bool VideoEncoder::Start(const std::string &_format,
   if (this->dataPtr->format.compare("v4l2") == 0)
   {
 #if LIBAVDEVICE_VERSION_INT >= AV_VERSION_INT(56, 4, 100)
+#if LIBAVFORMAT_VERSION_MAJOR >= 59
+    const AVOutputFormat *outputFormat = nullptr;
+#else
+    AVOutputFormat *outputFormat = nullptr;
+#endif
     while ((outputFormat = av_output_video_device_next(outputFormat))
            != nullptr)
     {
@@ -256,7 +260,7 @@ bool VideoEncoder::Start(const std::string &_format,
   }
   else
   {
-    outputFormat = av_guess_format(nullptr,
+    const AVOutputFormat * outputFormat = av_guess_format(nullptr,
                                    this->dataPtr->filename.c_str(), nullptr);
 
     if (!outputFormat)
@@ -294,7 +298,7 @@ bool VideoEncoder::Start(const std::string &_format,
   }
 
   // find the video encoder
-  AVCodec *encoder = avcodec_find_encoder(
+  const AVCodec *encoder = avcodec_find_encoder(
       this->dataPtr->formatCtx->oformat->video_codec);
   if (!encoder)
   {


### PR DESCRIPTION
Partial backport of:
* https://github.com/ignitionrobotics/ign-common/commit/e2f6a84100f39fe29d5ffc49447e12c1f6c4196d
* https://github.com/ignitionrobotics/ign-common/pull/325
* https://github.com/ignitionrobotics/ign-common/pull/220

to Classic Gazebo.

With respect to https://github.com/ignitionrobotics/ign-common/pull/325, I noticed a strange behaviour for which the [`avcodec_parameters_to_context`](https://ffmpeg.org/doxygen/trunk/group__lavc__core.html#gac7b282f51540ca7a99416a3ba6ee0d16) function that in https://github.com/osrf/gazebo/pull/3195/files#diff-08c8dfc0ffe4733c2fcc1ebd0e3f67032e24b302b25a90c26e87994582503198R326 was not copying the members of the `AVCodecParameters` structure to the `AVCodecContext` structure. I was not able to understand why that happened, but copying the members manually worked fine, however it is probably worth to check that the tests work fine on another setup by commenting out https://github.com/osrf/gazebo/pull/3195/files#diff-08c8dfc0ffe4733c2fcc1ebd0e3f67032e24b302b25a90c26e87994582503198R334-R348 .