### PR TITLE
Fix Instance() method of Singleton classes

### DIFF
--- a/gazebo/common/FuelModelDatabase.cc
+++ b/gazebo/common/FuelModelDatabase.cc
@@ -322,3 +322,16 @@ std::string FuelModelDatabase::CachedFilePath(const std::string &_uri)
 
   return path;
 }
+
+//////////////////////////////////////////////////
+FuelModelDatabase* FuelModelDatabase::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<FuelModelDatabase>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/common/FuelModelDatabase.hh
+++ b/gazebo/common/FuelModelDatabase.hh
@@ -123,6 +123,9 @@ namespace gazebo
       /// \return Local path to the file
       public: std::string CachedFilePath(const std::string &_uri);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static FuelModelDatabase* Instance();
+
       /// \brief Private data.
       private: std::unique_ptr<FuelModelDatabasePrivate> dataPtr;
 

--- a/gazebo/common/MeshManager.cc
+++ b/gazebo/common/MeshManager.cc
@@ -1394,5 +1394,18 @@ void MeshManager::ConvertPolylinesToVerticesAndEdges(
     }
   }
 }
+
+//////////////////////////////////////////////////
+MeshManager* MeshManager::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<MeshManager>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}
 }
 }

--- a/gazebo/common/MeshManager.hh
+++ b/gazebo/common/MeshManager.hh
@@ -261,6 +261,9 @@ namespace gazebo
                       const ignition::math::Vector2d &_p,
                       double _tol);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static MeshManager* Instance();
+
       /// \brief Singleton implementation
       private: friend class SingletonT<MeshManager>;
 

--- a/gazebo/common/ModelDatabase.cc
+++ b/gazebo/common/ModelDatabase.cc
@@ -683,3 +683,16 @@ std::string ModelDatabase::GetModelFile(const std::string &_uri)
 
   return result;
 }
+
+//////////////////////////////////////////////////
+ModelDatabase* ModelDatabase::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<ModelDatabase>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/common/ModelDatabase.hh
+++ b/gazebo/common/ModelDatabase.hh
@@ -150,6 +150,9 @@ namespace gazebo
       /// no one else should use this function.
       private: bool UpdateModelCacheImpl();
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static ModelDatabase* Instance();
+
       /// \brief Private data.
       private: ModelDatabasePrivate *dataPtr;
 

--- a/gazebo/common/SingletonT.hh
+++ b/gazebo/common/SingletonT.hh
@@ -33,7 +33,7 @@ template <class T>
 class SingletonT
 {
   /// \brief Get an instance of the singleton
-  public: static T *Instance()
+  public: static T *Instance() GAZEBO_DEPRECATED(11.0)
           {
             return &GetInstance();
           }

--- a/gazebo/common/SingletonT.hh
+++ b/gazebo/common/SingletonT.hh
@@ -29,6 +29,23 @@
 
 /// \class SingletonT SingletonT.hh common/common.hh
 /// \brief Singleton template class
+///
+/// This class can be used to simplify the implementation of singletons,
+/// i.e. classes that only have one instance. An important constraint to
+/// respect is that for each type `T`, the method SingletonT<T>::Instance
+/// should be instantiated only once. For this reason this method should
+/// be called only once for class, and only in a non-inline method not 
+/// defined in an header file. To ensure that the SingletonT<T>::Instance 
+/// method is not accidentally called in a inline method, or multiple times, 
+/// the method is marked as deprecated. To call it (after making sure that 
+/// you are calling it respecting the constraint given in documentation), 
+/// make sure to temporary suppress deprecation warnings before calling it,
+/// and suppress them again after the Instance method has been called.
+///
+/// See https://github.com/gazebosim/gazebo-classic/pull/3269 for further
+/// details on the use of this class.
+
+
 template <class T>
 class SingletonT
 {

--- a/gazebo/common/SystemPaths.cc
+++ b/gazebo/common/SystemPaths.cc
@@ -577,3 +577,16 @@ void SystemPaths::AddSearchPathSuffix(const std::string &_suffix)
 
   this->suffixPaths.push_back(s);
 }
+
+//////////////////////////////////////////////////
+SystemPaths* SystemPaths::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<SystemPaths>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/common/SystemPaths.hh
+++ b/gazebo/common/SystemPaths.hh
@@ -181,6 +181,9 @@ namespace gazebo
       private: void InsertUnique(const std::string &_path,
                                  std::list<std::string> &_list);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static SystemPaths* Instance();
+
       /// \brief Paths to installed gazebo media files
       private: std::list<std::string> gazeboPaths;
 

--- a/gazebo/gui/KeyEventHandler.cc
+++ b/gazebo/gui/KeyEventHandler.cc
@@ -116,3 +116,16 @@ bool KeyEventHandler::Handle(const common::KeyEvent &_event,
   }
   return false;
 }
