### PR TITLE
Support shininess value for each Visual in a Model

### DIFF
--- a/gazebo/physics/Link.cc
+++ b/gazebo/physics/Link.cc
@@ -1547,6 +1547,16 @@ void Link::UpdateVisualMsg()
       bool newVis = true;
       std::string visName = this->GetScopedName() + "::" + msg.name();
 
+      if (visualElem->HasElement("material"))
+      {
+        sdf::ElementPtr matElem = visualElem->GetElement("material");
+        if (matElem->HasElement("shininess"))
+        {
+          this->world->SetVisualShininess(
+              visName, matElem->Get<double>("shininess"));
+        }
+      }
+
       // update visual msg if it exists
       for (auto &iter : this->visuals)
       {

--- a/gazebo/physics/Link.cc
+++ b/gazebo/physics/Link.cc
@@ -1545,13 +1545,11 @@ void Link::UpdateVisualMsg()
                   common::resolveSdfPose(visualDom->SemanticPose()));
       }
       bool newVis = true;
-      std::string linkName = this->GetScopedName();
+      std::string visName = this->GetScopedName() + "::" + msg.name();
 
       // update visual msg if it exists
       for (auto &iter : this->visuals)
       {
-        std::string visName = linkName + "::" +
-            visualElem->Get<std::string>("name");
         if (iter.second.name() == visName)
         {
           iter.second.mutable_geometry()->CopyFrom(msg.geometry());
@@ -1563,7 +1561,6 @@ void Link::UpdateVisualMsg()
       // add to visual msgs if not found.
       if (newVis)
       {
-        std::string visName = this->GetScopedName() + "::" + msg.name();
         msg.set_name(visName);
         msg.set_id(physics::getUniqueId());
         msg.set_parent_name(this->GetScopedName());

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -3468,10 +3468,22 @@ bool World::ShadowCasterRenderBackFacesService(ignition::msgs::Boolean &_res)
 }
 
 //////////////////////////////////////////////////
+double World::ShininessByScopedName(const std::string &_scopedName) const
+{
+  std::lock_guard<std::mutex> lock(this->dataPtr->materialShininessMutex);
+  if (this->dataPtr->materialShininessMap.find(_scopedName) !=
+      this->dataPtr->materialShininessMap.end())
+  {
+    return this->dataPtr->materialShininessMap.at(_scopedName);
+  }
+  return 0.0;
+}
+
+//////////////////////////////////////////////////
 bool World::MaterialShininessService(
     const ignition::msgs::StringMsg &_req, msgs::Any &_res)
 {
   _res.set_type(msgs::Any::DOUBLE);
-  _res.set_double_value(this->dataPtr->materialShininessMap[_req.data()]);
+  _res.set_double_value(this->ShininessByScopedName(_req.data()));
   return true;
 }

--- a/gazebo/physics/World.hh
+++ b/gazebo/physics/World.hh
@@ -464,6 +464,12 @@ namespace gazebo
       /// \param[in] _func function to be called
       public: void SetSensorWaitFunc(std::function<void(double, double)> _func);
 
+      /// \brief Set Visual shininess value by scoped name
+      /// \param[in] _scopedName Scoped name of visual.
+      /// \param[in] _shininess Shininess value.
+      public: void SetVisualShininess(const std::string &_scopedName,
+          double _shininess);
+
       /// \cond
       /// This is an internal function.
       /// \brief Get a model by id.

--- a/gazebo/physics/World.hh
+++ b/gazebo/physics/World.hh
@@ -461,7 +461,7 @@ namespace gazebo
       public: std::string UniqueModelName(const std::string &_name);
 
       /// \brief Set callback 'waitForSensors'
-      /// \param[in] function to be called
+      /// \param[in] _func function to be called
       public: void SetSensorWaitFunc(std::function<void(double, double)> _func);
 
       /// \cond
@@ -677,6 +677,13 @@ namespace gazebo
       /// \return True if the info was successfully obtained.
       private: bool MaterialShininessService(
           const ignition::msgs::StringMsg &_request, msgs::Any &_response);
+
+      /// \brief Helper function for getting shininess values by scoped
+      /// visual name.
+      /// \param[in] _scopedName Scoped visual name.
+      /// \return Shininess value.
+      private: double ShininessByScopedName(const std::string &_scopedName)
+          const;
 
       /// \internal
       /// \brief Private data pointer.

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -398,6 +398,10 @@ namespace gazebo
       /// \brief Shadow caster render back faces from scene SDF
       public: bool shadowCasterRenderBackFaces = true;
 
+      /// \brief This mutex is used to by the SetVisualShininess and
+      /// ShininessByScopedName methods to protect materialShininessMap.
+      public: std::mutex materialShininessMutex;
+
       /// \brief Shininess values from scene SDF
       public: std::map<std::string, double> materialShininessMap;
     };

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -354,10 +354,9 @@ void Visual::Load()
     ignition::transport::Node node;
     msgs::Any rep;
 
-    const std::string visualName =
-        this->Name().substr(0, this->Name().find(":"));
+    const std::string visualName = this->Name();
 
-    const std::string serviceName = "/" + visualName + "/shininess";
+    const std::string serviceName = "/shininess";
 
     const std::string validServiceName =
         ignition::transport::TopicUtils::AsValidTopic(serviceName);

--- a/test/integration/visual_shininess.cc
+++ b/test/integration/visual_shininess.cc
@@ -57,6 +57,7 @@ TEST_F(VisualShininess, ShapesShininessServices)
 
   CheckShininessService("ground_plane::link::visual", 0.0);
   CheckShininessService("box::link::visual", 1.0);
+  CheckShininessService("box::link::visual2", 10.0);
   CheckShininessService("sphere::link::visual", 5.0);
   CheckShininessService("cylinder::link::visual", 10.0);
 }
