### PR TITLE
Separate cache files for each heightmap LOD

### DIFF
--- a/gazebo/rendering/Heightmap.cc
+++ b/gazebo/rendering/Heightmap.cc
@@ -550,7 +550,7 @@ void Heightmap::Load()
       gzmsg << "Large heightmap used with LOD. It will be subdivided into " <<
           this->dataPtr->numTerrainSubdivisions << " terrains." << std::endl;
     }
-    std::string terrainName = "gazebo_terrain_" + terrainNameSuffix;
+    std::string terrainName = "gazebo_terrain" + terrainNameSuffix;
     prefix = terrainDirPath / terrainName.c_str();
   }
 

--- a/gazebo/rendering/Heightmap.cc
+++ b/gazebo/rendering/Heightmap.cc
@@ -518,13 +518,19 @@ void Heightmap::Load()
     }
   }
 
+  std::string terrainNameSuffix = "";
+  if (this->LOD() == 0)
+  {
+    terrainNameSuffix = "_LOD0";
+  }
+
   // If the paging is enabled we modify the number of subterrains
   if (this->dataPtr->useTerrainPaging)
   {
     this->dataPtr->splitTerrain = true;
     nTerrains = this->dataPtr->numTerrainSubdivisions;
     std::string terrainName = "gazebo_terrain_cache" +
-        std::to_string(this->LOD());
+        terrainNameSuffix;
     prefix = terrainDirPath / terrainName.c_str();
   }
   else
@@ -544,7 +550,7 @@ void Heightmap::Load()
       gzmsg << "Large heightmap used with LOD. It will be subdivided into " <<
           this->dataPtr->numTerrainSubdivisions << " terrains." << std::endl;
     }
-    std::string terrainName = "gazebo_terrain_" + std::to_string(this->LOD());
+    std::string terrainName = "gazebo_terrain_" + terrainNameSuffix;
     prefix = terrainDirPath / terrainName.c_str();
   }
 

--- a/gazebo/rendering/Heightmap.cc
+++ b/gazebo/rendering/Heightmap.cc
@@ -523,7 +523,9 @@ void Heightmap::Load()
   {
     this->dataPtr->splitTerrain = true;
     nTerrains = this->dataPtr->numTerrainSubdivisions;
-    prefix = terrainDirPath / "gazebo_terrain_cache";
+    std::string terrainName = "gazebo_terrain_cache" +
+        std::to_string(this->LOD());
+    prefix = terrainDirPath / terrainName.c_str();
   }
   else
   {
@@ -542,7 +544,8 @@ void Heightmap::Load()
       gzmsg << "Large heightmap used with LOD. It will be subdivided into " <<
           this->dataPtr->numTerrainSubdivisions << " terrains." << std::endl;
     }
-    prefix = terrainDirPath / "gazebo_terrain";
+    std::string terrainName = "gazebo_terrain_" + std::to_string(this->LOD());
+    prefix = terrainDirPath / terrainName.c_str();
   }
 
   double sqrtN = sqrt(nTerrains);

--- a/test/integration/heightmap.cc
+++ b/test/integration/heightmap.cc
@@ -761,7 +761,7 @@ void HeightmapTest::HeightmapCache()
       + "/paging");
   std::string shaPath = heightmapDir + "/" + heightmapName + "/gzterrain.SHA1";
   std::string cachePath = heightmapDir +
-      "/" + heightmapName + "/gazebo_terrain_00000000.dat";
+      "/" + heightmapName + "/gazebo_terrain_LOD0_00000000.dat";
 
   // temporary backup files for testing if cache files exist.
   std::string shaPathBk = shaPath + ".bk";


### PR DESCRIPTION
Closes #3199 

To prevent gazebo from loading the wrong cache files, each heightmap LOD will have its own set of cache files.

The LOD is appended to the cache files' names (_5_ in the example):
```
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00000000.dat
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00010000.dat
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00000001.dat
[Msg] Loading heightmap cache data: /root/.gazebo/paging/heightmap_bowl_2/gazebo_terrain_5_00010001.dat
```