### PR TITLE
Fix disappearing shadows when looking from certain angles

### DIFF
--- a/media/rtshaderlib/SGXLib_IntegratedPSSM.glsl
+++ b/media/rtshaderlib/SGXLib_IntegratedPSSM.glsl
@@ -78,7 +78,22 @@ void SGX_ApplyShadowFactor_Diffuse(in vec4 ambient,
 float _SGX_ShadowPoisson9(sampler2DShadow shadowMap, vec4 shadowMapPos, vec2 invShadowMapSize, bool hardwarePCF)
 {
   // Remove shadow outside shadow maps so that all that area appears lit
-  if (shadowMapPos.z < 0.0 || shadowMapPos.z > 1.0)
+  //
+  // GAZEBO CUSTOM NOTE:
+  // Due to historical API quirks, OpenGL would store depth in the range [0; 1]
+  // inside the depth buffer; but request the depth to be delivered in
+  // range [-1; 1]; while all other APIs use the range [0; 1] instead.
+  //
+  // Ogre 1.9 uses PF_FLOAT32_R colour render targets for
+  // shadow maps instead of a raw depth texture (also for historical reasons);
+  //
+  // which means the depth is in range [-1; 1] when using Ogre 1.9 + OpenGL.
+  // Newer Ogre versions use raw depth textures directly, which means
+  // the range is in [0; 1] and this fix is no longer necessary.
+  //
+  // Therefore Gazebo must reject z < -1.0 instead of z < 0.0
+  // See https://github.com/osrf/gazebo/issues/3259
+  if (shadowMapPos.z < -1.0 || shadowMapPos.z > 1.0)
     return 1.0;
 
   float shadow = 0.0;


### PR DESCRIPTION
Fixes osrf/gazebo#3259
Signed-off-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>

# Note

Ideally this bug would be fixed on the Ogre side (so that the right range is applied in D3D11, D3D9, and GL); but this bug was already fixed.

It's just that Gazebo is using an old 1.9 version.

# Note: Compatibility with Ogre 1.11

I do not know if this patch breaks shadows with Ogre 1.11 (which is likely; since Ogre 1.11 should be using the correct range); as I see that the code has various:
`#if OGRE_VERSION_MAJOR == 1 && OGRE_VERSION_MINOR >= 11` signifying it's possible to compile with a new version.

However I tried to use Ogre 1.11 and all I get were crashes (which I workarounded), followed by a black screen once it reaches the main screen. This leads me to believe Gazebo's compatibility with newer Ogre versions hasn't been tested in a long time and hence it's not worth researching.

I am also under the impression Gazebo Classic is in "maintenance only" mode due to LTS support with EOL in January 29, 2025.