### PR TITLE
Add missing header files

### DIFF
--- a/examples/stand_alone/marker/marker.cc
+++ b/examples/stand_alone/marker/marker.cc
@@ -15,7 +15,9 @@
  *
 */
 #include <ignition/transport.hh>
-#include <ignition/math.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Rand.hh>
+#include <ignition/math/Vector3.hh>
 #include <ignition/msgs.hh>
 #include <gazebo/common/Time.hh>
 

--- a/gazebo/common/ColladaLoader_TEST.cc
+++ b/gazebo/common/ColladaLoader_TEST.cc
@@ -17,6 +17,11 @@
 #include <gtest/gtest.h>
 
 #include "test_config.h"
+
+#include <ignition/math/Color.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/Mesh.hh"
 #include "gazebo/common/Material.hh"
 #include "gazebo/common/ColladaLoader.hh"

--- a/gazebo/common/MeshManager.cc
+++ b/gazebo/common/MeshManager.cc
@@ -19,6 +19,14 @@
 #include <string>
 #include <map>
 
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Plane.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/CommonIface.hh"
 #include "gazebo/common/Exception.hh"
 #include "gazebo/common/Console.hh"

--- a/gazebo/common/SVGLoader.cc
+++ b/gazebo/common/SVGLoader.cc
@@ -20,6 +20,11 @@
 #include <utility>
 #include <cmath>
 
+#include <ignition/math/Angle.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
+
 #include <gazebo/common/Console.hh>
 #include <gazebo/common/Assert.hh>
 

--- a/gazebo/common/Skeleton.cc
+++ b/gazebo/common/Skeleton.cc
@@ -16,6 +16,10 @@
  */
 #include <list>
 
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/Skeleton.hh"
 #include "gazebo/common/SkeletonAnimation.hh"
 

--- a/gazebo/common/SkeletonAnimation.cc
+++ b/gazebo/common/SkeletonAnimation.cc
@@ -15,6 +15,12 @@
  *
 */
 
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/SkeletonAnimation.hh"
 #include "gazebo/common/Console.hh"
 #include "gazebo/common/Assert.hh"

--- a/gazebo/common/SphericalCoordinates.cc
+++ b/gazebo/common/SphericalCoordinates.cc
@@ -17,6 +17,11 @@
 #include <string>
 #include <math.h>
 
+#include <ignition/math/Angle.hh>
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/Console.hh"
 #include "gazebo/common/SphericalCoordinates.hh"
 #include "gazebo/common/SphericalCoordinatesPrivate.hh"

--- a/gazebo/gui/ViewAngleWidget.cc
+++ b/gazebo/gui/ViewAngleWidget.cc
@@ -15,6 +15,9 @@
  *
 */
 
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/rendering/UserCamera.hh"
 #include "gazebo/rendering/Visual.hh"
 

--- a/gazebo/gui/model/JointMaker.cc
+++ b/gazebo/gui/model/JointMaker.cc
@@ -19,6 +19,11 @@
 #include <vector>
 #include <ignition/math/Color.hh>
 #include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Plane.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
 
 #include "gazebo/common/MouseEvent.hh"
 

--- a/gazebo/gui/model/ModelCreator.cc
+++ b/gazebo/gui/model/ModelCreator.cc
@@ -21,6 +21,13 @@
 
 #include <sdf/sdf.hh>
 
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/CommonIface.hh"
 #include "gazebo/common/Exception.hh"
 #include "gazebo/common/KeyEvent.hh"

--- a/gazebo/msgs/msgs_TEST.cc
+++ b/gazebo/msgs/msgs_TEST.cc
@@ -223,7 +223,7 @@ TEST_F(MsgsTest, ConvertMsgsVector3dToMath)
   EXPECT_DOUBLE_EQ(3, v.Z());
 }
 
