### PR TITLE
Camera: expose intrinsics parameters

### DIFF
--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -121,8 +121,7 @@ Camera::Camera(const std::string &_name, ScenePtr _scene,
 
   this->dataPtr->antiAliasingValue = 4;
 
-  // calculate intrinsics from default matrix
-  this->CalculateIntrinsicsFromProjectionMatrix();
+  this->dataPtr->cameraIntrinsicMatrix = ignition::math::Matrix3d::Identity;
 }
 
 //////////////////////////////////////////////////
@@ -238,8 +237,8 @@ void Camera::UpdateCameraIntrinsics(
     _cameraIntrinsicsCx, _cameraIntrinsicsCy,
     _cameraIntrinsicsS, clipNear, clipFar);
   this->dataPtr->cameraIntrinsicMatrix = this->BuildIntrinsicMatrix(
-              _cameraIntrinsicsFx, _cameraIntrinsicsFy,
-              _cameraIntrinsicsCx, _cameraIntrinsicsCy);
+             _cameraIntrinsicsFx, _cameraIntrinsicsFy,
+             _cameraIntrinsicsCx, _cameraIntrinsicsCy);
 
   if (this->camera != nullptr)
   {
@@ -2196,8 +2195,8 @@ void Camera::CalculateIntrinsicsFromProjectionMatrix()
   double inverseWidth = 1.0 / (right - left);
   double inverseHeight = 1.0 / (top - bottom);
 
-  double fX = m(0, 0)/ 2*inverseWidth;
-  double fY = m(1, 1) / 2*inverseHeight;
+  double fX = m(0, 0)/ (2*inverseWidth);
+  double fY = m(1, 1) / (2*inverseHeight);
   double cX = -((m(0, 2) - ((right + left) / (right - left))) * (right - left)) / 2;
   double cY = this->imageHeight + ((m(1, 2) - ((top + bottom) / (top - bottom))) * (top - bottom)) / 2;
 

--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -237,7 +237,7 @@ void Camera::UpdateCameraIntrinsics(
     _cameraIntrinsicsFx, _cameraIntrinsicsFy,
     _cameraIntrinsicsCx, _cameraIntrinsicsCy,
     _cameraIntrinsicsS, clipNear, clipFar);
-  this->cameraIntrinsicMatrix = this->BuildIntrinsicMatrix(
+  this->dataPtr->cameraIntrinsicMatrix = this->BuildIntrinsicMatrix(
               _cameraIntrinsicsFx, _cameraIntrinsicsFy,
               _cameraIntrinsicsCx, _cameraIntrinsicsCy);
 
@@ -1120,25 +1120,25 @@ double Camera::FarClip() const
 //////////////////////////////////////////////////
 double Camera::FocalLengthX() const
 {
-  return this->cameraIntrinsicMatrix(0, 0);
+  return this->dataPtr->cameraIntrinsicMatrix(0, 0);
 }
 
 //////////////////////////////////////////////////
 double Camera::FocalLengthY() const
 {
-  return this->cameraIntrinsicMatrix(1, 1);
+  return this->dataPtr->cameraIntrinsicMatrix(1, 1);
 }
 
 //////////////////////////////////////////////////
 double Camera::OpticalCentreX() const
 {
-  return this->cameraIntrinsicMatrix(0, 2);
+  return this->dataPtr->cameraIntrinsicMatrix(0, 2);
 }
 
 //////////////////////////////////////////////////
 double Camera::OpticalCentreY() const
 {
-  return this->cameraIntrinsicMatrix(1, 3);
+  return this->dataPtr->cameraIntrinsicMatrix(1, 3);
 }
 
 //////////////////////////////////////////////////
@@ -2201,7 +2201,7 @@ void Camera::CalculateIntrinsicsFromProjectionMatrix()
   double cX = -((m(0, 2) - ((right + left) / (right - left))) * (right - left)) / 2;
   double cY = this->imageHeight + ((m(1, 2) - ((top + bottom) / (top - bottom))) * (top - bottom)) / 2;
 
-  this->cameraIntrinsicMatrix = this->BuildIntrinsicMatrix(
+  this->dataPtr->cameraIntrinsicMatrix = this->BuildIntrinsicMatrix(
       fX, fY, cX, cY);
 }
 

--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -2188,20 +2188,13 @@ void Camera::CalculateIntrinsicsFromProjectionMatrix()
 {
   const ignition::math::Matrix4d& projectionMat = this->ProjectionMatrix();
 
-  double right = this->imageWidth;
-  double left = 0.0;
-  double top = this->imageHeight;
-  double bottom = 0.0;
+  const double width = this->imageWidth;
+  const double height = this->imageHeight;
 
-  double inverseWidth = 1.0 / (right - left);
-  double inverseHeight = 1.0 / (top - bottom);
-
-  double fX = projectionMat(0, 0)/ (2*inverseWidth);
-  double fY = projectionMat(1, 1) / (2*inverseHeight);
-  double cX = -((projectionMat(0, 2) -
-            ((right + left) / (right - left))) * (right - left)) / 2;
-  double cY = this->imageHeight + ((projectionMat(1, 2) -
-            ((top + bottom) / (top - bottom))) * (top - bottom)) / 2;
+  double fX = (projectionMat(0, 0) * width) / 2;
+  double fY = (projectionMat(1, 1) * height) / 2;
+  double cX = -(width * (projectionMat(0, 2) - 1.0)) / 2;
+  double cY = height + (height * (projectionMat(1, 2) - 1.0)) / 2;
 
   this->dataPtr->cameraIntrinsicMatrix = this->BuildIntrinsicMatrix(
       fX, fY, cX, cY);

--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -1117,25 +1117,25 @@ double Camera::FarClip() const
 }
 
 //////////////////////////////////////////////////
-double Camera::FocalLengthX() const
+double Camera::ImageFocalLengthX() const
 {
   return this->dataPtr->cameraIntrinsicMatrix(0, 0);
 }
 
 //////////////////////////////////////////////////
-double Camera::FocalLengthY() const
+double Camera::ImageFocalLengthY() const
 {
   return this->dataPtr->cameraIntrinsicMatrix(1, 1);
 }
 
 //////////////////////////////////////////////////
-double Camera::OpticalCentreX() const
+double Camera::ImageOpticalCentreX() const
 {
   return this->dataPtr->cameraIntrinsicMatrix(0, 2);
 }
 
 //////////////////////////////////////////////////
-double Camera::OpticalCentreY() const
+double Camera::ImageOpticalCentreY() const
 {
   return this->dataPtr->cameraIntrinsicMatrix(1, 3);
 }

--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -245,6 +245,7 @@ void Camera::UpdateCameraIntrinsics(
     this->camera->setCustomProjectionMatrix(true,
         Conversions::Convert(this->cameraProjectiveMatrix));
   }
+
   this->cameraUsingIntrinsics = true;
 }
 
@@ -1129,15 +1130,15 @@ double Camera::ImageFocalLengthY() const
 }
 
 //////////////////////////////////////////////////
-double Camera::ImageOpticalCentreX() const
+double Camera::ImageOpticalCenterX() const
 {
   return this->dataPtr->cameraIntrinsicMatrix(0, 2);
 }
 
 //////////////////////////////////////////////////
-double Camera::ImageOpticalCentreY() const
+double Camera::ImageOpticalCenterY() const
 {
-  return this->dataPtr->cameraIntrinsicMatrix(1, 3);
+  return this->dataPtr->cameraIntrinsicMatrix(1, 2);
 }
 
 //////////////////////////////////////////////////
@@ -2185,7 +2186,7 @@ ignition::math::Matrix4d Camera::ProjectionMatrix() const
 ///////////////////////////////////////////////
 void Camera::CalculateIntrinsicsFromProjectionMatrix()
 {
-  const ignition::math::Matrix4d& m = this->ProjectionMatrix();
+  const ignition::math::Matrix4d& projectionMat = this->ProjectionMatrix();
 
   double right = this->imageWidth;
   double left = 0.0;
@@ -2195,10 +2196,12 @@ void Camera::CalculateIntrinsicsFromProjectionMatrix()
   double inverseWidth = 1.0 / (right - left);
   double inverseHeight = 1.0 / (top - bottom);
 
-  double fX = m(0, 0)/ (2*inverseWidth);
-  double fY = m(1, 1) / (2*inverseHeight);
-  double cX = -((m(0, 2) - ((right + left) / (right - left))) * (right - left)) / 2;
-  double cY = this->imageHeight + ((m(1, 2) - ((top + bottom) / (top - bottom))) * (top - bottom)) / 2;
+  double fX = projectionMat(0, 0)/ (2*inverseWidth);
+  double fY = projectionMat(1, 1) / (2*inverseHeight);
+  double cX = -((projectionMat(0, 2) -
+            ((right + left) / (right - left))) * (right - left)) / 2;
+  double cY = this->imageHeight + ((projectionMat(1, 2) -
+            ((top + bottom) / (top - bottom))) * (top - bottom)) / 2;
 
   this->dataPtr->cameraIntrinsicMatrix = this->BuildIntrinsicMatrix(
       fX, fY, cX, cY);

--- a/gazebo/rendering/Camera.hh
+++ b/gazebo/rendering/Camera.hh
@@ -907,8 +907,8 @@ namespace gazebo
 
       /// \brief Calculates the focal length and optical center by decoupling the
       ///        projection matrix returned from ProjectionMatrix().
-      ///        This function sets focalLengthX, focalLengthY, opticalCentreX
-      ///        and opticalCentreY variables of the class.
+      ///        This function sets the intrinsic calibration matrix using
+      ///        BuildIntrinsicMatrix() function of this class.
       private: void CalculateIntrinsicsFromProjectionMatrix();
 
       /// \brief Name of the camera.

--- a/gazebo/rendering/Camera.hh
+++ b/gazebo/rendering/Camera.hh
@@ -206,14 +206,6 @@ namespace gazebo
               const double _intrinsicsS,
               const double _clipNear, const double _clipFar);
 
