### PR TITLE
SphericalCoordinates: support Lunar calculations

### DIFF
--- a/gazebo/common/SphericalCoordinates.cc
+++ b/gazebo/common/SphericalCoordinates.cc
@@ -39,12 +39,30 @@ const double g_EarthWGS84Flattening = 1.0/298.257223563;
 // Radius of the Earth (meters).
 const double g_EarthRadius = 6371000.0;
 
+// Radius of the Moon (meters).
+// Source: https://lunar.gsfc.nasa.gov/library/451-SCI-000958.pdf
+const double g_MoonRadius = 1737400.0;
+
+// a: Equatorial radius of the Moon.
+// Source : https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html
+const double g_MoonAxisEquatorial = 1738100.0;
+
+// b: Polar radius of the Moon.
+// Source : https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html
+const double g_MoonAxisPolar = 1736000.0;
+
+// if: Unitless flattening parameter for the Moon.
+// Source : https://nssdc.gsfc.nasa.gov/planetary/factsheet/moonfact.html
+const double g_MoonFlattening = 0.0012;
+
 //////////////////////////////////////////////////
 SphericalCoordinates::SurfaceType SphericalCoordinates::Convert(
   const std::string &_str)
 {
   if ("EARTH_WGS84" == _str)
     return EARTH_WGS84;
+  else if ("MOON_SCS" == _str)
+    return MOON_SCS;
 
   gzerr << "SurfaceType string not recognized, "
         << "EARTH_WGS84 returned by default" << std::endl;
@@ -156,6 +174,30 @@ void SphericalCoordinates::SetSurfaceType(const SurfaceType &_type)
 
       break;
       }
+    case MOON_SCS:
+      {
+      // Set the semi-major axis
+      this->dataPtr->ellA = g_MoonAxisEquatorial;
+
+      // Set the semi-minor axis
+      this->dataPtr->ellB = g_MoonAxisPolar;
+
+      // Set the flattening parameter
+      this->dataPtr->ellF = g_MoonFlattening;
+
+      // Set the first eccentricity ellipse parameter
+      // https://en.wikipedia.org/wiki/Eccentricity_(mathematics)#Ellipses
+      this->dataPtr->ellE = sqrt(1.0 -
+          std::pow(this->dataPtr->ellB, 2) / std::pow(this->dataPtr->ellA, 2));
+
+      // Set the second eccentricity ellipse parameter
+      // https://en.wikipedia.org/wiki/Eccentricity_(mathematics)#Ellipses
+      this->dataPtr->ellP = sqrt(
+          std::pow(this->dataPtr->ellA, 2) / std::pow(this->dataPtr->ellB, 2) -
+          1.0);
+
+      break;
+      }
     default:
       gzerr << "Unknown surface type[" << this->dataPtr->surfaceType << "]\n";
       break;
