### PR TITLE
Fixing  WideAngleCamera Lensflare issue 

### DIFF
--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -214,6 +214,8 @@ namespace gazebo
       // a gazebo camera object
       std::vector<Ogre::Camera *> ogreEnvCameras =
           _wideAngleCam->OgreEnvCameras();
+      // set dummy camera properties based on env cam
+      Ogre::Camera *cam = ogreEnvCameras[0];
       if (!this->dataPtr->wideAngleDummyCamera)
       {
         // create camera with auto render set to false
@@ -227,17 +229,15 @@ namespace gazebo
             dummyCamName, false);
         this->dataPtr->wideAngleDummyCamera->Load();
 
-        // set dummy camera properties based on env cam
-        Ogre::Camera *cam = ogreEnvCameras[0];
         this->dataPtr->wideAngleDummyCamera->SetImageWidth(
-            cam->getViewport()->getActualWidth());
+            _wideAngleCam->ViewportWidth());
         this->dataPtr->wideAngleDummyCamera->SetImageHeight(
-            cam->getViewport()->getActualHeight());
+            _wideAngleCam->ViewportHeight());
         this->dataPtr->wideAngleDummyCamera->Init();
         this->dataPtr->wideAngleDummyCamera->CreateRenderTexture(
             dummyCamName + "_rtt");
         this->dataPtr->wideAngleDummyCamera->SetAspectRatio(
-            cam->getAspectRatio());
+            _wideAngleCam->AspectRatio());
         // aspect ratio should be 1.0 so VFOV should equal to HFOV
         this->dataPtr->wideAngleDummyCamera->SetHFOV(
             ignition::math::Angle(cam->getFOVy().valueRadians()));
@@ -268,15 +268,9 @@ namespace gazebo
       lightPos.z = (imagePos.Z() > 1.75) ? -1 : 1;
 
       // check occlusion and set scale
-      // loop through all env cameras and find the cam that sees the light
-      // ray cast using that env camera to see if the distance to closest
-      // intersection point is less than light's world pos
       double occlusionScale = 1.0;
       if (lightPos.z >= 0.0)
       {
-        // loop through all env cameras
-        for (auto cam : ogreEnvCameras)
-        {
           // project light world point to camera clip space.
           auto viewProj = cam->getProjectionMatrix() * cam->getViewMatrix();
           auto pos = viewProj *
@@ -284,7 +278,8 @@ namespace gazebo
           pos.x /= pos.w;
           pos.y /= pos.w;
           // check if light is visible
-          if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 && pos.z > 0)
+          if (std::fabs(pos.x) <= 1 &&
+              std::fabs(pos.y) <= 1 && pos.z > abs(pos.w))
           {
             // check occlusion using this env camera
             this->dataPtr->wideAngleDummyCamera->SetWorldPose(
@@ -296,9 +291,7 @@ namespace gazebo
                 this->dataPtr->wideAngleDummyCamera,
                 ignition::math::Vector3d(pos.x, pos.y, pos.z),
                 this->dataPtr->lightWorldPos);
-            break;
           }
-        }
       }
       _pos = Conversions::ConvertIgn(lightPos);
       _scale = occlusionScale * this->dataPtr->scale;
@@ -347,8 +340,11 @@ namespace gazebo
           screenPos.X() = ((j / 2.0) + 0.5) * viewportWidth;
           screenPos.Y() = (1 - ((i / 2.0) + 0.5)) * viewportHeight;
           intersect = scene->FirstContact(_cam, screenPos, position);
-          if (intersect && (position.Length() < _worldPos.Length()))
+          if (intersect &&
+              (position.SquaredLength() < _worldPos.SquaredLength()))
+          {
             occluded++;
+          }
           rays++;
         }
       }