-      /// \brief Compute the intrinsic camera matrix, this matrix is different
-      ///        than the one used by OpenGL internally and contains the camera
-      ///        calibrated values
-      /// \return intrinsic matrix
-      private: ignition::math::Matrix3d BuildIntrinsicMatrix(
-              const double _intrinsicsFx, const double _intrinsicsFy,
-              const double _intrinsicsCx, double _intrinsicsCy);
-
       /// \brief Initialize the camera
       public: virtual void Init();
 
@@ -411,11 +403,11 @@ namespace gazebo
 
       /// \brief Get the X principal point in pixels
       /// \return X principal point in pixels
-      public: double ImageOpticalCentreX() const;
+      public: double ImageOpticalCenterX() const;
 
       /// \brief Get the Y principal point in pixels
       /// \return Y principal point in pixels
-      public: double ImageOpticalCentreY() const;
+      public: double ImageOpticalCenterY() const;
 
       /// \brief Enable or disable saving
       /// \param[in] _enable Set to True to enable saving of frames
@@ -904,6 +896,14 @@ namespace gazebo
 
       /// \brief Create the ogre camera.
       private: void CreateCamera();
+
+      /// \brief Compute the intrinsic camera matrix, this matrix is different
+      ///        than the one used by OpenGL internally and contains the camera
+      ///        calibrated values
+      /// \return intrinsic matrix
+      private: ignition::math::Matrix3d BuildIntrinsicMatrix(
+          const double _intrinsicsFx, const double _intrinsicsFy,
+          const double _intrinsicsCx, double _intrinsicsCy);
 
       /// \brief Calculates the focal length and optical center by decoupling the
       ///        projection matrix returned from ProjectionMatrix().

--- a/gazebo/rendering/Camera.hh
+++ b/gazebo/rendering/Camera.hh
@@ -941,9 +941,6 @@ namespace gazebo
       /// \brief Flag for signaling the usage of camera intrinsics within OGRE
       protected: bool cameraUsingIntrinsics;
 
-      /// \brief Camera Intrinsic Matrix
-      protected: ignition::math::Matrix3d cameraIntrinsicMatrix;
-
       /// \brief Viewport the ogre camera uses.
       protected: Ogre::Viewport *viewport;
 

--- a/gazebo/rendering/Camera.hh
+++ b/gazebo/rendering/Camera.hh
@@ -206,6 +206,14 @@ namespace gazebo
               const double _intrinsicsS,
               const double _clipNear, const double _clipFar);
 
+      /// \brief Compute the intrinsic camera matrix, this matrix is different
+      ///        than the one used by OpenGL internally and contains the camera
+      ///        calibrated values
+      /// \return intrinsic matrix
+      private: ignition::math::Matrix3d BuildIntrinsicMatrix(
+              const double _intrinsicsFx, const double _intrinsicsFy,
+              const double _intrinsicsCx, double _intrinsicsCy);
+
       /// \brief Initialize the camera
       public: virtual void Init();
 
@@ -392,6 +400,22 @@ namespace gazebo
       /// \brief Get the far clip distance
       /// \return Far clip distance
       public: double FarClip() const;
+
+      /// \brief  Get the X focal length in pixels
+      /// \return X focal length in pixels
+      public: double FocalLengthX() const;
+
+      /// \brief Get the Y focal length in pixels
+      /// \return Y focal length in pixels
+      public: double FocalLengthY() const;
+
+      /// \brief Get the X principal point in pixels
+      /// \return X principal point in pixels
+      public: double OpticalCentreX() const;
+
+      /// \brief Get the Y principal point in pixels
+      /// \return Y principal point in pixels
+      public: double OpticalCentreY() const;
 
       /// \brief Enable or disable saving
       /// \param[in] _enable Set to True to enable saving of frames
@@ -881,6 +905,12 @@ namespace gazebo
       /// \brief Create the ogre camera.
       private: void CreateCamera();
 
+      /// \brief Calculates the focal length and optical center by decoupling the
+      ///        projection matrix returned from ProjectionMatrix().
+      ///        This function sets focalLengthX, focalLengthY, opticalCentreX
+      ///        and opticalCentreY variables of the class.
+      private: void CalculateIntrinsicsFromProjectionMatrix();
+
       /// \brief Name of the camera.
       protected: std::string name;
 
@@ -910,6 +940,9 @@ namespace gazebo
 
       /// \brief Flag for signaling the usage of camera intrinsics within OGRE
       protected: bool cameraUsingIntrinsics;
+
+      /// \brief Camera Intrinsic Matrix
+      protected: ignition::math::Matrix3d cameraIntrinsicMatrix;
 
       /// \brief Viewport the ogre camera uses.
       protected: Ogre::Viewport *viewport;

--- a/gazebo/rendering/Camera.hh
+++ b/gazebo/rendering/Camera.hh
@@ -403,19 +403,19 @@ namespace gazebo
 
       /// \brief  Get the X focal length in pixels
       /// \return X focal length in pixels
-      public: double FocalLengthX() const;
+      public: double ImageFocalLengthX() const;
 
       /// \brief Get the Y focal length in pixels
       /// \return Y focal length in pixels
-      public: double FocalLengthY() const;
+      public: double ImageFocalLengthY() const;
 
       /// \brief Get the X principal point in pixels
       /// \return X principal point in pixels
-      public: double OpticalCentreX() const;
+      public: double ImageOpticalCentreX() const;
 
       /// \brief Get the Y principal point in pixels
       /// \return Y principal point in pixels
-      public: double OpticalCentreY() const;
+      public: double ImageOpticalCentreY() const;
 
       /// \brief Enable or disable saving
       /// \param[in] _enable Set to True to enable saving of frames

--- a/gazebo/rendering/CameraPrivate.hh
+++ b/gazebo/rendering/CameraPrivate.hh
@@ -120,6 +120,9 @@ namespace gazebo
 
       /// \brief Anti-aliasing value
       public: uint32_t antiAliasingValue;
+
+      /// \brief Camera Intrinsic Matrix
+      public: ignition::math::Matrix3d cameraIntrinsicMatrix;
     };
   }
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -234,6 +234,8 @@ set(qt_tests
 gz_build_qt_tests(${qt_tests})
 
 if (VALID_DRI_DISPLAY)
+  add_dependencies(${TEST_TYPE}_camera_sensor AmbientOcclusionVisualPlugin)
+  add_dependencies(${TEST_TYPE}_camera_sensor LensFlareSensorPlugin)
   add_dependencies(${TEST_TYPE}_heightmap HeightmapLODPlugin)
   # Increase timeout, to account for model download time.
   set_tests_properties(${TEST_TYPE}_factory PROPERTIES TIMEOUT 500)

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2270,6 +2270,8 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
 }
 
 /////////////////////////////////////////////////
+// Test fails on macOS CI
+#ifndef __APPLE__
 TEST_F(CameraSensor, CheckIntrinsics)
 {
   Load("worlds/camera_intrinsics_test.world");
@@ -2425,3 +2427,4 @@ TEST_F(CameraSensor, CheckIntrinsics)
   delete[] img2;
   delete[] img3;
 }