@@ -244,6 +286,53 @@ double SphericalCoordinates::Distance(const ignition::math::Angle &_latA,
   double c = 2 * atan2(sqrt(a), sqrt(1 - a));
   double d = g_EarthRadius * c;
   return d;
+}
+
+//////////////////////////////////////////////////
+/// Based on Haversine formula (http://en.wikipedia.org/wiki/Haversine_formula).
+/// This takes into account the surface type.
+double SphericalCoordinates::DistanceBetweenPoints(
+    const gz::math::Angle &_latA,
+    const gz::math::Angle &_lonA,
+    const gz::math::Angle &_latB,
+    const gz::math::Angle &_lonB)
+{
+  ignition::math::Angle dLat = _latB - _latA;
+  ignition::math::Angle dLon = _lonB - _lonA;
+
+  double a = sin(dLat.Radian() / 2) * sin(dLat.Radian() / 2) +
+             sin(dLon.Radian() / 2) * sin(dLon.Radian() / 2) *
+             cos(_latA.Radian()) * cos(_latB.Radian());
+
+  double c = 2 * atan2(sqrt(a), sqrt(1 - a));
+  if (this->dataPtr->surfaceType == MOON_SCS)
+    return g_MoonRadius * c;
+  else
+    return g_EarthRadius * c;
+}
+
+//////////////////////////////////////////////////
+double SphericalCoordinates::SurfaceRadius() const
+{
+  return this->dataPtr->surfaceRadius;
+}
+
+//////////////////////////////////////////////////
+double SphericalCoordinates::SurfaceAxisEquatorial() const
+{
+  return this->dataPtr->ellA;
+}
+
+//////////////////////////////////////////////////
+double SphericalCoordinates::SurfaceAxisPolar() const
+{
+  return this->dataPtr->ellB;
+}
+
+//////////////////////////////////////////////////
+double SphericalCoordinates::SurfaceFlattening() const
+{
+  return this->dataPtr->ellF;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/common/SphericalCoordinates.cc
+++ b/gazebo/common/SphericalCoordinates.cc
@@ -305,10 +305,7 @@ double SphericalCoordinates::DistanceBetweenPoints(
              cos(_latA.Radian()) * cos(_latB.Radian());
 
   double c = 2 * atan2(sqrt(a), sqrt(1 - a));
-  if (this->dataPtr->surfaceType == MOON_SCS)
-    return g_MoonRadius * c;
-  else
-    return g_EarthRadius * c;
+  return this->SurfaceRadius() * c;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/common/SphericalCoordinates.cc
+++ b/gazebo/common/SphericalCoordinates.cc
@@ -292,10 +292,10 @@ double SphericalCoordinates::Distance(const ignition::math::Angle &_latA,
 /// Based on Haversine formula (http://en.wikipedia.org/wiki/Haversine_formula).
 /// This takes into account the surface type.
 double SphericalCoordinates::DistanceBetweenPoints(
-    const gz::math::Angle &_latA,
-    const gz::math::Angle &_lonA,
-    const gz::math::Angle &_latB,
-    const gz::math::Angle &_lonB)
+    const ignition::math::Angle &_latA,
+    const ignition::math::Angle &_lonA,
+    const ignition::math::Angle &_latB,
+    const ignition::math::Angle &_lonB)
 {
   ignition::math::Angle dLat = _latB - _latA;
   ignition::math::Angle dLon = _lonB - _lonA;
@@ -314,7 +314,11 @@ double SphericalCoordinates::DistanceBetweenPoints(
 //////////////////////////////////////////////////
 double SphericalCoordinates::SurfaceRadius() const
 {
-  return this->dataPtr->surfaceRadius;
+  if (this->dataPtr->surfaceType ==
+      SphericalCoordinates::SurfaceType::MOON_SCS)
+    return g_MoonRadius;
+  else
+    return g_EarthRadius;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/common/SphericalCoordinates.hh
+++ b/gazebo/common/SphericalCoordinates.hh
@@ -44,7 +44,12 @@ namespace gazebo
               {
                 /// \brief Model of reference ellipsoid for earth, based on
                 /// WGS 84 standard. see wikipedia: World_Geodetic_System
-                EARTH_WGS84 = 1
+                EARTH_WGS84 = 1,
+
+                /// \brief Model of the moon, based on the Selenographic
+                /// coordinate system, see wikipedia: Selenographic
+                /// Coordinate System.
+                MOON_SCS = 2
               };
 
       /// \enum CoordinateType
@@ -119,6 +124,23 @@ namespace gazebo
                                      const ignition::math::Angle &_latB,
                                      const ignition::math::Angle &_lonB);
 
+      /// \brief Get the distance between two points expressed in geographic
+      /// latitude and longitude. It assumes that both points are at sea level.
+      /// Example: _latA = 38.0016667 and _lonA = -123.0016667) represents
+      /// the point with latitude 38d 0'6.00"N and longitude 123d 0'6.00"W.
+      /// This is different from the deprecated static Distance() method as it
+      /// takes into account the set surface's radius.
+      /// \param[in] _latA Latitude of point A.
+      /// \param[in] _lonA Longitude of point A.
+      /// \param[in] _latB Latitude of point B.
+      /// \param[in] _lonB Longitude of point B.
+      /// \return Distance in meters.
+      public: double DistanceBetweenPoints(
+                  const gz::math::Angle &_latA,
+                  const gz::math::Angle &_lonA,
+                  const gz::math::Angle &_latB,
+                  const gz::math::Angle &_lonB);
+
       /// \brief Get SurfaceType currently in use.
       /// \return Current SurfaceType value.
       public: SurfaceType GetSurfaceType() const;
@@ -130,6 +152,22 @@ namespace gazebo
       /// \brief Get reference longitude.
       /// \return Reference longitude.
       public: ignition::math::Angle LongitudeReference() const;
+
+      /// \brief Get the radius of the surface.
+      /// \return radius of the surface in use.
+      public: double SurfaceRadius() const;
+
+      /// \brief Get the major axis of the surface.
+      /// \return Equatorial axis of the surface in use.
+      public: double SurfaceAxisEquatorial() const;
+
+      /// \brief Get the minor axis of the surface.
+      /// \return Polar axis of the surface in use.
+      public: double SurfaceAxisPolar() const;
+
+      /// \brief Get the flattening of the surface.
+      /// \return Flattening parameter of the surface in use.
+      public: double SurfaceFlattening() const;
 
       /// \brief Get reference elevation in meters.
       /// \return Reference elevation.

--- a/gazebo/common/SphericalCoordinates.hh
+++ b/gazebo/common/SphericalCoordinates.hh
@@ -128,7 +128,7 @@ namespace gazebo
       /// latitude and longitude. It assumes that both points are at sea level.
       /// Example: _latA = 38.0016667 and _lonA = -123.0016667) represents
       /// the point with latitude 38d 0'6.00"N and longitude 123d 0'6.00"W.
-      /// This is different from the deprecated static Distance() method as it
+      /// This is different from the static Distance() method as it
       /// takes into account the set surface's radius.
       /// \param[in] _latA Latitude of point A.
       /// \param[in] _lonA Longitude of point A.

--- a/gazebo/common/SphericalCoordinates.hh
+++ b/gazebo/common/SphericalCoordinates.hh
@@ -136,10 +136,10 @@ namespace gazebo
       /// \param[in] _lonB Longitude of point B.
       /// \return Distance in meters.
       public: double DistanceBetweenPoints(
-                  const gz::math::Angle &_latA,
-                  const gz::math::Angle &_lonA,
-                  const gz::math::Angle &_latB,
-                  const gz::math::Angle &_lonB);
+                  const ignition::math::Angle &_latA,
+                  const ignition::math::Angle &_lonA,
+                  const ignition::math::Angle &_latB,
+                  const ignition::math::Angle &_lonB);
 
       /// \brief Get SurfaceType currently in use.
       /// \return Current SurfaceType value.

--- a/gazebo/common/SphericalCoordinates_TEST.cc
+++ b/gazebo/common/SphericalCoordinates_TEST.cc
@@ -104,7 +104,8 @@ TEST_F(SphericalCoordinatesTest, Constructor)
   {
     common::SphericalCoordinates sc(
         common::SphericalCoordinates::MOON_SCS);
-    EXPECT_EQ(sc.GetSurfaceType(), st);
+    EXPECT_EQ(sc.GetSurfaceType(),
+        common::SphericalCoordinates::MOON_SCS);
     EXPECT_EQ(sc.LatitudeReference(), ignition::math::Angle());
     EXPECT_EQ(sc.LongitudeReference(), ignition::math::Angle());
     EXPECT_EQ(sc.HeadingOffset(), ignition::math::Angle());
@@ -126,7 +127,8 @@ TEST_F(SphericalCoordinatesTest, Constructor)
     common::SphericalCoordinates sc(
         common::SphericalCoordinates::MOON_SCS,
         lat, lon, elev, heading);
-    EXPECT_EQ(sc.GetSurfaceType(), st);
+    EXPECT_EQ(sc.GetSurfaceType(),
+        common::SphericalCoordinates::MOON_SCS);
     EXPECT_EQ(sc.LatitudeReference(), lat);
     EXPECT_EQ(sc.LongitudeReference(), lon);
     EXPECT_EQ(sc.HeadingOffset(), heading);

--- a/gazebo/common/SphericalCoordinates_TEST.cc
+++ b/gazebo/common/SphericalCoordinates_TEST.cc
@@ -349,11 +349,11 @@ TEST_F(SphericalCoordinatesTest, Distance)
   EXPECT_NEAR(14002, d1, 20);
 
   // Using the non static method. The default surface type is EARTH_WGS84.
-  common::SphericalCoordinates earthSC = common::SphericalCoordinates();
-  double d2 = earthSC.DistanceBetweenPoints(latA, longA, latB, longB);
+  common::SphericalCoordinates defaultEarthSC = common::SphericalCoordinates();
+  double d2 = defaultEarthSC.DistanceBetweenPoints(latA, longA, latB, longB);
   EXPECT_NEAR(d1, d2, 0.1);
 
-  earthSC = common::SphericalCoordinates(
+  common::SphericalCoordinates earthSC = common::SphericalCoordinates(
       common::SphericalCoordinates::EARTH_WGS84);
   double d3 = earthSC.DistanceBetweenPoints(latA, longA, latB, longB);
   EXPECT_NEAR(d2, d3, 0.1);

--- a/gazebo/common/SphericalCoordinates_TEST.cc
+++ b/gazebo/common/SphericalCoordinates_TEST.cc
@@ -75,6 +75,10 @@ TEST_F(SphericalCoordinatesTest, Convert)
     common::SphericalCoordinates::EARTH_WGS84;
 
   EXPECT_EQ(common::SphericalCoordinates::Convert("EARTH_WGS84"), st);
+
+  // For Moon surface type
+  st = common::SphericalCoordinates::MOON_SCS;
+  EXPECT_EQ(common::SphericalCoordinates::Convert("MOON_SCS"), st);
 }
 
 //////////////////////////////////////////////////
@@ -261,9 +265,26 @@ TEST_F(SphericalCoordinatesTest, Distance)
   longA.Degree(-122.249972);
   latB.Degree(46.124953);
   longB.Degree(-122.251683);
-  double d = common::SphericalCoordinates::Distance(latA, longA, latB, longB);
 
-  EXPECT_NEAR(14002, d, 20);
+  // Caculating distance using the statis method.
+  double d1 = common::SphericalCoordinates::Distance(latA, longA, latB, longB);
+  EXPECT_NEAR(14002, d1, 20);
+
+  // Using the non static method. The default surface type is EARTH_WGS84.
+  common::SphericalCoordinates earthSC = common::SphericalCoordinates();
+  double d2 = earthSC.DistanceBetweenPoints(latA, longA, latB, longB);
+  EXPECT_NEAR(d1, d2, 0.1);
+
+  earthSC = common::SphericalCoordinates(
+      common::SphericalCoordinates::EARTH_WGS84);
+  double d3 = earthSC.DistanceBetweenPoints(latA, longA, latB, longB);
+  EXPECT_NEAR(d2, d3, 0.1);
+
+  // Setting the surface type as Moon.
+  common::SphericalCoordinates moonSC = common::SphericalCoordinates(
+      common::SphericalCoordinates::MOON_SCS);
+  double d4 = moonSC.DistanceBetweenPoints(latA, longA, latB, longB);
+  EXPECT_NEAR(3820, d4, 5);
 }
 
 /////////////////////////////////////////////////

--- a/gazebo/common/SphericalCoordinates_TEST.cc
+++ b/gazebo/common/SphericalCoordinates_TEST.cc
@@ -29,6 +29,17 @@ class SphericalCoordinatesTest : public gazebo::testing::AutoLogFixture { };
 // Test different constructors, default parameters
 TEST_F(SphericalCoordinatesTest, Constructor)
 {
+  // Constants
+  const double g_EarthWGS84AxisEquatorial = 6378137.0;
+  const double g_EarthWGS84AxisPolar = 6356752.314245;
+  const double g_EarthWGS84Flattening = 1.0/298.257223563;
+  const double g_EarthRadius = 6371000.0;
+
+  const double g_MoonRadius = 1737400.0;
+  const double g_MoonAxisEquatorial = 1738100.0;
+  const double g_MoonAxisPolar = 1736000.0;
+  const double g_MoonFlattening = 0.0012;
+
   // Default surface type
   common::SphericalCoordinates::SurfaceType st =
     common::SphericalCoordinates::EARTH_WGS84;
@@ -41,6 +52,14 @@ TEST_F(SphericalCoordinatesTest, Constructor)
     EXPECT_EQ(sc.LongitudeReference(), ignition::math::Angle());
     EXPECT_EQ(sc.HeadingOffset(), ignition::math::Angle());
     EXPECT_NEAR(sc.GetElevationReference(), 0.0, 1e-6);
+
+    EXPECT_NEAR(sc.SurfaceRadius(), g_EarthRadius, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisEquatorial(),
+        g_EarthWGS84AxisEquatorial, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisPolar(),
+        g_EarthWGS84AxisPolar, 1e-6);
+    EXPECT_NEAR(sc.SurfaceFlattening(),
+        g_EarthWGS84Flattening, 1e-6);
   }
 
   // SurfaceType argument, default parameters
@@ -51,6 +70,14 @@ TEST_F(SphericalCoordinatesTest, Constructor)
     EXPECT_EQ(sc.LongitudeReference(), ignition::math::Angle());
     EXPECT_EQ(sc.HeadingOffset(), ignition::math::Angle());
     EXPECT_NEAR(sc.GetElevationReference(), 0.0, 1e-6);
+
+    EXPECT_NEAR(sc.SurfaceRadius(), g_EarthRadius, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisEquatorial(),
+        g_EarthWGS84AxisEquatorial, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisPolar(),
+        g_EarthWGS84AxisPolar, 1e-6);
+    EXPECT_NEAR(sc.SurfaceFlattening(),
+        g_EarthWGS84Flattening, 1e-6);
   }
 
   // All arguments
@@ -63,6 +90,55 @@ TEST_F(SphericalCoordinatesTest, Constructor)
     EXPECT_EQ(sc.LongitudeReference(), lon);
     EXPECT_EQ(sc.HeadingOffset(), heading);
     EXPECT_NEAR(sc.GetElevationReference(), elev, 1e-6);
+
+    EXPECT_NEAR(sc.SurfaceRadius(), g_EarthRadius, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisEquatorial(),
+        g_EarthWGS84AxisEquatorial, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisPolar(),
+        g_EarthWGS84AxisPolar, 1e-6);
+    EXPECT_NEAR(sc.SurfaceFlattening(),
+        g_EarthWGS84Flattening, 1e-6);
+  }
+
+  // For Moon surface
+  {
+    common::SphericalCoordinates sc(
+        common::SphericalCoordinates::MOON_SCS);
+    EXPECT_EQ(sc.GetSurfaceType(), st);
+    EXPECT_EQ(sc.LatitudeReference(), ignition::math::Angle());
+    EXPECT_EQ(sc.LongitudeReference(), ignition::math::Angle());
+    EXPECT_EQ(sc.HeadingOffset(), ignition::math::Angle());
+    EXPECT_NEAR(sc.GetElevationReference(), 0.0, 1e-6);
+
+    EXPECT_NEAR(sc.SurfaceRadius(), g_MoonRadius, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisEquatorial(),
+        g_MoonAxisEquatorial, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisPolar(),
+        g_MoonAxisPolar, 1e-6);
+    EXPECT_NEAR(sc.SurfaceFlattening(),
+        g_MoonFlattening, 1e-6);
+  }
+
+  // Moon surface with arguments
+  {
+    ignition::math::Angle lat(0.3), lon(-1.2), heading(0.5);
+    double elev = 354.1;
+    common::SphericalCoordinates sc(
+        common::SphericalCoordinates::MOON_SCS,
+        lat, lon, elev, heading);
+    EXPECT_EQ(sc.GetSurfaceType(), st);
+    EXPECT_EQ(sc.LatitudeReference(), lat);
+    EXPECT_EQ(sc.LongitudeReference(), lon);
+    EXPECT_EQ(sc.HeadingOffset(), heading);
+    EXPECT_NEAR(sc.GetElevationReference(), elev, 1e-6);
+
+    EXPECT_NEAR(sc.SurfaceRadius(), g_MoonRadius, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisEquatorial(),
+        g_MoonAxisEquatorial, 1e-6);
+    EXPECT_NEAR(sc.SurfaceAxisPolar(),
+        g_MoonAxisPolar, 1e-6);
+    EXPECT_NEAR(sc.SurfaceFlattening(),
+        g_MoonFlattening, 1e-6);
   }
 }
 
@@ -266,7 +342,7 @@ TEST_F(SphericalCoordinatesTest, Distance)
   latB.Degree(46.124953);
   longB.Degree(-122.251683);
 
-  // Caculating distance using the statis method.
+  // Calculating distance using the static method.
   double d1 = common::SphericalCoordinates::Distance(latA, longA, latB, longB);
   EXPECT_NEAR(14002, d1, 20);
 


### PR DESCRIPTION
This is PR aims to add https://github.com/gazebosim/gz-math/pull/434 to gazebo classic, as a part of ongoing ticket to backport 
support for lunar DEMs and supress projection errors.

This one makes changes in ``common::SphericalCoordinates`` analogous to the ones in gz-math. 

Signed-off-by: Aditya <aditya050995@gmail.com>