+
+//////////////////////////////////////////////////
+KeyEventHandler* KeyEventHandler::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<KeyEventHandler>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/gui/KeyEventHandler.hh
+++ b/gazebo/gui/KeyEventHandler.hh
@@ -145,6 +145,9 @@ namespace gazebo
       private: bool Handle(const common::KeyEvent &_event,
                    std::list<Filter> &_list);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static KeyEventHandler* Instance();
+
       /// \brief This is a singleton class.
       private: friend class SingletonT<KeyEventHandler>;
 

--- a/gazebo/gui/ModelAlign.cc
+++ b/gazebo/gui/ModelAlign.cc
@@ -362,3 +362,16 @@ void ModelAlign::SetHighlighted(const rendering::VisualPtr &_vis,
     }
   }
 }
+
+//////////////////////////////////////////////////
+ModelAlign* ModelAlign::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<ModelAlign>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/gui/ModelAlign.hh
+++ b/gazebo/gui/ModelAlign.hh
@@ -97,6 +97,9 @@ namespace gazebo
       private: void SetHighlighted(const rendering::VisualPtr &_vis,
           const bool _highlight);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static ModelAlign* Instance();
+
       /// \brief This is a singleton class.
       private: friend class SingletonT<ModelAlign>;
 

--- a/gazebo/gui/ModelManipulator.cc
+++ b/gazebo/gui/ModelManipulator.cc
@@ -987,6 +987,19 @@ void ModelManipulator::OnKeyReleaseEvent(const common::KeyEvent &_event)
   this->dataPtr->keyEvent.key = 0;
 }
 
+//////////////////////////////////////////////////
+ModelManipulator* ModelManipulator::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<ModelManipulator>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}
+
 // Function migrated here from GLWidget.cc and commented out since it doesn't
 // seem like it's currently used. Kept here for future references
 /////////////////////////////////////////////////

--- a/gazebo/gui/ModelManipulator.hh
+++ b/gazebo/gui/ModelManipulator.hh
@@ -179,6 +179,9 @@ namespace gazebo
           const ignition::math::Vector3d &_axis,
           const ignition::math::Vector3d &_scale, const std::string &_geom);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static ModelManipulator* Instance();
+
       /// \brief This is a singleton class.
       private: friend class SingletonT<ModelManipulator>;
 

--- a/gazebo/gui/ModelSnap.cc
+++ b/gazebo/gui/ModelSnap.cc
@@ -507,3 +507,16 @@ void ModelSnap::Update()
     this->dataPtr->selectedTriangleDirty = false;
   }
 }
+
+//////////////////////////////////////////////////
+ModelSnap* ModelSnap::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<ModelSnap>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/gui/ModelSnap.hh
+++ b/gazebo/gui/ModelSnap.hh
@@ -111,6 +111,9 @@ namespace gazebo
       /// \brief Update the visual representation of the snap spot.
       private: void Update();
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static ModelSnap* Instance();
+
       /// \brief This is a singleton class.
       private: friend class SingletonT<ModelSnap>;
 