+#endif

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2298,10 +2298,10 @@ TEST_F(CameraSensor, CheckIntrinsics)
   unsigned int defaultCamWidth = defaultIntrinsicsCam->ImageWidth();
   unsigned int defaultCamHeight = defaultIntrinsicsCam->ImageHeight();
   {
-    double defaultCamFx = defaultIntrinsicsCam->FocalLengthX();
-    double defaultCamFy = defaultIntrinsicsCam->FocalLengthY();
-    double defaultCamCx = defaultIntrinsicsCam->OpticalCentreX();
-    double defaultCamCy = defaultIntrinsicsCam->OpticalCentreY();
+    double defaultCamFx = defaultIntrinsicsCam->ImageFocalLengthX();
+    double defaultCamFy = defaultIntrinsicsCam->ImageFocalLengthY();
+    double defaultCamCx = defaultIntrinsicsCam->ImageOpticalCentreX();
+    double defaultCamCy = defaultIntrinsicsCam->ImageOpticalCentreY();
 
     EXPECT_GT(defaultCamWidth, 0u);
     EXPECT_GT(defaultCamHeight, 0u);
@@ -2328,10 +2328,10 @@ TEST_F(CameraSensor, CheckIntrinsics)
   unsigned int camWidth = intrinsicsCam->ImageWidth();
   unsigned int camHeight = intrinsicsCam->ImageHeight();
   {
-    double camFx = intrinsicsCam->FocalLengthX();
-    double camFy = intrinsicsCam->FocalLengthY();
-    double camCx = intrinsicsCam->OpticalCentreX();
-    double camCy = intrinsicsCam->OpticalCentreY();
+    double camFx = intrinsicsCam->ImageFocalLengthX();
+    double camFy = intrinsicsCam->ImageFocalLengthY();
+    double camCx = intrinsicsCam->ImageOpticalCentreX();
+    double camCy = intrinsicsCam->ImageOpticalCentreY();
 
     EXPECT_GT(camWidth, 0u);
     EXPECT_GT(camHeight, 0u);

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2293,7 +2293,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
   rendering::CameraPtr defaultIntrinsicsCam = defaultIntrinsicsCamSensor->Camera();
   EXPECT_TRUE(defaultIntrinsicsCam != nullptr);
 
-  // image size, focal length and optical centre for 'default_intrinsics_camera' sensor
+  // Image size, focal length and optical centre for 'default_intrinsics_camera' sensor
   unsigned int defaultCamWidth = defaultIntrinsicsCam->ImageWidth();
   unsigned int defaultCamHeight = defaultIntrinsicsCam->ImageHeight();
   double defaultCamFx = defaultIntrinsicsCam->ImageFocalLengthX();
@@ -2318,7 +2318,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
   rendering::CameraPtr intrinsicsCam = intrinsicsCamSensor->Camera();
   EXPECT_TRUE(intrinsicsCam != nullptr);
 
-  // image size, focal length and optical centre for 'intrinsics_camera' sensor
+  // Image size, focal length and optical centre for 'intrinsics_camera' sensor
   unsigned int  intrinsicsCamWidth = intrinsicsCam->ImageWidth();
   unsigned int  intrinsicsCamHeight = intrinsicsCam->ImageHeight();
   double intrinsicsCamFx = intrinsicsCam->ImageFocalLengthX();
@@ -2341,7 +2341,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
   rendering::CameraPtr cam = camSensor->Camera();
   EXPECT_TRUE(cam != nullptr);
 
-  // image size, focal length and optical centre for 'camera' sensor
+  // Image size, focal length and optical centre for 'camera' sensor
   unsigned int camWidth = cam->ImageWidth();
   unsigned int camHeight = cam->ImageHeight();
   double camFx = cam->ImageFocalLengthX();

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -1412,124 +1412,6 @@ TEST_F(CameraSensor, LensFlare)
 }
 
 /////////////////////////////////////////////////
-TEST_F(CameraSensor, Intrinsics)
-{
-  Load("worlds/camera_intrinsics_test.world");
-  physics::WorldPtr world = physics::get_world("default");
-  ASSERT_TRUE(world != NULL);
-
-  // Make sure the render engine is available.
-  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
-      rendering::RenderEngine::NONE)
-  {
-    gzerr << "No rendering engine, unable to run camera test\n";
-    return;
-  }
-
-  // get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor
-  // and we expect the intrinsics to be equal to the default intrinsic values provided by gazebo.
-  std::string defaultIntrinsicsCameraName = "default_intrinsics_camera_sensor";
-  sensors::SensorPtr defaultIntrinsicsSensor = sensors::get_sensor(defaultIntrinsicsCameraName);
-  sensors::CameraSensorPtr defaultIntrinsicsCamSensor =
-    std::dynamic_pointer_cast<sensors::CameraSensor>(defaultIntrinsicsSensor);
-  EXPECT_TRUE(defaultIntrinsicsCamSensor != nullptr);
-  rendering::CameraPtr defaultIntrinsicsCam = defaultIntrinsicsCamSensor->Camera();
-  EXPECT_TRUE(defaultIntrinsicsCam != nullptr);
-
-  // image size, focal length and optical centre for 'default_intrinsics_camera' sensor
-  unsigned int defaultCamWidth = defaultIntrinsicsCam->ImageWidth();
-  unsigned int defaultCamHeight = defaultIntrinsicsCam->ImageHeight();
-  {
-    double defaultCamFx = defaultIntrinsicsCam->FocalLengthX();
-    double defaultCamFy = defaultIntrinsicsCam->FocalLengthY();
-    double defaultCamCx = defaultIntrinsicsCam->OpticalCentreX();
-    double defaultCamCy = defaultIntrinsicsCam->OpticalCentreY();
-
-    EXPECT_GT(defaultCamWidth, 0u);
-    EXPECT_GT(defaultCamHeight, 0u);
-    EXPECT_EQ(defaultCamWidth, 320u);
-    EXPECT_EQ(defaultCamHeight, 240u);
-    double error = 0.0005;
-    EXPECT_NEAR(defaultCamFx, 277.127, error);
-    EXPECT_NEAR(defaultCamFy, 277.127, error);
-    EXPECT_DOUBLE_EQ(defaultCamCx, 160);
-    EXPECT_DOUBLE_EQ(defaultCamCy, 120);
-  }
-
-  // get the 'intrinsics_camera' sensor, <intrinsics> tag is used explicitly for this sensor
-  // where the intrinsics provided are same as gazebo default.
-  std::string intrinsicsCameraName = "intrinsics_camera_sensor";
-  sensors::SensorPtr intrinsicsSensor = sensors::get_sensor(intrinsicsCameraName);
-  sensors::CameraSensorPtr intrinsicsCamSensor =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(intrinsicsSensor);
-  EXPECT_TRUE(intrinsicsCamSensor != nullptr);
-  rendering::CameraPtr intrinsicsCam = intrinsicsCamSensor->Camera();
-  EXPECT_TRUE(intrinsicsCam != nullptr);
-
-  // image size, focal length and optical centre for 'intrinsics_camera_sensor' sensor
-  unsigned int camWidth = intrinsicsCam->ImageWidth();
-  unsigned int camHeight = intrinsicsCam->ImageHeight();
-  {
-    double camFx = intrinsicsCam->FocalLengthX();
-    double camFy = intrinsicsCam->FocalLengthY();
-    double camCx = intrinsicsCam->OpticalCentreX();
-    double camCy = intrinsicsCam->OpticalCentreY();
-
-    EXPECT_GT(camWidth, 0u);
-    EXPECT_GT(camHeight, 0u);
-    EXPECT_EQ(camWidth, 320u);
-    EXPECT_EQ(camHeight, 240u);
-    EXPECT_DOUBLE_EQ(camFx, 277);
-    EXPECT_DOUBLE_EQ(camFy, 277);
-    EXPECT_DOUBLE_EQ(camCx, 160);
-    EXPECT_DOUBLE_EQ(camCy, 120);
-  }
-
-  // connect to new frame event
-  imageCount = 0;
-  imageCount2 = 0;
-  img = new unsigned char[camWidth * camHeight * 3 * 2];
-  img2 = new unsigned char[camWidth * camHeight * 3 * 2];
-
-  event::ConnectionPtr c =
-      defaultIntrinsicsCamSensor->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount, img,
-                    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-                    std::placeholders::_4, std::placeholders::_5));
-
-  event::ConnectionPtr c2 =
-      intrinsicsCamSensor->Camera()->ConnectNewImageFrame(
-          std::bind(&::OnNewCameraFrame, &imageCount2, img2,
-                    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
-                    std::placeholders::_4, std::placeholders::_5));
-
-  // wait for a few images
-  int sleep = 0;
-  int maxSleep = 500;
-  int totalImages = 10;
-  while ((imageCount < totalImages || imageCount2 < totalImages)
-      && sleep++ < maxSleep)
-    common::Time::MSleep(10);
-
-  EXPECT_GE(imageCount, totalImages);
-  EXPECT_GE(imageCount2, totalImages);
-
-  c.reset();
-  c2.reset();
-
-  unsigned int diffMax = 0, diffSum = 0;
-  double diffAvg = 0.0;
-
-  // We expect that there will be zero difference between the images
-  this->ImageCompare(img, img2, camWidth, camHeight, 3,
-                     diffMax, diffSum, diffAvg);
-  EXPECT_EQ(diffSum, 0u);
-
-  delete[] img;
-  delete[] img2;
-}
-
-/////////////////////////////////////////////////
 TEST_F(CameraSensor, 16bit)
 {
   // World contains a box positioned at top right quadrant of image generated
@@ -2385,4 +2267,122 @@ TEST_F(CameraSensor, CheckNewAndLegacyDistortionModes)
   delete[] img2;
   delete[] img3;
   delete[] img4;
+}
+
+/////////////////////////////////////////////////
+TEST_F(CameraSensor, CheckIntrinsics)
+{
+  Load("worlds/camera_intrinsics_test.world");
+  physics::WorldPtr world = physics::get_world("default");
+  ASSERT_TRUE(world != NULL);
+
+  // Make sure the render engine is available.
+  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
+      rendering::RenderEngine::NONE)
+  {
+    gzerr << "No rendering engine, unable to run camera test\n";
+    return;
+  }
+
+  // get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor
+  // and we expect the intrinsics to be equal to the default intrinsic values provided by gazebo.
+  std::string defaultIntrinsicsCameraName = "default_intrinsics_camera_sensor";
+  sensors::SensorPtr defaultIntrinsicsSensor = sensors::get_sensor(defaultIntrinsicsCameraName);
+  sensors::CameraSensorPtr defaultIntrinsicsCamSensor =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(defaultIntrinsicsSensor);
+  EXPECT_TRUE(defaultIntrinsicsCamSensor != nullptr);
+  rendering::CameraPtr defaultIntrinsicsCam = defaultIntrinsicsCamSensor->Camera();
+  EXPECT_TRUE(defaultIntrinsicsCam != nullptr);
+
+  // image size, focal length and optical centre for 'default_intrinsics_camera' sensor
+  unsigned int defaultCamWidth = defaultIntrinsicsCam->ImageWidth();
+  unsigned int defaultCamHeight = defaultIntrinsicsCam->ImageHeight();
+  {
+    double defaultCamFx = defaultIntrinsicsCam->FocalLengthX();
+    double defaultCamFy = defaultIntrinsicsCam->FocalLengthY();
+    double defaultCamCx = defaultIntrinsicsCam->OpticalCentreX();
+    double defaultCamCy = defaultIntrinsicsCam->OpticalCentreY();
+
+    EXPECT_GT(defaultCamWidth, 0u);
+    EXPECT_GT(defaultCamHeight, 0u);
+    EXPECT_EQ(defaultCamWidth, 320u);
+    EXPECT_EQ(defaultCamHeight, 240u);
+    double error = 0.0005;
+    EXPECT_NEAR(defaultCamFx, 277.127, error);
+    EXPECT_NEAR(defaultCamFy, 277.127, error);
+    EXPECT_DOUBLE_EQ(defaultCamCx, 160);
+    EXPECT_DOUBLE_EQ(defaultCamCy, 120);
+  }
+
+  // get the 'intrinsics_camera' sensor, <intrinsics> tag is used explicitly for this sensor
+  // where the intrinsics provided are same as gazebo default.
+  std::string intrinsicsCameraName = "intrinsics_camera_sensor";
+  sensors::SensorPtr intrinsicsSensor = sensors::get_sensor(intrinsicsCameraName);
+  sensors::CameraSensorPtr intrinsicsCamSensor =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(intrinsicsSensor);
+  EXPECT_TRUE(intrinsicsCamSensor != nullptr);
+  rendering::CameraPtr intrinsicsCam = intrinsicsCamSensor->Camera();
+  EXPECT_TRUE(intrinsicsCam != nullptr);
+
+  // image size, focal length and optical centre for 'intrinsics_camera_sensor' sensor
+  unsigned int camWidth = intrinsicsCam->ImageWidth();
+  unsigned int camHeight = intrinsicsCam->ImageHeight();
+  {
+    double camFx = intrinsicsCam->FocalLengthX();
+    double camFy = intrinsicsCam->FocalLengthY();
+    double camCx = intrinsicsCam->OpticalCentreX();
+    double camCy = intrinsicsCam->OpticalCentreY();
+
+    EXPECT_GT(camWidth, 0u);
+    EXPECT_GT(camHeight, 0u);
+    EXPECT_EQ(camWidth, 320u);
+    EXPECT_EQ(camHeight, 240u);
+    EXPECT_DOUBLE_EQ(camFx, 277);
+    EXPECT_DOUBLE_EQ(camFy, 277);
+    EXPECT_DOUBLE_EQ(camCx, 160);
+    EXPECT_DOUBLE_EQ(camCy, 120);
+  }
+
+  // connect to new frame event
+  imageCount = 0;
+  imageCount2 = 0;
+  img = new unsigned char[camWidth * camHeight * 3 * 2];
+  img2 = new unsigned char[camWidth * camHeight * 3 * 2];
+
+  event::ConnectionPtr c =
+      defaultIntrinsicsCamSensor->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount, img,
+                    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+                    std::placeholders::_4, std::placeholders::_5));
+
+  event::ConnectionPtr c2 =
+      intrinsicsCamSensor->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount2, img2,
+                    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+                    std::placeholders::_4, std::placeholders::_5));
+
+  // wait for a few images
+  int sleep = 0;
+  int maxSleep = 500;
+  int totalImages = 10;
+  while ((imageCount < totalImages || imageCount2 < totalImages)
+      && sleep++ < maxSleep)
+    common::Time::MSleep(10);
+
+  EXPECT_GE(imageCount, totalImages);
+  EXPECT_GE(imageCount2, totalImages);
+
+  c.reset();
+  c2.reset();
+
+  unsigned int diffMax = 0, diffSum = 0;
+  double diffAvg = 0.0;
+
+  // We expect that there will be zero difference between the images
+  this->ImageCompare(img, img2, camWidth, camHeight, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_EQ(diffSum, 0u);
+
+  delete[] img;
+  delete[] img2;
 }

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2284,99 +2284,106 @@ TEST_F(CameraSensor, CheckIntrinsics)
     return;
   }
 
