### PR TITLE
LensFlare: parameterize number of occlusion steps

### DIFF
--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -367,6 +367,9 @@ namespace gazebo
       public: ignition::math::Vector3d lensFlareColor
           = ignition::math::Vector3d(1.0, 1.0, 1.0);
 
+      /// \brief Color of lens flare.
+      public: double lensFlareOcclusionSteps = 10;
+
       /// \brief Compositor name to be used for lens flare
       public: std::string compositorName = "CameraLensFlare/Default";
 
@@ -435,7 +438,7 @@ void LensFlare::SetCamera(CameraPtr _camera)
     this->dataPtr->lensFlareCompositorListener->SetColor(
         this->dataPtr->lensFlareColor);
     this->dataPtr->lensFlareCompositorListener->SetOcclusionSteps(
-        this->dataPtr->lensFlareColor);
+        this->dataPtr->lensFlareOcclusionSteps);
 
     this->dataPtr->lensFlareInstance =
         Ogre::CompositorManager::getSingleton().addCompositor(
@@ -479,7 +482,7 @@ void LensFlare::SetColor(const ignition::math::Vector3d &_color)
 //////////////////////////////////////////////////
 void LensFlare::SetOcclusionSteps(double _occlusionSteps)
 {
-  this->dataPtr->occlusionSteps = _occlusionSteps;
+  this->dataPtr->lensFlareOcclusionSteps = _occlusionSteps;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -55,6 +55,10 @@ namespace gazebo
       /// \brief Color of lens flare.
       public: ignition::math::Vector3d color
           = ignition::math::Vector3d(1.0, 1.0, 1.0);
+
+      /// \brief Number of steps to take in each direction when checking for
+      /// occlusion.
+      public: double occlusionSteps = 10;
     };
 
     //////////////////////////////////////////////////
@@ -93,6 +97,13 @@ namespace gazebo
         const ignition::math::Vector3d &_color)
     {
       this->dataPtr->color = _color;
+    }
+
+    //////////////////////////////////////////////////
+    void LensFlareCompositorListener::SetOcclusionSteps(
+        double _occlusionSteps)
+    {
+      this->dataPtr->occlusionSteps = _occlusionSteps;
     }
 
     //////////////////////////////////////////////////
@@ -313,7 +324,7 @@ namespace gazebo
       // work in normalized device coordinates
       // lens flare's halfSize is just an approximated value
       double halfSize = 0.05 * this->dataPtr->scale;
-      double steps = 10;
+      double steps = this->dataPtr->occlusionSteps;
       double stepSize = halfSize * 2 / steps;
       double cx = _imgPos.X();
       double cy = _imgPos.Y();
@@ -423,6 +434,8 @@ void LensFlare::SetCamera(CameraPtr _camera)
         this->dataPtr->lensFlareScale);
     this->dataPtr->lensFlareCompositorListener->SetColor(
         this->dataPtr->lensFlareColor);
+    this->dataPtr->lensFlareCompositorListener->SetOcclusionSteps(
+        this->dataPtr->lensFlareColor);
 
     this->dataPtr->lensFlareInstance =
         Ogre::CompositorManager::getSingleton().addCompositor(
@@ -461,6 +474,12 @@ void LensFlare::SetColor(const ignition::math::Vector3d &_color)
     this->dataPtr->lensFlareCompositorListener->SetColor(
         this->dataPtr->lensFlareColor);
   }
+}
+
+//////////////////////////////////////////////////
+void LensFlare::SetOcclusionSteps(double _occlusionSteps)
+{
+  this->dataPtr->occlusionSteps = _occlusionSteps;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -58,7 +58,7 @@ namespace gazebo
 
       /// \brief Number of steps to take in each direction when checking for
       /// occlusion.
-      public: double occlusionSteps = 10;
+      public: double occlusionSteps = 10.0;
     };
 
     //////////////////////////////////////////////////
@@ -368,7 +368,7 @@ namespace gazebo
           = ignition::math::Vector3d(1.0, 1.0, 1.0);
 
       /// \brief Color of lens flare.
-      public: double lensFlareOcclusionSteps = 10;
+      public: double lensFlareOcclusionSteps = 10.0;
 
       /// \brief Compositor name to be used for lens flare
       public: std::string compositorName = "CameraLensFlare/Default";

--- a/gazebo/rendering/LensFlare.hh
+++ b/gazebo/rendering/LensFlare.hh
@@ -129,6 +129,12 @@ namespace gazebo
       /// \param[in] _color Color of lens flare
       public: void SetColor(const ignition::math::Vector3d &_color);
 
+      /// \brief Set the number of steps to take in each direction when
+      /// checking for occlusions.
+      /// \param[in] _occlusionSteps number of steps to take in each direction
+      /// when checking for occlusion.
+      public: void SetOcclusionSteps(double _occlusionSteps);
+
       /// \brief Set the name of the lens flare compositor to use the next
       /// time SetCamera is called.
       /// \param[in] _name Name of the compositor to use

--- a/gazebo/rendering/LensFlare.hh
+++ b/gazebo/rendering/LensFlare.hh
@@ -59,6 +59,12 @@ namespace gazebo
       /// \param[in] _color Color of lens flare
       public: void SetColor(const ignition::math::Vector3d &_color);
 
+      /// \brief Set the number of steps to take in each direction when
+      /// checking for occlusions.
+      /// \param[in] _occlusionSteps number of steps to take in each direction
+      /// when checking for occlusion.
+      public: void SetOcclusionSteps(double _occlusionSteps);
+
       /// \brief Callback that OGRE will invoke for us on each render call
       /// \param[in] _passID OGRE material pass ID.
       /// \param[in] _mat Pointer to OGRE material.