--- a/gazebo/rendering/WideAngleCamera.cc
+++ b/gazebo/rendering/WideAngleCamera.cc
@@ -773,7 +773,8 @@ ignition::math::Vector3d WideAngleCamera::Project3d(
     pos.x /= pos.w;
     pos.y /= pos.w;
     // check if point is visible
-    if (std::fabs(pos.x) <= 1 && std::fabs(pos.y) <= 1 && pos.z > 0)
+    if (std::fabs(pos.x) <= 1 &&
+        std::fabs(pos.y) <= 1 && pos.z > -std::fabs(pos.w))
     {
       // determine dir vector to projected point from env camera
       // work in y up, z forward, x right clip space

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -1412,6 +1412,107 @@ TEST_F(CameraSensor, LensFlare)
 }
 
 /////////////////////////////////////////////////
+TEST_F(CameraSensor, LensFlareWideAngleCamera)
+{
+  Load("worlds/lensflare_wideangle_cam.world");
+
+  // Make sure the render engine is available.
+  if (rendering::RenderEngine::Instance()->GetRenderPathType() ==
+      rendering::RenderEngine::NONE)
+  {
+    gzerr << "No rendering engine, unable to run camera test\n";
+    return;
+  }
+
+  // Get the lens flare wide angle camera model.
+  std::string modelNameLensFlare = "wide_angle_cameras_near_heightmap";
+  std::string cameraNameLensFlare = "camera_sensor_lensflare";
+
+  physics::WorldPtr world = physics::get_world();
+  ASSERT_TRUE(world != nullptr);
+  physics::ModelPtr model = world->ModelByName(modelNameLensFlare);
+  ASSERT_TRUE(model != nullptr);
+
+  sensors::SensorPtr sensorLensFlare =
+    sensors::get_sensor(cameraNameLensFlare);
+  sensors::CameraSensorPtr camSensorLensFlare =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorLensFlare);
+  ASSERT_TRUE(camSensorLensFlare != nullptr);
+
+  // Get the wide angle camera without the lens flare.
+  std::string modelNameWithoutLensFlare = "wide_angle_cameras_near_heightmap";
+  std::string cameraNameWithoutLensFlare = "camera_sensor_without_lensflare";
+
+  model = world->ModelByName(modelNameWithoutLensFlare);
+  ASSERT_TRUE(model != nullptr);
+
+  sensors::SensorPtr sensorWithoutLensFlare =
+    sensors::get_sensor(cameraNameWithoutLensFlare);
+  sensors::CameraSensorPtr camSensorWithoutLensFlare =
+    std::dynamic_pointer_cast<sensors::CameraSensor>(sensorWithoutLensFlare);
+  ASSERT_TRUE(camSensorWithoutLensFlare != nullptr);
+
+  unsigned int width = 320;
+  unsigned int height = 240;
+
+  // Collect images from the 2 cameras.
+  imageCount = 0;
+  imageCount2 = 0;
+  img = new unsigned char[width * height * 3];
+  img2 = new unsigned char[width * height * 3];
+  event::ConnectionPtr c =
+    camSensorLensFlare->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount, img,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+  event::ConnectionPtr c2 =
+    camSensorWithoutLensFlare->Camera()->ConnectNewImageFrame(
+        std::bind(&::OnNewCameraFrame, &imageCount2, img2,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3,
+          std::placeholders::_4, std::placeholders::_5));
+
+  // Get some images.
+  int sleep = 0;
+  while ((imageCount < 10 || imageCount2 < 10)
+      && sleep++ < 1000)
+  {
+    common::Time::MSleep(10);
+  }
+
+  EXPECT_GE(imageCount, 10);
+  EXPECT_GE(imageCount2, 10);
+
+  c.reset();
+  c2.reset();
+
+  // Compare colors.
+  unsigned int colorSum = 0;
+  unsigned int colorSum2 = 0;
+  for (unsigned int y = 0; y < height; ++y)
+  {
+    for (unsigned int x = 0; x < width*3; x+=3)
+    {
+      unsigned int r = img[(y*width*3) + x];
+      unsigned int g = img[(y*width*3) + x + 1];
+      unsigned int b = img[(y*width*3) + x + 2];
+      colorSum += r + g + b;
+      unsigned int r2 = img2[(y*width*3) + x];
+      unsigned int g2 = img2[(y*width*3) + x + 1];
+      unsigned int b2 = img2[(y*width*3) + x + 2];
+      colorSum2 += r2 + g2 + b2;
+    }
+  }
+
+  // Camera with lens flare should be brighter than camera without it.
+  EXPECT_GT(colorSum, colorSum2) <<
+      "colorSum: " << colorSum << ", " <<
+      "colorSum2: " << colorSum2;
+
+  delete[] img;
+  delete[] img2;
+}
+
+/////////////////////////////////////////////////
 TEST_F(CameraSensor, 16bit)
 {
   // World contains a box positioned at top right quadrant of image generated

--- a/worlds/lensflare_wideangle_cam.world
+++ b/worlds/lensflare_wideangle_cam.world
@@ -78,7 +78,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -88,7 +88,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -101,7 +101,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -111,7 +111,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -138,7 +138,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -148,7 +148,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -161,7 +161,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -171,7 +171,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -205,7 +205,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -215,7 +215,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -228,7 +228,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -238,7 +238,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -272,7 +272,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -282,7 +282,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -295,7 +295,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -305,7 +305,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -339,7 +339,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -349,7 +349,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -362,7 +362,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -372,7 +372,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>

--- a/worlds/lensflare_wideangle_cam.world
+++ b/worlds/lensflare_wideangle_cam.world
@@ -1,0 +1,389 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="default">
+
+  <!-- Light Source -->
+  <light type="directional" name="sun">
+    <cast_shadows>true</cast_shadows>
+    <pose>0 0 0 0.0 0.0 0.0</pose>
+    <diffuse>1.0 1.0 1.0 1.0</diffuse>
+    <specular>0.2 0.2 0.2 1</specular>
+    <direction>-1.0 0.0 -0.2</direction>
+  </light>
+
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <model name="heightmap">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <heightmap>
+              <uri>file://media/materials/textures/heightmap_bowl.png</uri>
+              <size>129 129 10</size>
+              <pos>0 0 0</pos>
+            </heightmap>
+          </geometry>
+        </collision>
+        <visual name="visual_abcedf">
+          <geometry>
+            <heightmap>
+              <use_terrain_paging>false</use_terrain_paging>
+              <texture>
+                <diffuse>file://media/materials/textures/dirt_diffusespecular.png</diffuse>
+                <normal>file://media/materials/textures/flat_normal.png</normal>
+                <size>1</size>
+              </texture>
+              <texture>
+                <diffuse>file://media/materials/textures/grass_diffusespecular.png</diffuse>
+                <normal>file://media/materials/textures/flat_normal.png</normal>
+                <size>1</size>
+              </texture>
+              <texture>
+                <diffuse>file://media/materials/textures/fungus_diffusespecular.png</diffuse>
+                <normal>file://media/materials/textures/flat_normal.png</normal>
+                <size>1</size>
+              </texture>
+              <blend>
+                <min_height>2</min_height>
+                <fade_dist>5</fade_dist>
+              </blend>
+              <blend>
+                <min_height>4</min_height>
+                <fade_dist>5</fade_dist>
+              </blend>
+              <uri>file://media/materials/textures/heightmap_bowl.png</uri>
+              <size>129 129 10</size>
+              <pos>0 0 0</pos>
+            </heightmap>
+          </geometry>
+        </visual>
+      </link>
+    </model>
+
+    <!-- model with two wide-angle cameras, with and without lens flare plugin -->
+    <model name="wide_angle_cameras_near_heightmap">
+      <static>true</static>
+      <pose>0 2 5.2 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+        </sensor>
+        <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <!-- model with two wide-angle cameras, with and without lens flare plugin -->
+    <model name="wide_angle_cameras_above_heightmap">
+      <static>true</static>
+      <pose>0 2 11.0 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+        </sensor>
+        <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <!-- A box that should occlude a camera's lens flare -->
+    <include>
+      <uri>model://brick_box_3x1x3</uri>
+      <pose>5 12 5 0 0 1.57</pose>
+      <name>brick_box_low</name>
+    </include>
+
+    <!-- model with two wide-angle cameras, with and without lens flare plugin -->
+    <model name="wide_angle_cameras_occluded_low">
+      <static>true</static>
+      <pose>0 12 5.2 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+        </sensor>
+        <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <!-- A box that should occlude a camera's lens flare -->
+    <include>
+      <uri>model://brick_box_3x1x3</uri>
+      <pose>5 12 10 0 0 1.57</pose>
+      <name>brick_box_high</name>
+    </include>
+
+    <!-- model with two wide-angle cameras, with and without lens flare plugin -->
+    <model name="wide_angle_cameras_occluded_high">
+      <static>true</static>
+      <pose>0 12 11.0 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+        </sensor>
+        <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+    <!-- A box that should occlude a camera's lens flare -->
+    <include>
+      <uri>model://brick_box_3x1x3</uri>
+      <pose>0 11 20 0 0 0</pose>
+      <name>brick_box_higher_side</name>
+    </include>
+
+    <!-- model with two wide-angle cameras, with and without lens flare plugin -->
+    <model name="wide_angle_cameras_occluded_higher">
+      <static>true</static>
+      <pose>0 12 21.0 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+        </sensor>
+        <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>1.047</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>gnomonical</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>25</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Signed-off-by: Sanjuksha Nirgude <sanjuksha@gmail.com>


# 🦟 Bug fix
https://github.com/gazebosim/gazebo-classic/issues/3273

## Summary
Porting the same change for gazebo classic from https://github.com/gazebosim/gz-rendering/pull/746  and a fix for wide angle camera not showing lensflare at certain angles. Wide Angle camera used to loop through all cameras to find the occlusion scale which resulted into not rendering lensfalre at certain angles. The fix removes the looping through all cameras and uses the camera facing the light source to calculate occlusion. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers


# Results 

![Screenshot from 2022-11-15 16-55-46](https://user-images.githubusercontent.com/28096692/202280539-e77c6641-116d-4601-8432-8fea8868bbe7.png)