-  // Get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor,
+  // Get the 'camera_without_intrinsics' sensor, no <intrinsics> tag is used for this sensor,
   // and we expect the intrinsics to be equal to the default intrinsic values provided by gazebo.
-  sensors::SensorPtr defaultIntrinsicsSensor = sensors::get_sensor("default_intrinsics_camera_sensor");
-  sensors::CameraSensorPtr defaultIntrinsicsCamSensor =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(defaultIntrinsicsSensor);
-  EXPECT_TRUE(defaultIntrinsicsCamSensor != nullptr);
-  rendering::CameraPtr defaultIntrinsicsCam = defaultIntrinsicsCamSensor->Camera();
-  EXPECT_TRUE(defaultIntrinsicsCam != nullptr);
+  sensors::SensorPtr camWithoutIntrinsicsSensorPtr =
+      sensors::get_sensor("camera_without_intrinsics_sensor");
+  sensors::CameraSensorPtr camWithoutIntrinsicsCameraSensorPtr =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(camWithoutIntrinsicsSensorPtr);
+  EXPECT_TRUE(camWithoutIntrinsicsCameraSensorPtr != nullptr);
+  rendering::CameraPtr camWithoutIntrinsicsCameraPtr =
+      camWithoutIntrinsicsCameraSensorPtr->Camera();
+  EXPECT_TRUE(camWithoutIntrinsicsCameraPtr != nullptr);
 
-  // Image size, focal length and optical centre for 'default_intrinsics_camera' sensor
-  unsigned int defaultCamWidth = defaultIntrinsicsCam->ImageWidth();
-  unsigned int defaultCamHeight = defaultIntrinsicsCam->ImageHeight();
-  double defaultCamFx = defaultIntrinsicsCam->ImageFocalLengthX();
-  double defaultCamFy = defaultIntrinsicsCam->ImageFocalLengthY();
-  double defaultCamCx = defaultIntrinsicsCam->ImageOpticalCenterX();
-  double defaultCamCy = defaultIntrinsicsCam->ImageOpticalCenterY();
+  // Image size, focal length and optical centre for 'camera_without_intrinsics' sensor
+  unsigned int camWithoutIntrinsicsWidth = camWithoutIntrinsicsCameraPtr->ImageWidth();
+  unsigned int camWithoutIntrinsicsHeight = camWithoutIntrinsicsCameraPtr->ImageHeight();
+  double camWithoutIntrinsicsFx = camWithoutIntrinsicsCameraPtr->ImageFocalLengthX();
+  double camWithoutIntrinsicsFy = camWithoutIntrinsicsCameraPtr->ImageFocalLengthY();
+  double camWithoutIntrinsicsCx = camWithoutIntrinsicsCameraPtr->ImageOpticalCenterX();
+  double camWithoutIntrinsicsCy = camWithoutIntrinsicsCameraPtr->ImageOpticalCenterY();
 
-  EXPECT_EQ(defaultCamWidth, 320u);
-  EXPECT_EQ(defaultCamHeight, 240u);
+  EXPECT_EQ(camWithoutIntrinsicsWidth, 320u);
+  EXPECT_EQ(camWithoutIntrinsicsHeight, 240u);
   double error = 0.0005;
-  EXPECT_NEAR(defaultCamFx, 277.127, error);
-  EXPECT_NEAR(defaultCamFy, 277.127, error);
-  EXPECT_DOUBLE_EQ(defaultCamCx, 160);
-  EXPECT_DOUBLE_EQ(defaultCamCy, 120);
+  EXPECT_NEAR(camWithoutIntrinsicsFx, 277.127, error);
+  EXPECT_NEAR(camWithoutIntrinsicsFy, 277.127, error);
+  EXPECT_DOUBLE_EQ(camWithoutIntrinsicsCx, 160);
+  EXPECT_DOUBLE_EQ(camWithoutIntrinsicsCy, 120);
 
