### PR TITLE
Fix for opende heightfield and console spam

### DIFF
--- a/deps/opende/src/heightfield.cpp
+++ b/deps/opende/src/heightfield.cpp
@@ -880,7 +880,7 @@ dGeomID dCreateHeightfield( dSpaceID space, dHeightfieldDataID data, int bPlacea
 void dGeomHeightfieldSetHeightfieldData( dGeomID g, dHeightfieldDataID d )
 {
     dxHeightfield* geom = (dxHeightfield*) g;
-    geom->data = d;
+    geom->m_p_data = d;
 }
 
 

--- a/gazebo/rendering/Visual.cc
+++ b/gazebo/rendering/Visual.cc
@@ -2180,8 +2180,11 @@ void Visual::SetRibbonTrail(bool _value,
 //////////////////////////////////////////////////
 DynamicLines *Visual::CreateDynamicLine(RenderOpType _type)
 {
-  this->dataPtr->preRenderConnection = event::Events::ConnectPreRender(
-      boost::bind(&Visual::Update, this));
+  if (!this->dataPtr->preRenderConnection)
+  {
+    this->dataPtr->preRenderConnection = event::Events::ConnectPreRender(
+        boost::bind(&Visual::Update, this));
+  }
 
   DynamicLines *line = new DynamicLines(_type);
   this->dataPtr->lines.push_back(line);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a memory access bug in the Open Dynamics Engine heightfield collision code and helps reduce some console spam

## Summary

This includes two small bug fixes:

* https://github.com/gazebosim/gazebo-classic/commit/37544c562e53449923ab06d83caf3ef23693c78b: port of fix for memory access bug from [odedevs/ode@63caf226abf3](https://bitbucket.org/odedevs/ode/commits/63caf226abf3be2225972955bec828f65887886f) on bitbucket.
* https://github.com/gazebosim/gazebo-classic/commit/4063d6ef1362e83da162675793df81934334f1d9: reduction in console spam from `[Event.cc:61] Warning: Deleting a connection right after creation. Make sure to save the ConnectionPtr from a Connect call.` messages.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
