### PR TITLE
CustomPSSMShadowCamera: support custom projection matrix

### DIFF
--- a/gazebo/rendering/Camera.cc
+++ b/gazebo/rendering/Camera.cc
@@ -813,11 +813,8 @@ void Camera::SetClipDist()
 
   if (this->camera)
   {
-    if (!this->cameraUsingIntrinsics)
-    {
-      this->camera->setNearClipDistance(clipElem->Get<double>("near"));
-      this->camera->setFarClipDistance(clipElem->Get<double>("far"));
-    }
+    this->camera->setNearClipDistance(clipElem->Get<double>("near"));
+    this->camera->setFarClipDistance(clipElem->Get<double>("far"));
     this->camera->setRenderingDistance(clipElem->Get<double>("far"));
   }
   else

--- a/gazebo/rendering/CustomPSSMShadowCameraSetup.cc
+++ b/gazebo/rendering/CustomPSSMShadowCameraSetup.cc
@@ -465,8 +465,10 @@ void CustomPSSMShadowCameraSetup::calculateShadowMappingMatrix(
 }
 
 //////////////////////////////////////////////////
-Ogre::Matrix4 CustomPSSMShadowCameraSetup::buildSimplePerspectiveMatrix(
-    const Ogre::Real _near, const Ogre::Real _far) const
+// Build a simple perspective projection matrix using only near and far clipping
+// planes.
+static Ogre::Matrix4 buildSimplePerspectiveMatrix(
+    const Ogre::Real _near, const Ogre::Real _far)
 {
   return Ogre::Matrix4(1, 0, 0, 0,
     0, 1, 0, 0,
@@ -636,7 +638,8 @@ void CustomPSSMShadowCameraSetup::getShadowCamera(const Ogre::SceneManager *_sm,
     // elements differ in the forth or fifth digit).
     Ogre::Matrix4 oldNearFarMat = buildSimplePerspectiveMatrix(oldNear, oldFar);
     Ogre::Matrix4 newNearFarMat = buildSimplePerspectiveMatrix(nearDist, farDist);
-    cam->setCustomProjectionMatrix(true, oldCustomProjMat * oldNearFarMat.inverse() * newNearFarMat);
+    cam->setCustomProjectionMatrix(true, oldCustomProjMat *
+                                   oldNearFarMat.inverse() * newNearFarMat);
   }
 
   // Replaced LiSPSMShadowCameraSetup::getShadowCamera() with

--- a/gazebo/rendering/CustomPSSMShadowCameraSetup.hh
+++ b/gazebo/rendering/CustomPSSMShadowCameraSetup.hh
@@ -102,11 +102,6 @@ namespace gazebo
           Ogre::Matrix4 *_out_view, Ogre::Matrix4 *_outProj,
           Ogre::Camera *_outCam) const;
 
-      /// \brief Build a simple perspective projection matrix using only near
-      /// and far clipping planes.
-      public: Ogre::Matrix4 buildSimplePerspectiveMatrix(const Ogre::Real _near,
-          const Ogre::Real _far) const;
-
       /// \brief The same as FocusedShadowCameraSetup::buildViewMatrix() except
       /// resulting matrices are z-up instead of y-up.
       /// \sa FocusedShadowCameraSetup::buildViewMatrix()

--- a/gazebo/rendering/CustomPSSMShadowCameraSetup.hh
+++ b/gazebo/rendering/CustomPSSMShadowCameraSetup.hh
@@ -97,10 +97,15 @@ namespace gazebo
 
       /// \brief lightly modified
       /// FocusedShadowCameraSetup::calculateShadowMappingMatrix().
-      void calculateShadowMappingMatrix(const Ogre::SceneManager &_sm,
+      public: void calculateShadowMappingMatrix(const Ogre::SceneManager &_sm,
           const Ogre::Camera &_cam, const Ogre::Light &_light,
           Ogre::Matrix4 *_out_view, Ogre::Matrix4 *_outProj,
           Ogre::Camera *_outCam) const;
+
+      /// \brief Build a simple perspective projection matrix using only near
+      /// and far clipping planes.
+      public: Ogre::Matrix4 buildSimplePerspectiveMatrix(const Ogre::Real _near,
+          const Ogre::Real _far) const;
 
       /// \brief The same as FocusedShadowCameraSetup::buildViewMatrix() except
       /// resulting matrices are z-up instead of y-up.


### PR DESCRIPTION
PSSM shadows only support a regular camera matrix defined by horizontal_fov. If you instead use a custom matrix defined by camera intrinsics, the PSSM algorithm does not build a new shadow camera matrix for each of the 3 shadow maps. This PR fixes that deficiency.

Example camera using horizontal_fov:
```
           <camera>
            <horizontal_fov>0.28</horizontal_fov>
            <image>
              <width>2048</width>
              <height>2048</height>
            </image>
            <clip>
              <near>0.1</near>
              <far>500</far>
            </clip>
          </camera>
```

Example camera using intrinsics:
```
           <camera>
            <lens>
              <intrinsics>
                <fx>1434.84</fx>
                <fy>1435.36</fy>
                <cx>1010.23</cx>
                <cy>1034.08</cy>
              </intrinsics>
            </lens>
            <image>
              <width>2048</width>
              <height>2048</height>
            </image>
            <clip>
              <near>0.1</near>
              <far>500</far>
            </clip>
          </camera>
```