-  // Get the 'intrinsics_camera' sensor, <intrinsics> tag is used explicitly for this sensor
-  // where the intrinsics provided are same as gazebo default.
-  sensors::SensorPtr intrinsicsSensor = sensors::get_sensor("intrinsics_camera_sensor");
-  sensors::CameraSensorPtr intrinsicsCamSensor =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(intrinsicsSensor);
-  EXPECT_TRUE(intrinsicsCamSensor != nullptr);
-  rendering::CameraPtr intrinsicsCam = intrinsicsCamSensor->Camera();
-  EXPECT_TRUE(intrinsicsCam != nullptr);
+  // Get the 'camera_default_intrinsics' sensor, <intrinsics> tag is used explicitly for this
+  // sensor where the intrinsics provided are same as gazebo default.
+  sensors::SensorPtr camDefaultIntrinsicsSensorPtr =
+      sensors::get_sensor("camera_default_intrinsics_sensor");
+  sensors::CameraSensorPtr camDefaultIntrinsicsCameraSensorPtr =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(camDefaultIntrinsicsSensorPtr);
+  EXPECT_TRUE(camDefaultIntrinsicsCameraSensorPtr != nullptr);
+  rendering::CameraPtr camDefaultIntrinsicsCameraPtr =
+      camDefaultIntrinsicsCameraSensorPtr->Camera();
+  EXPECT_TRUE(camDefaultIntrinsicsCameraPtr != nullptr);
 
-  // Image size, focal length and optical centre for 'intrinsics_camera' sensor
-  unsigned int  intrinsicsCamWidth = intrinsicsCam->ImageWidth();
-  unsigned int  intrinsicsCamHeight = intrinsicsCam->ImageHeight();
-  double intrinsicsCamFx = intrinsicsCam->ImageFocalLengthX();
-  double intrinsicsCamFy = intrinsicsCam->ImageFocalLengthY();
-  double intrinsicsCamCx = intrinsicsCam->ImageOpticalCenterX();
-  double intrinsicsCamCy = intrinsicsCam->ImageOpticalCenterY();
-  EXPECT_EQ(intrinsicsCamWidth, 320u);
-  EXPECT_EQ(intrinsicsCamHeight, 240u);
-  EXPECT_DOUBLE_EQ(intrinsicsCamFx, 277);
-  EXPECT_DOUBLE_EQ(intrinsicsCamFy, 277);
-  EXPECT_DOUBLE_EQ(intrinsicsCamCx, 160);
-  EXPECT_DOUBLE_EQ(intrinsicsCamCy, 120);
+  // Image size, focal length and optical centre for 'camera_default_intrinsics' sensor
+  unsigned int  camDefaultIntrinsicsWidth = camDefaultIntrinsicsCameraPtr->ImageWidth();
+  unsigned int  camDefaultIntrinsicsHeight = camDefaultIntrinsicsCameraPtr->ImageHeight();
+  double camDefaultIntrinsicsFx = camDefaultIntrinsicsCameraPtr->ImageFocalLengthX();
+  double camDefaultIntrinsicsFy = camDefaultIntrinsicsCameraPtr->ImageFocalLengthY();
+  double camDefaultIntrinsicsCx = camDefaultIntrinsicsCameraPtr->ImageOpticalCenterX();
+  double camDefaultIntrinsicsCy = camDefaultIntrinsicsCameraPtr->ImageOpticalCenterY();
+  EXPECT_EQ(camDefaultIntrinsicsWidth, 320u);
+  EXPECT_EQ(camDefaultIntrinsicsHeight, 240u);
+  EXPECT_DOUBLE_EQ(camDefaultIntrinsicsFx, 277);
+  EXPECT_DOUBLE_EQ(camDefaultIntrinsicsFy, 277);
+  EXPECT_DOUBLE_EQ(camDefaultIntrinsicsCx, 160);
+  EXPECT_DOUBLE_EQ(camDefaultIntrinsicsCy, 120);
 
-  // Get the 'camera' sensor, <intrinsics> tag is used explicitly for this sensor
-  // where the intrinsics provided are different from the gazebo default.
-  sensors::SensorPtr sensor = sensors::get_sensor("camera_sensor");
-  sensors::CameraSensorPtr camSensor =
-      std::dynamic_pointer_cast<sensors::CameraSensor>(sensor);
-  EXPECT_TRUE(camSensor != nullptr);
-  rendering::CameraPtr cam = camSensor->Camera();
-  EXPECT_TRUE(cam != nullptr);
+  // Get the 'camera_custom_intrinsics' sensor, <intrinsics> tag is used explicitly for this
+  // sensor where the intrinsics provided are different from the gazebo default.
+  sensors::SensorPtr camCustomIntrinsicsSensorPtr =
+      sensors::get_sensor("camera_custom_intrinsics_sensor");
+  sensors::CameraSensorPtr camCustomIntrinsicsCameraSensorPtr =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(camCustomIntrinsicsSensorPtr);
+  EXPECT_TRUE(camCustomIntrinsicsCameraSensorPtr != nullptr);
+  rendering::CameraPtr camCustomIntrinsicsCameraPtr =
+      camCustomIntrinsicsCameraSensorPtr->Camera();
+  EXPECT_TRUE(camCustomIntrinsicsCameraPtr != nullptr);
 
-  // Image size, focal length and optical centre for 'camera' sensor
-  unsigned int camWidth = cam->ImageWidth();
-  unsigned int camHeight = cam->ImageHeight();
-  double camFx = cam->ImageFocalLengthX();
-  double camFy = cam->ImageFocalLengthY();
-  double camCx = cam->ImageOpticalCenterX();
-  double camCy = cam->ImageOpticalCenterY();
-  EXPECT_EQ(camWidth, 320u);
-  EXPECT_EQ(camHeight, 240u);
-  EXPECT_DOUBLE_EQ(camFx, 320);
-  EXPECT_DOUBLE_EQ(camFy, 320);
-  EXPECT_DOUBLE_EQ(camCx, 160);
-  EXPECT_DOUBLE_EQ(camCy, 120);
+  // Image size, focal length and optical centre for 'camera_custom_intrinsics' sensor
+  unsigned int camCustomIntrinsicsWidth = camCustomIntrinsicsCameraPtr->ImageWidth();
+  unsigned int camCustomIntrinsicsHeight = camCustomIntrinsicsCameraPtr->ImageHeight();
+  double camCustomIntrinsicsFx = camCustomIntrinsicsCameraPtr->ImageFocalLengthX();
+  double camCustomIntrinsicsFy = camCustomIntrinsicsCameraPtr->ImageFocalLengthY();
+  double camCustomIntrinsicsCx = camCustomIntrinsicsCameraPtr->ImageOpticalCenterX();
+  double camCustomIntrinsicsCy = camCustomIntrinsicsCameraPtr->ImageOpticalCenterY();
+  EXPECT_EQ(camCustomIntrinsicsWidth, 320u);
+  EXPECT_EQ(camCustomIntrinsicsHeight, 240u);
+  EXPECT_DOUBLE_EQ(camCustomIntrinsicsFx, 320);
+  EXPECT_DOUBLE_EQ(camCustomIntrinsicsFy, 320);
+  EXPECT_DOUBLE_EQ(camCustomIntrinsicsCx, 160);
+  EXPECT_DOUBLE_EQ(camCustomIntrinsicsCy, 120);
 
   // Connect to new frame event
   imageCount = 0;
   imageCount2 = 0;
   imageCount3 = 0;
-  img = new unsigned char[camWidth * camHeight * 3 * 2];
-  img2 = new unsigned char[camWidth * camHeight * 3 * 2];
-  img3 = new unsigned char[camWidth * camHeight * 3 * 2];
+  // Image size is same for all three cameras
+  img = new unsigned char[camCustomIntrinsicsWidth * camCustomIntrinsicsHeight * 3 * 2];
+  img2 = new unsigned char[camCustomIntrinsicsWidth * camCustomIntrinsicsHeight * 3 * 2];
+  img3 = new unsigned char[camCustomIntrinsicsWidth * camCustomIntrinsicsHeight * 3 * 2];
 
   event::ConnectionPtr c =