--- a/gazebo/gui/MouseEventHandler.cc
+++ b/gazebo/gui/MouseEventHandler.cc
@@ -135,3 +135,16 @@ void MouseEventHandler::Handle(const common::MouseEvent &_event,
       break;
   }
 }
+
+//////////////////////////////////////////////////
+MouseEventHandler* MouseEventHandler::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<MouseEventHandler>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/gui/MouseEventHandler.hh
+++ b/gazebo/gui/MouseEventHandler.hh
@@ -156,6 +156,9 @@ namespace gazebo
       private: void Handle(const common::MouseEvent &_event,
                    std::list<Filter> &_list);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static MouseEventHandler* Instance();
+
       /// \brief List of mouse press filters.
       private: std::list<Filter> pressFilters;
 

--- a/gazebo/gui/plot/PlotManager.cc
+++ b/gazebo/gui/plot/PlotManager.cc
@@ -190,3 +190,16 @@ std::string PlotManager::HumanReadableName(const std::string &_uri) const
 
   return label;
 }
+
+//////////////////////////////////////////////////
+PlotManager* PlotManager::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<PlotManager>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/gui/plot/PlotManager.hh
+++ b/gazebo/gui/plot/PlotManager.hh
@@ -87,6 +87,9 @@ namespace gazebo
       /// \return Human readable name
       public: std::string HumanReadableName(const std::string &_uri) const;
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static PlotManager* Instance();
+
       /// \brief This is a singleton class.
       private: friend class SingletonT<PlotManager>;
 

--- a/gazebo/gui/plot/TopicCurveHandler.cc
+++ b/gazebo/gui/plot/TopicCurveHandler.cc
@@ -55,6 +55,9 @@ namespace gazebo
       /// \param[in] _msg WorldStats msg.
       public: void OnStats(ConstWorldStatisticsPtr &_msg);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static TopicTime* Instance();
+
       /// \brief Node for communications.
       private: transport::NodePtr node;
 
@@ -166,6 +169,19 @@ void TopicTime::OnStats(ConstWorldStatisticsPtr &_msg)
 
   std::lock_guard<std::mutex> lock(this->mutex);
   this->lastSimTime = msgs::Convert(t);
+}
+
+//////////////////////////////////////////////////
+TopicTime* TopicTime::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<TopicTime>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////

--- a/gazebo/rendering/RTShaderSystem.cc
+++ b/gazebo/rendering/RTShaderSystem.cc
@@ -810,3 +810,16 @@ void RTShaderSystem::UpdateShadows(ScenePtr _scene)
   sceneMgr->setShadowTextureCasterMaterial(_scene->ShadowCasterMaterialName());
 #endif
 }
+
+//////////////////////////////////////////////////
+RTShaderSystem* RTShaderSystem::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<RTShaderSystem>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/rendering/RTShaderSystem.hh
+++ b/gazebo/rendering/RTShaderSystem.hh
@@ -187,6 +187,9 @@ namespace gazebo
       /// \brief Re-apply shadows. Call this if a shadow paramenter is changed.
       private: void ReapplyShadows();
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static RTShaderSystem* Instance();
+
       /// \brief Make the RTShader system a singleton.
       private: friend class SingletonT<RTShaderSystem>;
 

--- a/gazebo/rendering/RenderEngine.cc
+++ b/gazebo/rendering/RenderEngine.cc
@@ -883,3 +883,16 @@ Ogre::OverlaySystem *RenderEngine::OverlaySystem() const
   return this->dataPtr->overlaySystem;
 }
 #endif
