### PR TITLE
Add sdf param to skip GetGeoRef call when loading DEMs

### DIFF
--- a/gazebo/common/Dem.hh
+++ b/gazebo/common/Dem.hh
@@ -54,6 +54,11 @@ namespace gazebo
       /// \return 0 when the operation succeeds to open a file.
       public: int Load(const std::string &_filename="");
 
+      /// \brief Load a DEM file without georeferencing transformation.
+      /// \param[in] _filename the path to the terrain file.
+      /// \return 0 when the operation succeeds to open a file.
+      public: int LoadWithoutTransform(const std::string &_filename="");
+
       /// \brief Get the elevation of a terrain's point in meters.
       /// \param[in] _x X coordinate of the terrain.
       /// \param[in] _y Y coordinate of the terrain.

--- a/gazebo/common/HeightmapData.hh
+++ b/gazebo/common/HeightmapData.hh
@@ -82,6 +82,16 @@ namespace gazebo
       public: static HeightmapData *LoadTerrainFile(
           const std::string &_filename);
 
+      /// \brief Load a terrain file specified by _filename. The terrain file
+      /// format might be an image or a DEM file. libgdal is required to enable
+      /// DEM support. For a list of all raster formats supported you can type
+      /// the command "gdalinfo --formats". Skips the georeferencing
+      /// transformation.
+      /// \param[in] _filename The path to the terrain file.
+      /// \return 0 when the operation succeeds to load a file or -1 when fails.
+      public: static HeightmapData *LoadTerrainFileWithoutTransform(
+          const std::string &_filename);
+
       /// \brief Load a DEM specified by _filename as a terrain file.
       /// \param[in] _filename The path to the terrain file.
       /// \return 0 when the operation succeeds to load a file or -1 when fails.

--- a/gazebo/physics/HeightmapShape.cc
+++ b/gazebo/physics/HeightmapShape.cc
@@ -81,7 +81,20 @@ void HeightmapShape::OnRequest(ConstRequestPtr &_msg)
 //////////////////////////////////////////////////
 int HeightmapShape::LoadTerrainFile(const std::string &_filename)
 {
-  this->heightmapData = common::HeightmapDataLoader::LoadTerrainFile(_filename);
+  bool skipGeoRef = false;
+  if (this->sdf->HasElement("skipGeoRef"))
+  {
+    skipGeoRef = this->sdf->Get<bool>("skipGeoRef");
+  }
+
+  if (skipGeoRef)
+  {
+    this->heightmapData = common::HeightmapDataLoader::LoadTerrainFileWithoutTransform(_filename);
+  }
+  else
+  {
+    this->heightmapData = common::HeightmapDataLoader::LoadTerrainFile(_filename);
+  }
   if (!this->heightmapData)
   {
     gzerr << "Unable to load heightmap data" << std::endl;
@@ -118,7 +131,10 @@ int HeightmapShape::LoadTerrainFile(const std::string &_filename)
 
       try
       {
-        this->dem.GetGeoReferenceOrigin(latitude, longitude);
+        if (!skipGeoRef)
+        {
+          this->dem.GetGeoReferenceOrigin(latitude, longitude);
+        }
       }
       catch(const common::Exception &)
       {


### PR DESCRIPTION
Partially resolves https://github.com/osrf/gazebo/issues/2881

This adds a sdf tag ``<skipGeoRef>`` to skip ``GetGeoRef`` call and stops it from spamming the console with error msgs. Added extra functions to maintain ABI. Currently this works for ``gzserver``, and ``gzclient`` will still throw the same errors. 

## Testing

This same test file (https://github.com/osrf/gazebo/issues/2881#issuecomment-1105894154) should not throw any more errors, with a slight modification : 

```
<heightmap>
    <uri>file://dem_neg.tif</uri>
    <size>80.078 80.078 5</size>
    <skipGeoRef>true</skipGeoRef>
</heightmap>
```

## The problem
The chain of function calls is as follows :
```
Dem.cc::GetGeoRef() --> This function is spamming the error, need to skip it based on an sdf flag.
  |
Dem.cc::Load()
  |
HeightMapDataLoader::LoadDEMAsTerrain()
 |
HeightMapDataLoader::LoadTerrainFile()
 |
HeightMapShape::LoadTerrainFile() --> This has access to the sdf element
```

### Solution 1
This means the sdf flag has to be trickled down without affecting ABI. I could create copies of these functions with different names and have them called by the lowest level ``LoadTerrainFile()`` based on the sdf flag.

#### Issues :
* This makes it difficult to implement in ``gzclient`` though, as it does not have access to the sdf element. 
* The code just looks unnecessarily complicated with the extra functions.

### Solution 2
We could have a service that is advertising a "global" flag that would speficy whether we should run the ``GetGeoRef`` function. This would mean the code would be cleaner and changes would be applied to gzclient as well, but it would apply to ALL heightmaps.
