### PR TITLE
Remove legacy workarounds in  conda-forge GitHub Actions job

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -37,9 +37,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        # re-add dartsim once the libsdformat 9.8 issue is resolved
-        # https://github.com/osrf/gazebo/pull/3223#issuecomment-1140019713
-        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt=5.12.9=*_4 ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp simbody hdf5 openal-soft glib gts
+        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt-main ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp simbody hdf5 openal-soft glib gts dartsim
 
     - name: Linux-only Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

In https://github.com/gazebosim/gazebo-classic/pull/3223#issuecomment-1140038513 we added some workarounds for the conda-forge CI, namely pin the version of some dependencies and removed dartsim. Now that the long term fixes to that problems (linked in https://github.com/gazebosim/gazebo-classic/pull/3223#issuecomment-1140038513) has been fixed, we can remove the workarounds.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
