### PR TITLE
Fix crash with DEM and Camera

### DIFF
--- a/gazebo/rendering/Heightmap.cc
+++ b/gazebo/rendering/Heightmap.cc
@@ -425,6 +425,11 @@ void Heightmap::Load()
        sphericalCoordinates = boost::make_shared<common::SphericalCoordinates>(
                   common::SphericalCoordinates::MOON_SCS);
     }
+    else
+    {
+       sphericalCoordinates = boost::make_shared<common::SphericalCoordinates>(
+                  common::SphericalCoordinates::EARTH_WGS84);
+    }
 
     this->dataPtr->heightmapData = common::HeightmapDataLoader::LoadTerrainFile(
         this->dataPtr->filename, sphericalCoordinates);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes crash introduced by #3257 

## Summary

While reviewing #3257, I didn't notice one instance in `rendering/Heightmap.cc` in which a `SphericalCoordinates` pointer will be passed in its default `nullptr` state when the surface type is `EARTH_WGS84`. It particularly causes a crash when loading a DEM in `gzclient` or loading a DEM with a camera sensor in `gzserver`. This adds a failing test with a CameraSensor and DEM in https://github.com/gazebosim/gazebo-classic/commit/9739cebbb4d56e427ff99edca2a97b7dc85f8670 and.a fix in https://github.com/gazebosim/gazebo-classic/commit/75f9e6cc73ccc4f999db8925939e3cf9c3237985.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
