### PR TITLE
Backport #3211 -> 9: Fix missing namespace for string

### DIFF
--- a/gazebo/msgs/generator/GazeboGenerator.cc
+++ b/gazebo/msgs/generator/GazeboGenerator.cc
@@ -37,7 +37,7 @@ namespace cpp {
 GazeboGenerator::GazeboGenerator(const std::string &/*_name*/) {}
 GazeboGenerator::~GazeboGenerator() {}
 bool GazeboGenerator::Generate(const FileDescriptor *_file,
-                               const string &/*parameter*/,
+                               const std::string &/*parameter*/,
                                OutputDirectory *_generator_context,
                                std::string * /*_error*/) const
 {

--- a/gazebo/msgs/generator/GazeboGenerator.hh
+++ b/gazebo/msgs/generator/GazeboGenerator.hh
@@ -37,9 +37,9 @@ class GazeboGenerator : public CodeGenerator
   public: virtual ~GazeboGenerator();
 
   public: virtual bool Generate(const FileDescriptor* file,
-                const string& parameter,
+                const std::string& parameter,
                 OutputDirectory *directory,
-                string* error) const;
+                std::string* error) const;
 
   // private: GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(GazeboGenerator);
 };


### PR DESCRIPTION
Backport of #3211 to fix macOS build:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo9-homebrew-amd64&build=211)](https://build.osrfoundation.org/job/gazebo-ci-gazebo9-homebrew-amd64/211/) https://build.osrfoundation.org/job/gazebo-ci-gazebo9-homebrew-amd64/211/