-TEST_F(MsgsTest, ConvertMathQuaterionToMsgs)
+TEST_F(MsgsTest, ConvertMathQuaternionToMsgs)
 {
   msgs::Quaternion msg =
     msgs::Convert(ignition::math::Quaterniond(M_PI * 0.25, M_PI * 0.5, M_PI));

--- a/gazebo/physics/Actor.cc
+++ b/gazebo/physics/Actor.cc
@@ -18,6 +18,13 @@
 #include <limits>
 #include <algorithm>
 
+#include <ignition/math/Color.hh>
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/BVHLoader.hh"
 #include "gazebo/common/Console.hh"
 #include "gazebo/common/KeyFrame.hh"

--- a/gazebo/physics/Actor.hh
+++ b/gazebo/physics/Actor.hh
@@ -23,6 +23,9 @@
 #include <vector>
 
 #include <ignition/math/Color.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
 
 #include "gazebo/physics/Model.hh"
 #include "gazebo/common/Time.hh"

--- a/gazebo/physics/Inertial.cc
+++ b/gazebo/physics/Inertial.cc
@@ -15,6 +15,11 @@
  *
 */
 #include <functional>
+#include <ignition/math/Inertial.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
 #include "gazebo/physics/Inertial.hh"
 
 using namespace gazebo;

--- a/gazebo/physics/Inertial_TEST.cc
+++ b/gazebo/physics/Inertial_TEST.cc
@@ -16,6 +16,9 @@
 */
 
 #include <gtest/gtest.h>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
 #include "gazebo/physics/physics.hh"
 #include "gazebo/physics/Inertial.hh"
 #include "test/util.hh"

--- a/gazebo/physics/Joint.cc
+++ b/gazebo/physics/Joint.cc
@@ -15,6 +15,12 @@
  *
 */
 
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/SemanticVersion.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/transport/TransportIface.hh"
 #include "gazebo/transport/Publisher.hh"
 

--- a/gazebo/physics/Link.cc
+++ b/gazebo/physics/Link.cc
@@ -20,6 +20,12 @@
 #include <mutex>
 #include <sstream>
 
+#include <ignition/math/AxisAlignedBox.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/transport/TransportIface.hh"
 #include "gazebo/transport/TransportTypes.hh"
 #include "gazebo/transport/Node.hh"

--- a/gazebo/physics/dart/DARTCollision.cc
+++ b/gazebo/physics/dart/DARTCollision.cc
@@ -17,6 +17,10 @@
 
 #include <sstream>
 
+#include <ignition/math/AxisAlignedBox.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/Console.hh"
 
 #include "gazebo/physics/SurfaceParams.hh"

--- a/gazebo/physics/dart/DARTLink.cc
+++ b/gazebo/physics/dart/DARTLink.cc
@@ -17,6 +17,11 @@
 
 #include <functional>
 
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/Assert.hh"
 #include "gazebo/common/Console.hh"
 #include "gazebo/common/Exception.hh"

--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -22,7 +22,13 @@
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <ignition/common/Profiler.hh>
+#include <ignition/math/Angle.hh>
 #include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
 #include <sdf/sdf.hh>
 
 #ifndef _WIN32

--- a/gazebo/rendering/MarkerManager.cc
+++ b/gazebo/rendering/MarkerManager.cc
@@ -21,6 +21,8 @@
 #include <mutex>
 #include <string>
 
+#include <ignition/math/Helpers.hh>
+#include <ignition/math/Rand.hh>
 #include <ignition/msgs.hh>
 #include <ignition/transport/Node.hh>
 

--- a/gazebo/rendering/OculusCamera.cc
+++ b/gazebo/rendering/OculusCamera.cc
@@ -18,7 +18,12 @@
 #include <sstream>
 #include <string>
 #include <ignition/common/Profiler.hh>
+#include <ignition/math/Angle.hh>
+#include <ignition/math/Matrix4.hh>
 #include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Vector4.hh>
 
 #include "gazebo/rendering/ogre_gazebo.h"
 

--- a/gazebo/rendering/UserCamera.cc
+++ b/gazebo/rendering/UserCamera.cc
@@ -16,8 +16,12 @@
 */
 #include <boost/bind/bind.hpp>
 #include <ignition/common/Profiler.hh>
+#include <ignition/math/Angle.hh>
 #include <ignition/math/Color.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
 #include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
 
 #include "gazebo/rendering/ogre_gazebo.h"
 

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -19,7 +19,15 @@
 #include <boost/lexical_cast.hpp>
 
 #include <ignition/common/Profiler.hh>
+#include <ignition/math/AxisAlignedBox.hh>
+#include <ignition/math/Color.hh>
 #include <ignition/math/Helpers.hh>
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector2.hh>
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Vector4.hh>
 #include <ignition/transport/Node.hh>
 #include <ignition/transport/TopicUtils.hh>
 

--- a/gazebo/sensors/ForceTorqueSensor.cc
+++ b/gazebo/sensors/ForceTorqueSensor.cc
@@ -17,6 +17,9 @@
 #include <boost/algorithm/string.hpp>
 
 #include <ignition/common/Profiler.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
 
 #include "gazebo/physics/World.hh"
 #include "gazebo/physics/PhysicsEngine.hh"

--- a/gazebo/util/OpenAL.cc
+++ b/gazebo/util/OpenAL.cc
@@ -34,6 +34,10 @@
 #endif
 #endif
 
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Vector3.hh>
+
 #include "gazebo/common/CommonIface.hh"
 #include "gazebo/common/Console.hh"
 #include "gazebo/common/Exception.hh"

--- a/plugins/ActorPlugin.cc
+++ b/plugins/ActorPlugin.cc
@@ -17,7 +17,11 @@
 
 #include <functional>
 
-#include <ignition/math.hh>
+#include <ignition/math/Angle.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Rand.hh>
+#include <ignition/math/Vector3.hh>
 #include <ignition/common/Profiler.hh>
 #include "gazebo/physics/physics.hh"
 #include "plugins/ActorPlugin.hh"

--- a/plugins/LookAtDemoPlugin.cc
+++ b/plugins/LookAtDemoPlugin.cc
@@ -16,6 +16,10 @@
 */
 #include <sstream>
 
+#include <ignition/math/Matrix4.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
 #include <gazebo/gui/Actions.hh>
 #include "LookAtDemoPlugin.hh"
 

--- a/plugins/RaySensorNoisePlugin.cc
+++ b/plugins/RaySensorNoisePlugin.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <functional>
+#include <ignition/math/Rand.hh>
 #include "gazebo/sensors/Noise.hh"
 #include "RaySensorNoisePlugin.hh"
 

--- a/test/integration/marker.cc
+++ b/test/integration/marker.cc
@@ -14,6 +14,9 @@
  * limitations under the License.
  *
 */
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Rand.hh>
+#include <ignition/math/Vector3.hh>
 #include <ignition/msgs.hh>
 #include <ignition/transport.hh>
 #include "gazebo/gui/GuiIface.hh"

--- a/test/integration/physics_link.cc
+++ b/test/integration/physics_link.cc
@@ -17,7 +17,9 @@
 #include <string.h>
 #include <boost/algorithm/string.hpp>
 #include <ignition/math/MassMatrix3.hh>
+#include <ignition/math/Matrix3.hh>
 #include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
 #include <ignition/math/Vector3Stats.hh>
 
 #include "gazebo/msgs/msgs.hh"

--- a/test/integration/view_angle.cc
+++ b/test/integration/view_angle.cc
@@ -15,6 +15,8 @@
  *
 */
 
+#include <ignition/math/Matrix4.hh>
+
 #include "gazebo/gui/GuiIface.hh"
 #include "gazebo/gui/Actions.hh"
 #include "gazebo/gui/GLWidget.hh"

--- a/test/performance/introspectionmanager_stress.cc
+++ b/test/performance/introspectionmanager_stress.cc
@@ -16,6 +16,8 @@
 */
 #include <gtest/gtest.h>
 
+#include <numeric>
+
 #include "gazebo/util/IntrospectionManager.hh"
 #include "gazebo/test/ServerFixture.hh"
 


### PR DESCRIPTION
Some header files are proposed for removal from `sdf/Param.hh` in https://github.com/gazebosim/sdformat/pull/1044. While testing that branch with gazebo11, I noticed some compilation failures in files that use objects without including the associated header file. I've added missing header files for many `ignition/math/*` includes in https://github.com/osrf/gazebo/commit/c20bb21f4c282df7207da74b668911d719bd1a0c. It is more than enough to fix compilation, though it is not fully exhaustive.

I made two other small changes as well:

* https://github.com/osrf/gazebo/commit/d51a7de774c303db427f93ebcc8e23ccf1f9db47: fix a spelling error
* https://github.com/osrf/gazebo/commit/d5f9d42ca6e8b9078d58959bb3f3441760528d6e: replace inclusion of `ignition/math.hh` in two `.cc` files with the specific math header files that are needed to reduce compilation time. Since these are `.cc` files, there should not be an effect on any downstream code.