-      defaultIntrinsicsCamSensor->Camera()->ConnectNewImageFrame(
+      camWithoutIntrinsicsCameraSensorPtr->Camera()->ConnectNewImageFrame(
           std::bind(&::OnNewCameraFrame, &imageCount, img,
                     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                     std::placeholders::_4, std::placeholders::_5));
 
   event::ConnectionPtr c2 =
-      intrinsicsCamSensor->Camera()->ConnectNewImageFrame(
+      camDefaultIntrinsicsCameraSensorPtr->Camera()->ConnectNewImageFrame(
           std::bind(&::OnNewCameraFrame, &imageCount2, img2,
                     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                     std::placeholders::_4, std::placeholders::_5));
 
   event::ConnectionPtr c3 =
-      camSensor->Camera()->ConnectNewImageFrame(
+      camCustomIntrinsicsCameraSensorPtr->Camera()->ConnectNewImageFrame(
           std::bind(&::OnNewCameraFrame, &imageCount3, img3,
                     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                     std::placeholders::_4, std::placeholders::_5));
@@ -2402,14 +2409,16 @@ TEST_F(CameraSensor, CheckIntrinsics)
 
   // We expect that there will be zero difference between the images img and img2 since
   // they use the same default intrinsics.
-  this->ImageCompare(img, img2, camWidth, camHeight, 3,
-                     diffMax, diffSum, diffAvg);
+  this->ImageCompare(img, img2, camCustomIntrinsicsWidth,
+                     camCustomIntrinsicsHeight, 3, diffMax, diffSum,
+                     diffAvg);
   EXPECT_EQ(diffSum, 0u);
 
   // We expect that there will be non-zero difference between the images img2 and img3
   // since they use different intrinsics
-  this->ImageCompare(img2, img3, camWidth, camHeight, 3,
-                     diffMax, diffSum, diffAvg);
+  this->ImageCompare(img2, img3, camCustomIntrinsicsWidth,
+                     camCustomIntrinsicsHeight, 3, diffMax, diffSum,
+                     diffAvg);
   EXPECT_NE(diffSum, 0u);
 
   delete[] img;

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -1412,6 +1412,86 @@ TEST_F(CameraSensor, LensFlare)
 }
 
 /////////////////////////////////////////////////
+TEST_F(CameraSensor, Intrinsics)
+{
+  Load("worlds/camera_intrinsics_test.world");
+  physics::WorldPtr world = physics::get_world("default");
+  ASSERT_TRUE(world != NULL);
+
+  // Make sure the render engine is available.
+  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
+      rendering::RenderEngine::NONE)
+  {
+    gzerr << "No rendering engine, unable to run camera test\n";
+    return;
+  }
+
+  // get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor
+  // and we expect the intrinsics to be equal to the default intrinsic values provided by gazebo.
+  std::string defaultIntrinsicsCameraName = "default_intrinsics_camera_sensor";
+  sensors::SensorPtr defaultIntrinsicsSensor = sensors::get_sensor(defaultIntrinsicsCameraName);
+  sensors::CameraSensorPtr defaultIntrinsicsCamSensor =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(defaultIntrinsicsSensor);
+  EXPECT_TRUE(defaultIntrinsicsCamSensor != nullptr);
+  rendering::CameraPtr defaultIntrinsicsCam = defaultIntrinsicsCamSensor->Camera();
+  EXPECT_TRUE(defaultIntrinsicsCam != nullptr);
+
+  // image size, focal length and optical centre for 'default_intrinsics_camera' sensor
+  unsigned int defaultCamWidth = defaultIntrinsicsCam->ImageWidth();
+  unsigned int defaultCamHeight = defaultIntrinsicsCam->ImageHeight();
+
+  {
+    double defaultCamFx = defaultIntrinsicsCam->FocalLengthX();
+    double defaultCamFy = defaultIntrinsicsCam->FocalLengthY();
+    double defaultCamCx = defaultIntrinsicsCam->OpticalCentreX();
+    double defaultCamCy = defaultIntrinsicsCam->OpticalCentreY();
+
+    EXPECT_GT(defaultCamWidth, 0u);
+    EXPECT_GT(defaultCamHeight, 0u);
+    EXPECT_EQ(defaultCamWidth, 320u);
+    EXPECT_EQ(defaultCamHeight, 240u);
+    double error = 0.0005;
+    EXPECT_NEAR(defaultCamFx, 277.127, error);
+    EXPECT_NEAR(defaultCamFy, 277.127, error);
+    EXPECT_DOUBLE_EQ(defaultCamCx, 160);
+    EXPECT_DOUBLE_EQ(defaultCamCy, 120);
+  }
+
+  // get the 'intrinsics_camera' sensor, <intrinsics> tag is used explicitly for this sensor
+  // where the intrinsics provided are same as gazebo default.
+  std::string intrinsicsCameraName = "intrinsics_camera_sensor";
+  sensors::SensorPtr intrinsicsSensor = sensors::get_sensor(defaultIntrinsicsCameraName);
+  sensors::CameraSensorPtr intrinsicsCamSensor =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(defaultIntrinsicsSensor);
+  EXPECT_TRUE(intrinsicsCamSensor != nullptr);
+  rendering::CameraPtr intrinsicsCam = intrinsicsCamSensor->Camera();
+  EXPECT_TRUE(intrinsicsCam != nullptr);
+
+  // image size, focal length and optical centre for 'intrinsics_camera_sensor' sensor
+  unsigned int camWidth = intrinsicsCam->ImageWidth();
+  unsigned int camHeight = intrinsicsCam->ImageHeight();
+  {
+    double camFx = intrinsicsCam->FocalLengthX();
+    double camFy = intrinsicsCam->FocalLengthY();
+    double camCx = intrinsicsCam->OpticalCentreX();
+    double camCy = intrinsicsCam->OpticalCentreY();
+
+    EXPECT_GT(camWidth, 0u);
+    EXPECT_GT(camHeight, 0u);
+    EXPECT_EQ(camWidth, 320u);
+    EXPECT_EQ(camHeight, 240u);
+    EXPECT_DOUBLE_EQ(camFx, 277);
+    EXPECT_DOUBLE_EQ(camFy, 277);
+    EXPECT_DOUBLE_EQ(camCx, 160);
+    EXPECT_DOUBLE_EQ(camCy, 120);
+  }
+
+  // connect to new frame event
+  imageCount = 0;
+  imageCount2 = 0;
+}
+
+/////////////////////////////////////////////////
 TEST_F(CameraSensor, 16bit)
 {
   // World contains a box positioned at top right quadrant of image generated

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2284,10 +2284,9 @@ TEST_F(CameraSensor, CheckIntrinsics)
     return;
   }
 
-  // get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor
+  // get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor,
   // and we expect the intrinsics to be equal to the default intrinsic values provided by gazebo.
-  std::string defaultIntrinsicsCameraName = "default_intrinsics_camera_sensor";
-  sensors::SensorPtr defaultIntrinsicsSensor = sensors::get_sensor(defaultIntrinsicsCameraName);
+  sensors::SensorPtr defaultIntrinsicsSensor = sensors::get_sensor("default_intrinsics_camera_sensor");
   sensors::CameraSensorPtr defaultIntrinsicsCamSensor =
       std::dynamic_pointer_cast<sensors::CameraSensor>(defaultIntrinsicsSensor);
   EXPECT_TRUE(defaultIntrinsicsCamSensor != nullptr);
@@ -2297,57 +2296,72 @@ TEST_F(CameraSensor, CheckIntrinsics)
   // image size, focal length and optical centre for 'default_intrinsics_camera' sensor
   unsigned int defaultCamWidth = defaultIntrinsicsCam->ImageWidth();
   unsigned int defaultCamHeight = defaultIntrinsicsCam->ImageHeight();
-  {
-    double defaultCamFx = defaultIntrinsicsCam->ImageFocalLengthX();
-    double defaultCamFy = defaultIntrinsicsCam->ImageFocalLengthY();
-    double defaultCamCx = defaultIntrinsicsCam->ImageOpticalCentreX();
-    double defaultCamCy = defaultIntrinsicsCam->ImageOpticalCentreY();
+  double defaultCamFx = defaultIntrinsicsCam->ImageFocalLengthX();
+  double defaultCamFy = defaultIntrinsicsCam->ImageFocalLengthY();
+  double defaultCamCx = defaultIntrinsicsCam->ImageOpticalCenterX();
+  double defaultCamCy = defaultIntrinsicsCam->ImageOpticalCenterY();
 
-    EXPECT_GT(defaultCamWidth, 0u);
-    EXPECT_GT(defaultCamHeight, 0u);
-    EXPECT_EQ(defaultCamWidth, 320u);
-    EXPECT_EQ(defaultCamHeight, 240u);
-    double error = 0.0005;
-    EXPECT_NEAR(defaultCamFx, 277.127, error);
-    EXPECT_NEAR(defaultCamFy, 277.127, error);
-    EXPECT_DOUBLE_EQ(defaultCamCx, 160);
-    EXPECT_DOUBLE_EQ(defaultCamCy, 120);
-  }
+  EXPECT_EQ(defaultCamWidth, 320u);
+  EXPECT_EQ(defaultCamHeight, 240u);
+  double error = 0.0005;
+  EXPECT_NEAR(defaultCamFx, 277.127, error);
+  EXPECT_NEAR(defaultCamFy, 277.127, error);
+  EXPECT_DOUBLE_EQ(defaultCamCx, 160);
+  EXPECT_DOUBLE_EQ(defaultCamCy, 120);
 
   // get the 'intrinsics_camera' sensor, <intrinsics> tag is used explicitly for this sensor
   // where the intrinsics provided are same as gazebo default.
-  std::string intrinsicsCameraName = "intrinsics_camera_sensor";
-  sensors::SensorPtr intrinsicsSensor = sensors::get_sensor(intrinsicsCameraName);
+  sensors::SensorPtr intrinsicsSensor = sensors::get_sensor("intrinsics_camera_sensor");
   sensors::CameraSensorPtr intrinsicsCamSensor =
       std::dynamic_pointer_cast<sensors::CameraSensor>(intrinsicsSensor);
   EXPECT_TRUE(intrinsicsCamSensor != nullptr);
   rendering::CameraPtr intrinsicsCam = intrinsicsCamSensor->Camera();
   EXPECT_TRUE(intrinsicsCam != nullptr);
 
-  // image size, focal length and optical centre for 'intrinsics_camera_sensor' sensor
-  unsigned int camWidth = intrinsicsCam->ImageWidth();
-  unsigned int camHeight = intrinsicsCam->ImageHeight();
-  {
-    double camFx = intrinsicsCam->ImageFocalLengthX();
-    double camFy = intrinsicsCam->ImageFocalLengthY();
-    double camCx = intrinsicsCam->ImageOpticalCentreX();
-    double camCy = intrinsicsCam->ImageOpticalCentreY();
+  // image size, focal length and optical centre for 'intrinsics_camera' sensor
+  unsigned int  intrinsicsCamWidth = intrinsicsCam->ImageWidth();
+  unsigned int  intrinsicsCamHeight = intrinsicsCam->ImageHeight();
+  double intrinsicsCamFx = intrinsicsCam->ImageFocalLengthX();
+  double intrinsicsCamFy = intrinsicsCam->ImageFocalLengthY();
+  double intrinsicsCamCx = intrinsicsCam->ImageOpticalCenterX();
+  double intrinsicsCamCy = intrinsicsCam->ImageOpticalCenterY();
+  EXPECT_EQ(intrinsicsCamWidth, 320u);
+  EXPECT_EQ(intrinsicsCamHeight, 240u);
+  EXPECT_DOUBLE_EQ(intrinsicsCamFx, 277);
+  EXPECT_DOUBLE_EQ(intrinsicsCamFy, 277);
+  EXPECT_DOUBLE_EQ(intrinsicsCamCx, 160);
+  EXPECT_DOUBLE_EQ(intrinsicsCamCy, 120);
 
-    EXPECT_GT(camWidth, 0u);
-    EXPECT_GT(camHeight, 0u);
-    EXPECT_EQ(camWidth, 320u);
-    EXPECT_EQ(camHeight, 240u);
-    EXPECT_DOUBLE_EQ(camFx, 277);
-    EXPECT_DOUBLE_EQ(camFy, 277);
-    EXPECT_DOUBLE_EQ(camCx, 160);
-    EXPECT_DOUBLE_EQ(camCy, 120);
-  }
+  // get the 'camera' sensor, <intrinsics> tag is used explicitly for this sensor
+  // where the intrinsics provided are different from the gazebo default.
+  sensors::SensorPtr sensor = sensors::get_sensor("camera_sensor");
+  sensors::CameraSensorPtr camSensor =
+      std::dynamic_pointer_cast<sensors::CameraSensor>(sensor);
+  EXPECT_TRUE(camSensor != nullptr);
+  rendering::CameraPtr cam = camSensor->Camera();
+  EXPECT_TRUE(cam != nullptr);
+
+  // image size, focal length and optical centre for 'camera' sensor
+  unsigned int camWidth = cam->ImageWidth();
+  unsigned int camHeight = cam->ImageHeight();
+  double camFx = cam->ImageFocalLengthX();
+  double camFy = cam->ImageFocalLengthY();
+  double camCx = cam->ImageOpticalCenterX();
+  double camCy = cam->ImageOpticalCenterY();
+  EXPECT_EQ(camWidth, 320u);
+  EXPECT_EQ(camHeight, 240u);
+  EXPECT_DOUBLE_EQ(camFx, 320);
+  EXPECT_DOUBLE_EQ(camFy, 320);
+  EXPECT_DOUBLE_EQ(camCx, 160);
+  EXPECT_DOUBLE_EQ(camCy, 120);
 
   // connect to new frame event
   imageCount = 0;
   imageCount2 = 0;
+  imageCount3 = 0;
   img = new unsigned char[camWidth * camHeight * 3 * 2];
   img2 = new unsigned char[camWidth * camHeight * 3 * 2];
+  img3 = new unsigned char[camWidth * camHeight * 3 * 2];
 
   event::ConnectionPtr c =
       defaultIntrinsicsCamSensor->Camera()->ConnectNewImageFrame(
@@ -2361,28 +2375,44 @@ TEST_F(CameraSensor, CheckIntrinsics)
                     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                     std::placeholders::_4, std::placeholders::_5));
 
