### PR TITLE
Fix shininess and add tests

### DIFF
--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -327,6 +327,27 @@ void Visual::Init()
   this->dataPtr->inheritTransparency = true;
   this->dataPtr->scale = ignition::math::Vector3d::One;
 
+  this->dataPtr->initialized = true;
+}
+
+//////////////////////////////////////////////////
+void Visual::LoadFromMsg(const boost::shared_ptr< msgs::Visual const> &_msg)
+{
+  this->dataPtr->sdf = msgs::VisualToSDF(*_msg.get());
+  this->Load();
+  this->UpdateFromMsg(_msg);
+}
+
+//////////////////////////////////////////////////
+void Visual::Load(sdf::ElementPtr _sdf)
+{
+  this->dataPtr->sdf->Copy(_sdf);
+  this->Load();
+}
+
+//////////////////////////////////////////////////
+void Visual::Load()
+{
   if (this->dataPtr->sdf->HasElement("material"))
   {
     // Get shininess value from physics::World
@@ -369,27 +390,6 @@ void Visual::Init()
     }
   }
 
-  this->dataPtr->initialized = true;
-}
-
-//////////////////////////////////////////////////
-void Visual::LoadFromMsg(const boost::shared_ptr< msgs::Visual const> &_msg)
-{
-  this->dataPtr->sdf = msgs::VisualToSDF(*_msg.get());
-  this->Load();
-  this->UpdateFromMsg(_msg);
-}
-
-//////////////////////////////////////////////////
-void Visual::Load(sdf::ElementPtr _sdf)
-{
-  this->dataPtr->sdf->Copy(_sdf);
-  this->Load();
-}
-
-//////////////////////////////////////////////////
-void Visual::Load()
-{
   std::ostringstream stream;
   ignition::math::Pose3d pose;
   Ogre::MovableObject *obj = nullptr;

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -1575,6 +1575,12 @@ ignition::math::Color Visual::Emissive() const
   return this->dataPtr->emissive;
 }
 
+/////////////////////////////////////////////////
+double Visual::Shininess() const
+{
+  return this->dataPtr->shininess;
+}
+
 //////////////////////////////////////////////////
 void Visual::SetWireframe(bool _show)
 {

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -331,7 +331,7 @@ void Visual::Init()
 }
 
 //////////////////////////////////////////////////
