### PR TITLE
Test PR : ABI compatible change in spherical coordinates msg

### DIFF
--- a/gazebo/msgs/spherical_coordinates.proto
+++ b/gazebo/msgs/spherical_coordinates.proto
@@ -10,6 +10,7 @@ message SphericalCoordinates
   enum SurfaceModel
   {
     EARTH_WGS84 = 1;
+    MOON_SCS = 2;
   }
 
   required SurfaceModel surface_model   = 1;


### PR DESCRIPTION
This is a mock PR to check if adding an enum member breaks ABI in protobuf a msg.