### PR TITLE
LensFlare: verify that OcclusionSteps >= 1

### DIFF
--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -103,6 +103,13 @@ namespace gazebo
     void LensFlareCompositorListener::SetOcclusionSteps(
         double _occlusionSteps)
     {
+      if (_occlusionSteps < 1)
+      {
+        gzerr << "Invalid OcclusionSteps parameter [" << _occlusionSteps
+              << "], must be >= 1"
+              << std::endl;
+        return;
+      }
       this->dataPtr->occlusionSteps = _occlusionSteps;
     }
 


### PR DESCRIPTION
This is a quick follow-up to #3234 that adds some parameter validation to the occlusion steps parameter.