### PR TITLE
msgs.cc: add missing <array> include

### DIFF
--- a/gazebo/msgs/msgs.cc
+++ b/gazebo/msgs/msgs.cc
@@ -17,6 +17,7 @@
 
 #include <google/protobuf/descriptor.h>
 #include <algorithm>
+#include <array>
 #include <ignition/math/MassMatrix3.hh>
 #include <ignition/math/Rand.hh>
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/osrf/homebrew-simulation/issues/2179

## Summary

There is a reported build failure on some versions of macOS in https://github.com/osrf/homebrew-simulation/issues/2179, and I observed a failed bottle build on macOS Monterey:

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=generic-release-homebrew_triggered_bottle_builder%2Flabel%3Dosx_monterey&build=1088)](https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/label=osx_monterey/1088/) https://build.osrfoundation.org/job/generic-release-homebrew_triggered_bottle_builder/1088/label=osx_monterey/

There is a complaint about `msgs.cc`:

~~~
gazebo/msgs/msgs.cc:2023:34: error: implicit instantiation of undefined template 'std::array<std::string, 2>'
std::array<std::string, 2> dimensions = {{"horizontal", "vertical"}};
^
~~~

The solution is to include the `<array>` header file.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