+
+//////////////////////////////////////////////////
+RenderEngine* RenderEngine::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<RenderEngine>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/rendering/RenderEngine.hh
+++ b/gazebo/rendering/RenderEngine.hh
@@ -168,6 +168,9 @@ namespace gazebo
       /// \brief Check the rendering capabilities of the system.
       private: void CheckSystemCapabilities();
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static RenderEngine* Instance();
+
       /// \brief ID for a dummy window. Used for gui-less operation
       protected: uint64_t dummyWindowId;
 

--- a/gazebo/sensors/SensorManager.cc
+++ b/gazebo/sensors/SensorManager.cc
@@ -1005,6 +1005,20 @@ bool SensorManager::ImageSensorContainer::WaitForPrerendered(double _timeoutsec)
   return (ret == std::cv_status::no_timeout);
 }
 
+//////////////////////////////////////////////////
+SensorManager* SensorManager::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<SensorManager>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}
+
+
 /////////////////////////////////////////////////
 SimTimeEventHandler::SimTimeEventHandler()
 {

--- a/gazebo/sensors/SensorManager.hh
+++ b/gazebo/sensors/SensorManager.hh
@@ -193,6 +193,9 @@ namespace gazebo
       /// \param[in] _sensor Pointer to a sensor to add.
       private: void AddSensor(SensorPtr _sensor);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static SensorManager* Instance();
+
       /// \cond
       /// \brief A container for sensors of a specific type. This is used to
       /// separate sensors which rely on the rendering engine from those

--- a/gazebo/transport/ConnectionManager.cc
+++ b/gazebo/transport/ConnectionManager.cc
@@ -712,3 +712,16 @@ void ConnectionManager::TriggerUpdate()
 {
   this->updateCondition.notify_all();
 }
+
+//////////////////////////////////////////////////
+ConnectionManager* ConnectionManager::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<ConnectionManager>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/transport/ConnectionManager.hh
+++ b/gazebo/transport/ConnectionManager.hh
@@ -167,6 +167,9 @@ namespace gazebo
       /// \brief Run the manager update loop once
       private: void RunUpdate();
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static ConnectionManager* Instance();
+
       /// \brief Condition used to trigger an update.
       private: boost::condition_variable updateCondition;
 

--- a/gazebo/transport/TopicManager.cc
+++ b/gazebo/transport/TopicManager.cc
@@ -457,3 +457,16 @@ void TopicManager::PauseIncoming(bool _pause)
 {
   this->pauseIncoming = _pause;
 }
+
+//////////////////////////////////////////////////
+TopicManager* TopicManager::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<TopicManager>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/transport/TopicManager.hh
+++ b/gazebo/transport/TopicManager.hh
@@ -244,6 +244,9 @@ namespace gazebo
       /// \param[in] _ptr Node to process.
       public: void AddNodeToProcess(NodePtr _ptr);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static TopicManager* Instance();
+
       /// \brief A map of string->list of Node pointers
       typedef std::map<std::string, std::list<NodePtr> > SubNodeMap;
 

--- a/gazebo/util/Diagnostics.cc
+++ b/gazebo/util/Diagnostics.cc
@@ -250,6 +250,19 @@ common::Time DiagnosticManager::Time(const std::string &_label) const
 }
 
 //////////////////////////////////////////////////
+DiagnosticManager* DiagnosticManager::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<DiagnosticManager>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}
+
+//////////////////////////////////////////////////
 DiagnosticTimer::DiagnosticTimer(const std::string &_name)
 : Timer(),
   dataPtr(new DiagnosticTimerPrivate)

--- a/gazebo/util/Diagnostics.hh
+++ b/gazebo/util/Diagnostics.hh
@@ -143,6 +143,9 @@ namespace gazebo
                    const common::Time &_wallTime,
                    const common::Time &_elapsedtime);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static DiagnosticManager* Instance();
+
       // Singleton implementation
       private: friend class SingletonT<DiagnosticManager>;
 

--- a/gazebo/util/IntrospectionManager.cc
+++ b/gazebo/util/IntrospectionManager.cc
@@ -642,3 +642,16 @@ bool IntrospectionManager::ValidateParameter(const gazebo::msgs::Param &_msg,
 
   return true;
 }
