### PR TITLE
BulletLink: add and set force and torque

### DIFF
--- a/test/integration/physics_link.cc
+++ b/test/integration/physics_link.cc
@@ -118,39 +118,39 @@ void PhysicsLinkTest::AddLinkForceTwoWays(
   }
 
   // Check force and torque relative to the COG in world coordinates
-  ignition::math::Vector3d forceWorld = poseWorld0.Rot().RotateVector(_force);
+  ignition::math::Vector3d const forceWorld = poseWorld0.Rot().RotateVector(
+    _force);
   EXPECT_EQ(forceWorld, _link->WorldForce());
 
-  ignition::math::Vector3d worldOffset = poseWorld0.Rot().RotateVector(
-      _offset - _link->GetInertial()->CoG());
+  ignition::math::Vector3d const worldOffset = poseWorld0.Rot().RotateVector(
+    _offset - _link->GetInertial()->CoG());
   ignition::math::Vector3d torqueWorld = worldOffset.Cross(forceWorld);
   EXPECT_EQ(torqueWorld, _link->WorldTorque());
 
   // Check acceleration in world frame
-  ignition::math::Vector3d oneStepLinearAccel =
-      forceWorld/_link->GetInertial()->Mass();
+  ignition::math::Vector3d const oneStepLinearAccel = forceWorld /
+    _link->GetInertial()->Mass();
   EXPECT_EQ(oneStepLinearAccel, _link->WorldLinearAccel());
 
   // Compute angular accel by multiplying world torque
   // by inverse of world inertia matrix.
   // In this case, the gyroscopic coupling terms are zero
   // since the model is a unit box.
-  ignition::math::Vector3d oneStepAngularAccel =
-      _link->WorldInertiaMatrix().Inverse() * torqueWorld;
+  ignition::math::Vector3d const oneStepAngularAccel =
+    _link->WorldInertiaMatrix().Inverse() * torqueWorld;
   EXPECT_EQ(oneStepAngularAccel, _link->WorldAngularAccel());
 
-
   // Note: This step must be performed after checking the link forces when DART
-  // is the physics engine, because otherwise the accelerations used by the
-  // previous tests will be cleared out before they can be tested.
-  if ("dart" == _physicsEngine)
+  // or bullet is the physics engine, because otherwise the accelerations used
+  // by the previous tests will be cleared out before they can be tested.
+  if ("dart" == _physicsEngine || "bullet" == _physicsEngine)
   {
     _world->Step(1);
   }
 
   // Check velocity in world frame
-  ignition::math::Vector3d oneStepLinearVel = linearVelWorld0 +
-    dt*oneStepLinearAccel;
+  ignition::math::Vector3d const oneStepLinearVel = linearVelWorld0 +
+    dt * oneStepLinearAccel;
 
   // Dev note (MXG): DART does not always produce quite the same result as the
   // expected value for CoG linear velocity. It might be worth investigating
@@ -168,8 +168,8 @@ void PhysicsLinkTest::AddLinkForceTwoWays(
 
   VEC_EXPECT_NEAR(oneStepLinearVel, _link->WorldCoGLinearVel(), tolerance);
 
-  ignition::math::Vector3d oneStepAngularVel = angularVelWorld0 +
-    dt*oneStepAngularAccel;
+  ignition::math::Vector3d const oneStepAngularVel = angularVelWorld0 +
+    dt * oneStepAngularAccel;
   EXPECT_EQ(oneStepAngularVel, _link->WorldAngularVel());
 
   // Step forward and check again
@@ -208,12 +208,11 @@ void PhysicsLinkTest::AddLinkForceTwoWays(
 /////////////////////////////////////////////////
 void PhysicsLinkTest::AddForce(const std::string &_physicsEngine)
 {
-  // TODO bullet and simbody currently fail this test
-  if (_physicsEngine != "ode" && _physicsEngine != "dart")
+  // TODO simbody currently fail this test
+  if (_physicsEngine == "simbody")
   {
-    gzerr << "Aborting AddForce test for Bullet and Simbody. "
-          << "See issues #1476 and #1478."
-          << std::endl;
+    gzerr << "Aborting AddForce test for Simbody. "
+          << "See issue #1478." << std::endl;
     return;
   }
 


### PR DESCRIPTION
This PR adds the implementation of methods for applying forces and torques to links when using the Bullet physics engine.

The following methods are now implemented in the BulletLink class:

- AddForce
- AddRelativeForce
- AddForceAtWorldPosition
- AddForceAtRelativePosition
- AddLinkForce
- AddTorque
- AddRelativeTorque
- WorldTorque

The implementation of the above methods was designed to match ODE and DART behavior.

The WorldTorque method always returned a vector of zeros, and had a implementation for returning the totalTorque from the btRigidBody object that was commented out. I couldn't not find a reason for this in the commit history nor in the Github issues, please advise if there is a known problem with that implementation.

Additionally, the implementation of the following methods was modified to correct their behavior:

- SetForce
- SetTorque

Expectation, is that calling these methods should respect the following sequence of steps:

1. Initially, the link has world force F1 and world torque T1
2. SetForce is called with _force = F2
3. The link now has force equal to F2 and torque T1

This behavior is different from the one contained in the previous implementation, which was the following:

1. Initially, the link has world force F1 and world torque T1
2. SetForce is called with _force = F2
3. The link now has force equal to F1 + F2, and torque equal to T1

Also, the UpdateMass method was modified to also update the CoG position. This was required to ensure that the updates to CoG that exist in the AddForce test were adequately reflected in the btRigidBody object. Note that this is consistent with the implementation of the UpdateMass method of the ODELink class.

In order to test the above methods, the AddForce test of the physics_link integration tests is now enabled for Bullet, and executes successfully.

**Important:** The OnWrenchMsg test is still disabled for bullet, because I could not find a way to persist the application of forces across steps with this physics engine.

This PR solves issue #1476.