-void Visual::LoadFromMsg(const boost::shared_ptr< msgs::Visual const> &_msg)
+void Visual::LoadFromMsg(const boost::shared_ptr<msgs::Visual const> &_msg)
 {
   this->dataPtr->sdf = msgs::VisualToSDF(*_msg.get());
   this->Load();

--- a/gazebo/rendering/Visual.hh
+++ b/gazebo/rendering/Visual.hh
@@ -272,6 +272,10 @@ namespace gazebo
       /// \return Emissive color.
       public: ignition::math::Color Emissive() const;
 
+      /// \brief Get the shininess value of the visual.
+      /// \return Floating-point shininess value.
+      public: double Shininess() const;
+
       /// \brief Enable or disable wireframe for this visual.
       /// \param[in] _show True to enable wireframe for this visual.
       public: void SetWireframe(bool _show);

--- a/gazebo/rendering/Visual_TEST.cc
+++ b/gazebo/rendering/Visual_TEST.cc
@@ -951,6 +951,7 @@ TEST_F(Visual_TEST, Color)
   EXPECT_EQ(cylinderVis->Diffuse(), ignmath::Color::Black);
   EXPECT_EQ(cylinderVis->Specular(), ignmath::Color::Black);
   EXPECT_EQ(cylinderVis->Emissive(), ignmath::Color::Black);
+  EXPECT_DOUBLE_EQ(0.0, cylinderVis->Shininess());
 
   sdf::ElementPtr cylinderSDF2(new sdf::Element);
   sdf::initFile("visual.sdf", cylinderSDF2);
@@ -965,6 +966,7 @@ TEST_F(Visual_TEST, Color)
   EXPECT_EQ(cylinderVis2->Diffuse(), ignmath::Color::Blue);
   EXPECT_EQ(cylinderVis2->Specular(), ignmath::Color::Red);
   EXPECT_EQ(cylinderVis2->Emissive(), ignmath::Color::Yellow);
+  EXPECT_DOUBLE_EQ(0.0, cylinderVis2->Shininess());
 
   // test changing ambient/diffuse/specular colors
   {

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -205,6 +205,7 @@ set(dri_tests
   road.cc
   speed_pr2.cc
   visual.cc
+  visual_shininess.cc
   wideanglecamera_sensor.cc
   world_remove.cc
   world_reset.cc

--- a/test/integration/visual_shininess.cc
+++ b/test/integration/visual_shininess.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,11 @@
  * limitations under the License.
  *
 */
-#include <mutex>
-#include <functional>
-
-#include <ignition/math/Rand.hh>
 
 #include "test_config.h"
 
-#include "gazebo/physics/physics.hh"
-#include "gazebo/sensors/sensors.hh"
 #include "gazebo/common/Timer.hh"
-#include "gazebo/rendering/Camera.hh"
-#include "gazebo/sensors/CameraSensor.hh"
+#include "gazebo/rendering/rendering.hh"
 
 #include "gazebo/test/ServerFixture.hh"
 
@@ -77,7 +70,7 @@ TEST_F(VisualShininess, ShapesShininess)
   if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
       rendering::RenderEngine::NONE)
   {
-    gzerr << "No rendering engine, unable to run camera test"
+    gzerr << "No rendering engine, unable to run shininess test"
           << std::endl;
     return;
   }
@@ -101,6 +94,9 @@ TEST_F(VisualShininess, ShapesShininess)
     common::Time::MSleep(100);
     sleep++;
   }
+  ASSERT_NE(nullptr, box);
+  ASSERT_NE(nullptr, cylinder);
+  ASSERT_NE(nullptr, sphere);
   EXPECT_TRUE(scene->Initialized());
 
   std::unordered_map<std::string, double> nameToShininess;

--- a/test/integration/visual_shininess.cc
+++ b/test/integration/visual_shininess.cc
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2017 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <mutex>
+#include <functional>
+
+#include <ignition/math/Rand.hh>
+
+#include "test_config.h"
+
+#include "gazebo/physics/physics.hh"
+#include "gazebo/sensors/sensors.hh"
+#include "gazebo/common/Timer.hh"
+#include "gazebo/rendering/Camera.hh"
+#include "gazebo/sensors/CameraSensor.hh"
+
+#include "gazebo/test/ServerFixture.hh"
+
+using namespace gazebo;
+class VisualShininess : public RenderingFixture
+{
+};
+
+/////////////////////////////////////////////////
+void CheckShininessService(const std::string &_modelName,
+    double _expectedShininess)
+{
+  std::string serviceName = '/' + _modelName + "/shininess";
+  ignition::transport::Node ignNode;
+
+  {
+    std::vector<ignition::transport::ServicePublisher> publishers;
+    EXPECT_TRUE(ignNode.ServiceInfo(serviceName, publishers));
+  }
+
+  ignition::msgs::StringMsg request;
+  gazebo::msgs::Any reply;
+  const unsigned int timeout = 3000;
+  bool result = false;
+  request.set_data(_modelName);
+  EXPECT_TRUE(ignNode.Request(serviceName, request, timeout, reply, result));
+  EXPECT_TRUE(result);
+  EXPECT_EQ(msgs::Any_ValueType_DOUBLE, reply.type());
+  EXPECT_DOUBLE_EQ(_expectedShininess, reply.double_value()) << _modelName;
+}
+
+/////////////////////////////////////////////////
+TEST_F(VisualShininess, ShapesShininessServices)
+{
+  Load("worlds/shapes_shininess.world", true);
+
+  CheckShininessService("ground_plane", 0.0);
+  CheckShininessService("box", 1.0);
+  CheckShininessService("sphere", 5.0);
+  CheckShininessService("cylinder", 10.0);
+}
+
+/////////////////////////////////////////////////
+TEST_F(VisualShininess, ShapesShininess)
+{
+  Load("worlds/shapes_shininess.world");
+
+  // Make sure the render engine is available.
+  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
+      rendering::RenderEngine::NONE)
+  {
+    gzerr << "No rendering engine, unable to run camera test"
+          << std::endl;
+    return;
+  }
+  gazebo::rendering::ScenePtr scene = gazebo::rendering::get_scene();
+  ASSERT_NE(nullptr, scene);
+
+  // Wait until all models are inserted
+  unsigned int sleep = 0;
+  unsigned int maxSleep = 30;
+  rendering::VisualPtr box, sphere, cylinder;
+  while ((!box || !sphere || !cylinder) && sleep < maxSleep)
+  {
+    event::Events::preRender();
+    event::Events::render();
+    event::Events::postRender();
+
+    box = scene->GetVisual("box");
+    cylinder = scene->GetVisual("cylinder");
+    sphere = scene->GetVisual("sphere");
+
+    common::Time::MSleep(100);
+    sleep++;
+  }
+  EXPECT_TRUE(scene->Initialized());
+
+  std::unordered_map<std::string, double> nameToShininess;
+  nameToShininess["box::link::visual"] = 1.0;
+  nameToShininess["sphere::link::visual"] = 5.0;
+  nameToShininess["cylinder::link::visual"] = 10.0;
+
+  for (const auto &nameShininess : nameToShininess)
+  {
+    rendering::VisualPtr visual = scene->GetVisual(nameShininess.first);
+    ASSERT_NE(nullptr, visual);
+
+    // check shininess value
+    EXPECT_DOUBLE_EQ(nameShininess.second, visual->Shininess())
+        << nameShininess.first;
+  }
+}


### PR DESCRIPTION
The introduction of the Shininess feature in #3213 caused some test failures in CI that I attempted to fix in #3223, but I accidentally broke the shininess feature entirely. Here's I've added a `Visual::Shininess()` accessor to support testing along with tests and a fix.

* https://github.com/osrf/gazebo/commit/f68de5aa2122ef4ef7ae021c5183ba437475aa9b: add `Visual::Shininess()` accessor method
* https://github.com/osrf/gazebo/commit/18aa3a6b7aa0c308b40c07e20188dbd55b01b3c6: add `INTEGRATION_visual_shininess` test that uses the `shapes_shininess` demo world to verify that the `/*/shininess` services are working properly (already passing) and checks that `Visual::Shininess()` returns the expected values (not passing)
* https://github.com/osrf/gazebo/commit/61a7c9ece718dd8bd9bf0df42b39392690f2d110: revert problematic portion of #3223 (https://github.com/osrf/gazebo/pull/3223/commits/6c4c1889951ebaa9e66d4b741f02e5a33facf990), moving service call back to `Visual::Load`
* https://github.com/osrf/gazebo/commit/8d410e115f619b447e1e23d8f577db7276c37b6e (best viewed [without whitespace](https://github.com/osrf/gazebo/commit/8d410e115f619b447e1e23d8f577db7276c37b6e?w=1)): better fix for timeouts when loading PR2 by checking for existence of shininess service call before requesting it. Also prevents `return`ing early from `Visual::Load()` due to shininess service errors so that other loading may occur.