@@ -101,6 +102,7 @@ TEST_F(VisualShininess, ShapesShininess)
 
   std::unordered_map<std::string, double> nameToShininess;
   nameToShininess["box::link::visual"] = 1.0;
+  nameToShininess["box::link::visual2"] = 10.0;
   nameToShininess["sphere::link::visual"] = 5.0;
   nameToShininess["cylinder::link::visual"] = 10.0;
 

--- a/test/integration/visual_shininess.cc
+++ b/test/integration/visual_shininess.cc
@@ -28,10 +28,10 @@ class VisualShininess : public RenderingFixture
 };
 
 /////////////////////////////////////////////////
-void CheckShininessService(const std::string &_modelName,
+void CheckShininessService(const std::string &_scopedName,
     double _expectedShininess)
 {
-  std::string serviceName = '/' + _modelName + "/shininess";
+  std::string serviceName = "/shininess";
   ignition::transport::Node ignNode;
 
   {
@@ -43,11 +43,11 @@ void CheckShininessService(const std::string &_modelName,
   gazebo::msgs::Any reply;
   const unsigned int timeout = 3000;
   bool result = false;
-  request.set_data(_modelName);
+  request.set_data(_scopedName);
   EXPECT_TRUE(ignNode.Request(serviceName, request, timeout, reply, result));
   EXPECT_TRUE(result);
   EXPECT_EQ(msgs::Any_ValueType_DOUBLE, reply.type());
-  EXPECT_DOUBLE_EQ(_expectedShininess, reply.double_value()) << _modelName;
+  EXPECT_DOUBLE_EQ(_expectedShininess, reply.double_value()) << _scopedName;
 }
 
 /////////////////////////////////////////////////
@@ -55,10 +55,10 @@ TEST_F(VisualShininess, ShapesShininessServices)
 {
   Load("worlds/shapes_shininess.world", true);
 
-  CheckShininessService("ground_plane", 0.0);
-  CheckShininessService("box", 1.0);
-  CheckShininessService("sphere", 5.0);
-  CheckShininessService("cylinder", 10.0);
+  CheckShininessService("ground_plane::link::visual", 0.0);
+  CheckShininessService("box::link::visual", 1.0);
+  CheckShininessService("sphere::link::visual", 5.0);
+  CheckShininessService("cylinder::link::visual", 10.0);
 }
 
 /////////////////////////////////////////////////

--- a/worlds/shapes_shininess.world
+++ b/worlds/shapes_shininess.world
@@ -28,6 +28,18 @@
             </box>
           </geometry>
         </visual>
+        <visual name="visual2">
+          <pose>0 0 3 0 0 0</pose>
+          <material>
+            <specular>1 0 0 1</specular>
+            <shininess>10</shininess>
+          </material>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
       </link>
     </model>
     <model name="sphere">


### PR DESCRIPTION
As noted in #3232, only a single shininess value is currently supported for each model. This pull request expands the functionality of the ignition service interface so that the shininess of each Visual in a Model can be queried independently. This works by storing the shininess values by the scoped visual name. It also replaces the per-model ignition services with a single `/shininess` service.

It is technically a change to the transport interface, but since this is such a new feature and improved by the current changes, I think it is an acceptable behavior change.

Fixes #3232.