--- a/plugins/LensFlareSensorPlugin.cc
+++ b/plugins/LensFlareSensorPlugin.cc
@@ -41,7 +41,7 @@ namespace gazebo
         = ignition::math::Vector3d(1.4, 1.2, 1.0);
 
     /// \brief Lens flare occlusion steps
-    public: double occlusionSteps = 10;
+    public: double occlusionSteps = 10.0;
 
     /// \brief Lens flare compositor name
     public: std::string compositorName;

--- a/plugins/LensFlareSensorPlugin.cc
+++ b/plugins/LensFlareSensorPlugin.cc
@@ -40,6 +40,9 @@ namespace gazebo
     public: ignition::math::Vector3d color
         = ignition::math::Vector3d(1.4, 1.2, 1.0);
 
+    /// \brief Lens flare occlusion steps
+    public: double occlusionSteps = 10;
+
     /// \brief Lens flare compositor name
     public: std::string compositorName;
   };
@@ -85,6 +88,11 @@ void LensFlareSensorPlugin::Load(sensors::SensorPtr _sensor,
   if (_sdf->HasElement("color"))
   {
     this->dataPtr->color = _sdf->Get<ignition::math::Vector3d>("color");
+  }
+
+  if (_sdf->HasElement("occlusion_steps"))
+  {
+    this->dataPtr->occlusionSteps = _sdf->Get<double>("occlusion_steps");
   }
 
   const std::string compositorName = "compositor";
@@ -142,6 +150,17 @@ void LensFlareSensorPlugin::SetColor(const ignition::math::Vector3d &_color)
 }
 
 /////////////////////////////////////////////////
+void LensFlareSensorPlugin::SetOcclusionSteps(double _occlusionSteps)
+{
+  this->dataPtr->occlusionSteps = _occlusionSteps;
+
+  for (auto flare : this->dataPtr->lensFlares)
+  {
+    flare->SetOcclusionSteps(occlusionSteps);
+  }
+}
+
+/////////////////////////////////////////////////
 void LensFlareSensorPlugin::AddLensFlare(rendering::CameraPtr _camera)
 {
   if (!_camera)
@@ -156,5 +175,6 @@ void LensFlareSensorPlugin::AddLensFlare(rendering::CameraPtr _camera)
   lensFlare->SetCamera(_camera);
   lensFlare->SetScale(this->dataPtr->scale);
   lensFlare->SetColor(this->dataPtr->color);
+  lensFlare->SetOcclusionSteps(this->dataPtr->occlusionSteps);
   this->dataPtr->lensFlares.push_back(lensFlare);
 }

--- a/plugins/LensFlareSensorPlugin.cc
+++ b/plugins/LensFlareSensorPlugin.cc
@@ -156,7 +156,7 @@ void LensFlareSensorPlugin::SetOcclusionSteps(double _occlusionSteps)
 
   for (auto flare : this->dataPtr->lensFlares)
   {
-    flare->SetOcclusionSteps(occlusionSteps);
+    flare->SetOcclusionSteps(_occlusionSteps);
   }
 }
 

--- a/plugins/LensFlareSensorPlugin.cc
+++ b/plugins/LensFlareSensorPlugin.cc
@@ -172,9 +172,10 @@ void LensFlareSensorPlugin::AddLensFlare(rendering::CameraPtr _camera)
   {
     lensFlare->SetCompositorName(this->dataPtr->compositorName);
   }
-  lensFlare->SetCamera(_camera);
   lensFlare->SetScale(this->dataPtr->scale);
   lensFlare->SetColor(this->dataPtr->color);
   lensFlare->SetOcclusionSteps(this->dataPtr->occlusionSteps);
+  // SetCamera must be called last
+  lensFlare->SetCamera(_camera);
   this->dataPtr->lensFlares.push_back(lensFlare);
 }

--- a/plugins/LensFlareSensorPlugin.hh
+++ b/plugins/LensFlareSensorPlugin.hh
@@ -53,6 +53,12 @@ namespace gazebo
     /// \param[in] _color Color of lens flare
     public: void SetColor(const ignition::math::Vector3d &_color);
 
+    /// \brief Set the number of steps to take in each direction when
+    /// checking for occlusions.
+    /// \param[in] _occlusionSteps number of steps to take in each direction
+    /// when checking for occlusion.
+    public: void SetOcclusionSteps(double _occlusionSteps);
+
     /// \brief Add lens flare effect to a camera
     /// \param[in] _camera Camera to add the lens flare effect to.
     private: void AddLensFlare(rendering::CameraPtr _camera);

--- a/plugins/LensFlareSensorPlugin.hh
+++ b/plugins/LensFlareSensorPlugin.hh
@@ -28,9 +28,10 @@ namespace gazebo
   /// \brief Plugin that adds lens flare effect to a camera or multicamera
   /// sensor
   /// The plugin has the following optional parameter:
-  /// <compositor>  Name of the lens flare compositor to use.
-  /// <scale>       Scale of lens flare. Must be greater than 0
-  /// <color>       Color of lens flare.
+  /// <color>           Color of lens flare.
+  /// <compositor>      Name of the lens flare compositor to use.
+  /// <occlusion_steps> Number of steps used when checking for occlusions.
+  /// <scale>           Scale of lens flare. Must be greater than 0.
   /// \todo A potentially useful feature would be an option for constantly
   /// updating the flare color to match the light source color.
   class GZ_PLUGIN_VISIBLE LensFlareSensorPlugin : public SensorPlugin


### PR DESCRIPTION
Some testing of the LensFlare effects has indicated that the number of steps used when checking for occlusions in `LensFlareCompositorListener::OcclusionScale` is impacting performance. To investigate, I've exposed it as a parameter in the `rendering::LensFlare` c++ API and as an XML parameter `<occlusion_steps>` to the `LensFlarePlugin`.