### PR TITLE
Fix conda-forge GitHub Action CI by using mambaforge directly and by supporting graphviz >= 3 on Windows

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -25,9 +25,8 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
-        channels: conda-forge
-        channel-priority: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
 
     - name: Dependencies
       shell: bash -l {0}

--- a/gazebo/gui/CMakeLists.txt
+++ b/gazebo/gui/CMakeLists.txt
@@ -160,6 +160,17 @@ if (HAVE_GRAPHVIZ)
   # Activate Export macro for building the library itself
   # if QGVCORE_LIB is not set or equal 0 (null), import macro is used
   add_definitions(-DQGVCORE_LIB)
+  # If Graphviz >= 3.0.0 is used as shared library on Windows, the GVDLL 
+  # preprocess definition should be defined. As at this point we can't 
+  # know if graphviz is shared or static, we always defined GVDLL, 
+  # leaving an option that users can use to explicitly specify that 
+  # the linked graphviz is static
+  option(GAZEBO_FINDGRAPHVIZ_USE_STATIC_GRAPHVIZ 
+         "Enable when linking a static graphviz" OFF)
+  mark_as_advanced(GAZEBO_FINDGRAPHVIZ_USE_STATIC_GRAPHVIZ)
+  if(WIN32 AND NOT GAZEBO_FINDGRAPHVIZ_USE_STATIC_GRAPHVIZ)
+    add_definitions(-DGVDLL)
+  endif()
   include_directories(${GRAPHVIZ_INCLUDE_DIR})
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/qgv)
   include_directories(${CMAKE_CURRENT_SOURCE_DIR}/qgv/private)


### PR DESCRIPTION
# 🦟 Bug fix

Fix conda-forge CI.

## Summary

The fix is composed by two unrelated changes

### [Fix conda-forge GitHub Action CI by using mambaforge directly](https://github.com/gazebosim/gazebo-classic/commit/eea77c2d831763f6123b30e2b1a910b98205189a)

Currently the CI is failing on Linux and Windows with a weird conflict error. This is due to the fact that we are install mamba (from the conda-forge channel) on the top of miniconda3 (that by default install all the packages from the defaults channel). To make an analogy in apt world, this is like installing Debian, and then trying to install packages from the Ubuntu repo: something can go wrong.

To solve this problem, we install [mambaforge](https://github.com/conda-forge/miniforge) (a installer like miniconda3 but already using conda-forge packages) directly, so we always and only use packages from the conda-forge channel. 

Similar to:
* https://github.com/robotology/robotology-superbuild/pull/840
* https://github.com/robotology/robometry/pull/141
* https://github.com/robotology-playground/yarp-devices-ros2/pull/44

### [Add support to use graphviz >= 3 on Windows](https://github.com/gazebosim/gazebo-classic/commit/15435b1520b7fbe041cb79c5f57829ab028eb5dc)

Since graphviz 3, any downstream library that on Windows links against a graphviz shared library needs to define the `GVDLL` preprocessor definition (see https://gitlab.com/graphviz/graphviz/-/blob/3.0.0/CHANGELOG.md#changed). 

To deal with this, this PR adds the `GVDLL` definition for `gazebo_gui` when on Windows (on graphviz < 3 defining this definition will be harmless). As that prepocessor definition should not be set when linking static graphviz, and given that we can't detect in `FindGraphviz`  if the linked graphviz is static or not, an ad-hoc CMake variable `GAZEBO_FINDGRAPHVIZ_USE_STATIC_GRAPHVIZ` is introduced in the case this definition needs to be disabled. 


Similar to https://github.com/robotology/ycm/pull/414 .


## Checklist
- [ ] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

