### PR TITLE
Remove GZ_SINGLETON_DECLARE definition workaround (fix for armhf)

### DIFF
--- a/gazebo/common/SingletonT.hh
+++ b/gazebo/common/SingletonT.hh
@@ -52,23 +52,5 @@ class SingletonT
            }
 };
 
-/// \brief Helper to declare typed SingletonT
-// clang doesn't compile if it explicitly specializes a type before
-// the type is defined. (forward declaration is not enough.)
-#ifdef __clang__
 #define GZ_SINGLETON_DECLARE(visibility, n1, n2, singletonType)
-#else
-#define GZ_SINGLETON_DECLARE(visibility, n1, n2, singletonType) \
-namespace n1 \
-{ \
-  namespace n2 \
-  { \
-    class singletonType; \
-  } \
-} \
-template class visibility ::SingletonT<n1::n2::singletonType>;
-#endif
-
-/// \}
-
 #endif


### PR DESCRIPTION
Signed-off-by: Jose Luis Rivero <jrivero@osrfoundation.org>

# 🦟 Bug fix

Fixes #3208. 

## Summary
The trick of defining the template function specialized was introduced [in a commit part of the Windows works](https://github.com/gazebosim/gazebo-classic/commit/7f465242ae537f156353eb59af113b7b786de481#diff-9e0097c29a87bb223bef9013319db8dc6c73d9e559bfc41e3067495dccf8936e) as part of the Windows works, seems to me like a workaround to make the compilation to work somehow. On my Jammy testing system, both clang and gcc compiled it fine with this PR and packages were made using gcc for arm64, armhf and ppc64.

Did not test it on Windows, let's see if the CI is happy or it was indeed needed.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.