+  event::ConnectionPtr c3 =
+      camSensor->Camera()->ConnectNewImageFrame(
+          std::bind(&::OnNewCameraFrame, &imageCount3, img3,
+                    std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+                    std::placeholders::_4, std::placeholders::_5));
+
   // wait for a few images
   int sleep = 0;
   int maxSleep = 500;
   int totalImages = 10;
-  while ((imageCount < totalImages || imageCount2 < totalImages)
-      && sleep++ < maxSleep)
+  while ((imageCount < totalImages || imageCount2 < totalImages
+      || imageCount3 < totalImages) && sleep++ < maxSleep)
     common::Time::MSleep(10);
 
   EXPECT_GE(imageCount, totalImages);
   EXPECT_GE(imageCount2, totalImages);
+  EXPECT_GE(imageCount3, totalImages);
 
   c.reset();
   c2.reset();
+  c3.reset();
 
   unsigned int diffMax = 0, diffSum = 0;
   double diffAvg = 0.0;
 
-  // We expect that there will be zero difference between the images
+  // We expect that there will be zero difference between the images img and img2 since
+  // they use the same default intrinsics.
   this->ImageCompare(img, img2, camWidth, camHeight, 3,
                      diffMax, diffSum, diffAvg);
   EXPECT_EQ(diffSum, 0u);
 
+  // We expect that there will be non-zero difference between the images img2 and img3
+  // since they use different intrinsics
+  this->ImageCompare(img2, img3, camWidth, camHeight, 3,
+                     diffMax, diffSum, diffAvg);
+  EXPECT_NE(diffSum, 0u);
+
   delete[] img;
   delete[] img2;
+  delete[] img3;
 }

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -2284,7 +2284,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
     return;
   }
 
-  // get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor,
+  // Get the 'default_intrinsics_camera' sensor, no <intrinsics> tag is used for this sensor,
   // and we expect the intrinsics to be equal to the default intrinsic values provided by gazebo.
   sensors::SensorPtr defaultIntrinsicsSensor = sensors::get_sensor("default_intrinsics_camera_sensor");
   sensors::CameraSensorPtr defaultIntrinsicsCamSensor =
@@ -2309,7 +2309,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
   EXPECT_DOUBLE_EQ(defaultCamCx, 160);
   EXPECT_DOUBLE_EQ(defaultCamCy, 120);
 
-  // get the 'intrinsics_camera' sensor, <intrinsics> tag is used explicitly for this sensor
+  // Get the 'intrinsics_camera' sensor, <intrinsics> tag is used explicitly for this sensor
   // where the intrinsics provided are same as gazebo default.
   sensors::SensorPtr intrinsicsSensor = sensors::get_sensor("intrinsics_camera_sensor");
   sensors::CameraSensorPtr intrinsicsCamSensor =
@@ -2332,7 +2332,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
   EXPECT_DOUBLE_EQ(intrinsicsCamCx, 160);
   EXPECT_DOUBLE_EQ(intrinsicsCamCy, 120);
 
-  // get the 'camera' sensor, <intrinsics> tag is used explicitly for this sensor
+  // Get the 'camera' sensor, <intrinsics> tag is used explicitly for this sensor
   // where the intrinsics provided are different from the gazebo default.
   sensors::SensorPtr sensor = sensors::get_sensor("camera_sensor");
   sensors::CameraSensorPtr camSensor =
@@ -2355,7 +2355,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
   EXPECT_DOUBLE_EQ(camCx, 160);
   EXPECT_DOUBLE_EQ(camCy, 120);
 
-  // connect to new frame event
+  // Connect to new frame event
   imageCount = 0;
   imageCount2 = 0;
   imageCount3 = 0;
@@ -2381,7 +2381,7 @@ TEST_F(CameraSensor, CheckIntrinsics)
                     std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
                     std::placeholders::_4, std::placeholders::_5));
 
-  // wait for a few images
+  // Wait for a few images
   int sleep = 0;
   int maxSleep = 500;
   int totalImages = 10;

--- a/test/worlds/camera_intrinsics_test.world
+++ b/test/worlds/camera_intrinsics_test.world
@@ -33,11 +33,16 @@
             <image>
               <width>320</width>
               <height>240</height>
+              <format>RGB_UINT16</format>
             </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
           </camera>
           <always_on>1</always_on>
-          <update_rate>30</update_rate>
-          <visualize>true</visualize>
+          <update_rate>10</update_rate>
+          <visualize>false</visualize>
         </sensor>
       </link>
     </model>
@@ -60,7 +65,12 @@
             <image>
               <width>320</width>
               <height>240</height>
+              <format>RGB_UINT16</format>
             </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
             <lens>
               <intrinsics>
                 <fx>277</fx>
@@ -72,8 +82,8 @@
             </lens>
           </camera>
           <always_on>1</always_on>
-          <update_rate>30</update_rate>
-          <visualize>true</visualize>
+          <update_rate>10</update_rate>
+          <visualize>false</visualize>
         </sensor>
       </link>
     </model>