+
+//////////////////////////////////////////////////
+IntrospectionManager* IntrospectionManager::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<IntrospectionManager>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/util/IntrospectionManager.hh
+++ b/gazebo/util/IntrospectionManager.hh
@@ -193,6 +193,9 @@ namespace gazebo
       private: bool ValidateParameter(const gazebo::msgs::Param &_msg,
                              const std::set<std::string> &_allowedValues) const;
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static IntrospectionManager* Instance();
+
       /// \brief This is a singleton.
       private: friend class SingletonT<IntrospectionManager>;
 

--- a/gazebo/util/LogPlay.cc
+++ b/gazebo/util/LogPlay.cc
@@ -838,3 +838,16 @@ bool LogPlay::PrevChunk()
 
   return true;
 }
+
+//////////////////////////////////////////////////
+LogPlay* LogPlay::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<LogPlay>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/util/LogPlay.hh
+++ b/gazebo/util/LogPlay.hh
@@ -184,6 +184,9 @@ namespace gazebo
       /// chunks before the current one.
       private: bool PrevChunk();
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static LogPlay* Instance();
+
       /// \internal
       /// \brief Private data pointer
       private: std::unique_ptr<LogPlayPrivate> dataPtr;

--- a/gazebo/util/LogRecord.cc
+++ b/gazebo/util/LogRecord.cc
@@ -1110,3 +1110,16 @@ unsigned int LogRecord::BufferSize() const
 
   return size;
 }
+
+//////////////////////////////////////////////////
+LogRecord* LogRecord::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<LogRecord>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}

--- a/gazebo/util/LogRecord.hh
+++ b/gazebo/util/LogRecord.hh
@@ -262,6 +262,9 @@ namespace gazebo
       /// \brief Used to get the simulation pause state.
       private: void OnPause(const bool _pause);
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static LogRecord* Instance();
+
       /// \brief This is a singleton
       private: friend class SingletonT<LogRecord>;
 

--- a/gazebo/util/OpenAL.cc
+++ b/gazebo/util/OpenAL.cc
@@ -187,6 +187,19 @@ std::set<std::string> OpenAL::DeviceList() const
   return deviceList;
 }
 
+//////////////////////////////////////////////////
+OpenAL* OpenAL::Instance()
+{
+#ifndef _WIN32
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+  return SingletonT<OpenAL>::Instance();
+#ifndef _WIN32
+  #pragma GCC diagnostic pop
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 //                      OPENAL LISTENER

--- a/gazebo/util/OpenAL.hh
+++ b/gazebo/util/OpenAL.hh
@@ -81,6 +81,9 @@ namespace gazebo
       /// \return A list of audio device names
       public: std::set<std::string> DeviceList() const;
 
+      /// \brief Returns a pointer to the unique (static) instance
+      public: static OpenAL* Instance();
+
       /// \internal
       /// \brief Private data pointer.
       private: std::unique_ptr<OpenALPrivate> dataPtr;


### PR DESCRIPTION
In particular, make sure that all the Instance() methods of the same class always use the same instantiation.

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/conda-forge/gazebo-feedstock/issues/148 .

## Summary

This should fix all the cases in which multiple instances of a Singleton classes were observed, as for example in conda-forge/macOS build of Classic Gazebo (see https://github.com/conda-forge/gazebo-feedstock/issues/148#issuecomment-1249496093). The fix was inspired from https://github.com/gazebosim/gz-sim/issues/1725 and from the related PRs:
* https://github.com/gazebosim/gz-common/pull/451
* https://github.com/gazebosim/gz-rendering/pull/734

Thanks a lot to @azeey for suggesting the correct fix in https://github.com/conda-forge/gazebo-feedstock/pull/152#issuecomment-1275198706 .

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
