### PR TITLE
Fix tests related to shininess

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -37,7 +37,9 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt=5.12.9=*_4 ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp dartsim simbody hdf5 openal-soft glib gts
+        # re-add dartsim once the libsdformat 9.8 issue is resolved
+        # https://github.com/osrf/gazebo/pull/3223#issuecomment-1140019713
+        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt=5.12.9=*_4 ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp simbody hdf5 openal-soft glib gts
 
     - name: Linux-only Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -608,7 +608,7 @@ endif ()
 
 ########################################
 # Find SDFormat
-set(SDF_MIN_REQUIRED_VERSION 9.3)
+set(SDF_MIN_REQUIRED_VERSION 9.8)
 find_package(sdformat9 ${SDF_MIN_REQUIRED_VERSION} REQUIRED)
 if (sdformat9_FOUND)
   message (STATUS "Looking for SDFormat9  - found")

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -1259,29 +1259,32 @@ ModelPtr World::LoadModel(sdf::ElementPtr _sdf , BasePtr _parent)
       }
     }
 
-    sdf::ElementPtr linkElem = _sdf->GetElement("link");
-    if (linkElem->HasElement("visual") &&
-        linkElem->GetElement("visual")->HasElement("material"))
+    if (_sdf->HasElement("link"))
     {
-      sdf::ElementPtr matElem = linkElem->GetElement("visual")->
-          GetElement("material");
+      sdf::ElementPtr linkElem = _sdf->GetElement("link");
+      if (linkElem->HasElement("visual") &&
+          linkElem->GetElement("visual")->HasElement("material"))
+      {
+        sdf::ElementPtr matElem = linkElem->GetElement("visual")->
+            GetElement("material");
 
-      if (matElem->HasElement("shininess"))
-      {
-        this->dataPtr->materialShininessMap[modelName] =
-            matElem->Get<double>("shininess");
-      }
-      else
-      {
-        this->dataPtr->materialShininessMap[modelName] = 0;
-      }
+        if (matElem->HasElement("shininess"))
+        {
+          this->dataPtr->materialShininessMap[modelName] =
+              matElem->Get<double>("shininess");
+        }
+        else
+        {
+          this->dataPtr->materialShininessMap[modelName] = 0;
+        }
 
-      std::string materialShininessService("/" + modelName + "/shininess");
-      if (!this->dataPtr->ignNode.Advertise(materialShininessService,
-          &World::MaterialShininessService, this))
-      {
-        gzerr << "Error advertising service ["
-              << materialShininessService << "]" << std::endl;
+        std::string materialShininessService("/" + modelName + "/shininess");
+        if (!this->dataPtr->ignNode.Advertise(materialShininessService,
+            &World::MaterialShininessService, this))
+        {
+          gzerr << "Error advertising service ["
+                << materialShininessService << "]" << std::endl;
+        }
       }
     }
 

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -20,6 +20,8 @@
 
 #include <ignition/common/Profiler.hh>
 #include <ignition/math/Helpers.hh>
+#include <ignition/transport/Node.hh>
+#include <ignition/transport/TopicUtils.hh>
 
 #include "gazebo/msgs/msgs.hh"
 
@@ -325,27 +327,6 @@ void Visual::Init()
   this->dataPtr->inheritTransparency = true;
   this->dataPtr->scale = ignition::math::Vector3d::One;
 
-  this->dataPtr->initialized = true;
-}
-
-//////////////////////////////////////////////////
-void Visual::LoadFromMsg(const boost::shared_ptr< msgs::Visual const> &_msg)
-{
-  this->dataPtr->sdf = msgs::VisualToSDF(*_msg.get());
-  this->Load();
-  this->UpdateFromMsg(_msg);
-}
-
-//////////////////////////////////////////////////
-void Visual::Load(sdf::ElementPtr _sdf)
-{
-  this->dataPtr->sdf->Copy(_sdf);
-  this->Load();
-}
-
-//////////////////////////////////////////////////
-void Visual::Load()
-{
   if (this->dataPtr->sdf->HasElement("material"))
   {
     // Get shininess value from physics::World
@@ -388,6 +369,27 @@ void Visual::Load()
     }
   }
 
+  this->dataPtr->initialized = true;
+}
+
+//////////////////////////////////////////////////
+void Visual::LoadFromMsg(const boost::shared_ptr< msgs::Visual const> &_msg)
+{
+  this->dataPtr->sdf = msgs::VisualToSDF(*_msg.get());
+  this->Load();
+  this->UpdateFromMsg(_msg);
+}
+
+//////////////////////////////////////////////////
+void Visual::Load(sdf::ElementPtr _sdf)
+{
+  this->dataPtr->sdf->Copy(_sdf);
+  this->Load();
+}
+
+//////////////////////////////////////////////////
+void Visual::Load()
+{
   std::ostringstream stream;
   ignition::math::Pose3d pose;
   Ogre::MovableObject *obj = nullptr;

--- a/gazebo/rendering/Visual.hh
+++ b/gazebo/rendering/Visual.hh
@@ -30,8 +30,6 @@
 #include <ignition/math/Quaternion.hh>
 #include <ignition/math/Vector3.hh>
 #include <ignition/msgs/MessageTypes.hh>
-#include <ignition/transport/Node.hh>
-#include <ignition/transport/TopicUtils.hh>
 
 #include "gazebo/common/Mesh.hh"
 #include "gazebo/common/Time.hh"


### PR DESCRIPTION
The material shininess features added in #3213 introduced a few test regressions that we difficult to notice due to the large number of existing test failures in our CI. Having been able to observe several sets of builds since then, I've noticed the following test failures that I believe we introduced:

* [FactoryTest.FilenameModelDatabaseSpaces](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/126/testReport/(root)/FactoryTest/FilenameModelDatabaseSpaces/)
* [PhysicsEngines/NestedModelTest.SpawnNestedModel/0](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/126/testReport/(root)/PhysicsEngines_NestedModelTest/SpawnNestedModel_0/)
* [PhysicsEngines/NestedModelTest.SpawnNestedModel/1](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/126/testReport/(root)/PhysicsEngines_NestedModelTest/SpawnNestedModel_1/)
* [INTEGRATION_pr2.test_ran](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/126/testReport/(root)/INTEGRATION_pr2/test_ran/)
* [ModelListWidget_TEST.NestedLinkProperties](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-bionic-amd64-gpu-nvidia/126/testReport/(root)/ModelListWidget_TEST/NestedLinkProperties/)

The `PhysicsEngines/NestedModelTest.SpawnNestedModel/*` tests (and possibly `ModelListWidget_TEST.NestedLinkProperties`) should be fixed by https://github.com/osrf/gazebo/commit/b29d38cdc21a685a779d8bf20bdff8f3bf6843d6 ([diff without whitespace](https://github.com/osrf/gazebo/commit/b29d38cdc21a685a779d8bf20bdff8f3bf6843d6?w=1)). The remaining tests should be fixed by https://github.com/osrf/gazebo/commit/6c4c1889951ebaa9e66d4b741f02e5a33facf990.