--- a/test/worlds/camera_intrinsics_test.world
+++ b/test/worlds/camera_intrinsics_test.world
@@ -1,0 +1,102 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!--
+      The 'default_intrinsics_camera' model should have the same image output as the
+      'intrinsics_camera' model.  The 'default_intrinsics_camera' model uses the default
+      intrinsics values directly from gazebo for focal length and optical centre.
+      The 'intrinsics_camera' model however uses the intrinsic tag explicitly to provide
+      the intrinsics same as gazebo default intrinsics.
+    -->
+    <model name="default_intrinsics_camera">
+      <static>true</static>
+      <pose>0.0 0.0 0.5 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="default_intrinsics_camera_sensor" type="camera">
+          <camera>
+            <!-- Use default horizontal FOV-->
+            <horizontal_fov>1.0472</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <model name="intrinsics_camera">
+      <static>true</static>
+      <pose>0.0 0.0 0.5 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="intrinsics_camera_sensor" type="camera">
+          <camera>
+            <!-- Use default horizontal FOV-->
+            <horizontal_fov>1.0472</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <lens>
+              <intrinsics>
+                <fx>277</fx>
+                <fy>277</fy>
+                <cx>160</cx>
+                <cy>120</cy>
+                <s>0</s>
+              </intrinsics>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <model name="box">
+      <pose>3 0 0.5 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/test/worlds/camera_intrinsics_test.world
+++ b/test/worlds/camera_intrinsics_test.world
@@ -3,15 +3,16 @@
   <!--
   World file for testing the intrinsics API of gazebo.
 
-  The 'default_intrinsics_camera' model uses the default intrinsics values directly
+  The 'camera_without_intrinsics' model uses the default intrinsics values directly
   from gazebo for focal length and optical centre.
-  The 'intrinsics_camera' model uses the intrinsic tag explicitly to provide
+  The 'camera_default_intrinsics' model uses the intrinsic tag explicitly to provide
   the intrinsics same as gazebo default intrinsics.
-  The 'camera' model uses different intrinsics than the one used by default from gazebo.
+  The 'camera_custom_intrinsics' model uses different intrinsics than the one used
+  by default from gazebo.
 
-  We expect the 'default_intrinsics_camera' model to have the same image output as the
-  'intrinsics_camera' model and the image output for 'camera' to be different from the
-  one from 'default_intrinsics_camera' or 'intrinsics_camera' model.
+  We expect the 'camera_without_intrinsics' model to have the same image output as the
+  'camera_default_intrinsics' model and the image output for 'camera_custom_intrinsics'
+  to be different from 'camera_without_intrinsics' or 'camera_default_intrinsics' model.
   -->
   <world name="default">
     <include>
@@ -25,7 +26,7 @@
   Camera sensor where no <intrinsics> tag is used and default values of
   intrinsics are used from gazebo.
   -->
-  <model name="default_intrinsics_camera">
+  <model name="camera_without_intrinsics">
     <static>true</static>
     <pose>0.0 0.0 0.5 0 0 0</pose>
     <link name="link">
@@ -36,7 +37,7 @@
           </box>
         </geometry>
       </visual>
-      <sensor name="default_intrinsics_camera_sensor" type="camera">
+      <sensor name="camera_without_intrinsics_sensor" type="camera">
         <camera>
           <!-- Use default horizontal FOV-->
             <horizontal_fov>1.0472</horizontal_fov>
@@ -61,7 +62,7 @@
     Camera sensor where <intrinsics> tag is used and intrinsic values used
     are the same as default intrinsics used by gazebo.
     -->
-    <model name="intrinsics_camera">
+    <model name="camera_default_intrinsics">
       <static>true</static>
       <pose>0.0 0.0 0.5 0 0 0</pose>
       <link name="link">
@@ -72,7 +73,7 @@
             </box>
           </geometry>
         </visual>
-        <sensor name="intrinsics_camera_sensor" type="camera">
+        <sensor name="camera_default_intrinsics_sensor" type="camera">
           <camera>
             <!-- Use default horizontal FOV-->
             <horizontal_fov>1.0472</horizontal_fov>
@@ -106,7 +107,7 @@
     Camera sensor where <intrinsics> tag is used and intrinsic values used
     are different from the default intrinsics used by gazebo.
     -->
-    <model name="camera">
+    <model name="camera_custom_intrinsics">
       <static>true</static>
       <pose>0.0 0.0 0.5 0 0 0</pose>
       <link name="link">
@@ -117,7 +118,7 @@
             </box>
           </geometry>
         </visual>
-        <sensor name="camera_sensor" type="camera">
+        <sensor name="camera_custom_intrinsics_sensor" type="camera">
           <camera>
             <!-- Use default horizontal FOV-->
             <horizontal_fov>1.0472</horizontal_fov>

--- a/test/worlds/camera_intrinsics_test.world
+++ b/test/worlds/camera_intrinsics_test.world
@@ -1,5 +1,18 @@
 <?xml version="1.0" ?>
 <sdf version="1.6">
+  <!--
+  World file for testing the intrinsics API of gazebo.
+
+  The 'default_intrinsics_camera' model uses the default intrinsics values directly
+  from gazebo for focal length and optical centre.
+  The 'intrinsics_camera' model uses the intrinsic tag explicitly to provide
+  the intrinsics same as gazebo default intrinsics.
+  The 'camera' model uses different intrinsics than the one used by default from gazebo.
+
+  We expect the 'default_intrinsics_camera' model to have the same image output as the
+  'intrinsics_camera' model and the image output for 'camera' to be different from the
+  one from 'default_intrinsics_camera' or 'intrinsics_camera' model.
+  -->
   <world name="default">
     <include>
       <uri>model://ground_plane</uri>
@@ -8,27 +21,24 @@
       <uri>model://sun</uri>
     </include>
 
-    <!--
-      The 'default_intrinsics_camera' model should have the same image output as the
-      'intrinsics_camera' model.  The 'default_intrinsics_camera' model uses the default
-      intrinsics values directly from gazebo for focal length and optical centre.
-      The 'intrinsics_camera' model however uses the intrinsic tag explicitly to provide
-      the intrinsics same as gazebo default intrinsics.
-    -->
-    <model name="default_intrinsics_camera">
-      <static>true</static>
-      <pose>0.0 0.0 0.5 0 0 0</pose>
-      <link name="link">
-        <visual name="visual">
-          <geometry>
-            <box>
-              <size>0.1 0.1 0.1</size>
-            </box>
-          </geometry>
-        </visual>
-        <sensor name="default_intrinsics_camera_sensor" type="camera">
-          <camera>
-            <!-- Use default horizontal FOV-->
+  <!--
+  Camera sensor where no <intrinsics> tag is used and default values of
+  intrinsics are used from gazebo.
+  -->
+  <model name="default_intrinsics_camera">
+    <static>true</static>
+    <pose>0.0 0.0 0.5 0 0 0</pose>
+    <link name="link">
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.1</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="default_intrinsics_camera_sensor" type="camera">
+        <camera>
+          <!-- Use default horizontal FOV-->
             <horizontal_fov>1.0472</horizontal_fov>
             <image>
               <width>320</width>
@@ -47,6 +57,10 @@
       </link>
     </model>
 
+    <!--
+    Camera sensor where <intrinsics> tag is used and intrinsic values used
+    are the same as default intrinsics used by gazebo.
+    -->
     <model name="intrinsics_camera">
       <static>true</static>
       <pose>0.0 0.0 0.5 0 0 0</pose>
@@ -75,6 +89,51 @@
               <intrinsics>
                 <fx>277</fx>
                 <fy>277</fy>
+                <cx>160</cx>
+                <cy>120</cy>
+                <s>0</s>
+              </intrinsics>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>10</update_rate>
+          <visualize>false</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <!--
+    Camera sensor where <intrinsics> tag is used and intrinsic values used
+    are different from the default intrinsics used by gazebo.
+    -->
+    <model name="camera">
+      <static>true</static>
+      <pose>0.0 0.0 0.5 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor" type="camera">
+          <camera>
+            <!-- Use default horizontal FOV-->
+            <horizontal_fov>1.0472</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+              <format>RGB_UINT16</format>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <intrinsics>
+                <fx>320</fx>
+                <fy>320</fy>
                 <cx>160</cx>
                 <cy>120</cy>
                 <s>0</s>


### PR DESCRIPTION
This PR makes efforts to expose camera intrinsic parameters so that they can be accessed by `gazebo_ros_camera` plugin. 
Currently, the Camera API exposes a `ProjectionMatrix()` which is normalised based on Open GL graphics and whose  values doesn't make sense to the user using the API. 

The PR exposed `ImageFocalLengthX(), ImageFocalLengthY(), ImageOpticalCentreX() and ImageOpticalCentreY()` API's. These values are populated from the `intrinsic` tag in case intrinsic are provided in `sdf` file. If no intrinsic are provided then these values are decoupled from the `ProjectionMatrix` since the ProjectionMatrix is calculated by default based on `fov`, `image size` and we can decouple it to get the intrinsic.

Some related discussion here: https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1407

Signed-off-by: deepanshu <deepanshubansal01@gmail.com>