### PR TITLE
Set initial sim time from the command-line

### DIFF
--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -194,6 +194,8 @@ bool Server::ParseArgs(int _argc, char **_argv)
      "Absolute path in which to store state data")
     ("record_period", po::value<double>()->default_value(-1),
      "Recording period (seconds).")
+    ("initial_sim_time", po::value<double>(),
+     "Initial simulation time (seconds).")
     ("record_filter", po::value<std::string>()->default_value(""),
      "Recording filter (supports wildcard and regular expression).")
     ("record_resources", "Recording with model meshes and materials.")
@@ -403,6 +405,23 @@ bool Server::ParseArgs(int _argc, char **_argv)
         gzerr << "Specified profile [" << profileName << "] was not found."
               << std::endl;
       }
+    }
+  }
+
+  if (this->dataPtr->vm.count("initial_sim_time"))
+  {
+    try
+    {
+      physics::get_world()->SetSimTime(
+          common::Time(this->dataPtr->vm["initial_sim_time"].as<double>()));
+      gzmsg << "Setting initial sim time to [" <<
+        physics::get_world()->SimTime() << "]\n" << std::endl;
+    }
+    catch(...)
+    {
+      gzerr << "Unable to cast initial_sim_time[" <<
+        this->dataPtr->vm["initial_sim_time"].as<double>() << "] "
+        << "to double for setting initial sim time\n" << std::endl;
     }
   }
 

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -197,9 +197,9 @@ bool Server::ParseArgs(int _argc, char **_argv)
     ("record_filter", po::value<std::string>()->default_value(""),
      "Recording filter (supports wildcard and regular expression).")
     ("record_resources", "Recording with model meshes and materials.")
+    ("seed",  po::value<double>(), "Start with a given random number seed.")
     ("initial_sim_time", po::value<double>(),
      "Initial simulation time (seconds).")
-    ("seed",  po::value<double>(), "Start with a given random number seed.")
     ("iters",  po::value<unsigned int>(), "Number of iterations to simulate.")
     ("minimal_comms", "Reduce the TCP/IP traffic output by gzserver")
     ("server-plugin,s", po::value<std::vector<std::string> >(),

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -752,10 +752,6 @@ void Server::ProcessParams()
           this->dataPtr->params.count("record_resources") > 0;
       util::LogRecord::Instance()->Start(params);
     }
-    else {
-      gzerr << "Unknown parameter[" << iter->first << "] with value["
-            << iter->second << "]" << std::endl;
-    }
   }
 }
 

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -194,11 +194,11 @@ bool Server::ParseArgs(int _argc, char **_argv)
      "Absolute path in which to store state data")
     ("record_period", po::value<double>()->default_value(-1),
      "Recording period (seconds).")
-    ("initial_sim_time", po::value<double>(),
-     "Initial simulation time (seconds).")
     ("record_filter", po::value<std::string>()->default_value(""),
      "Recording filter (supports wildcard and regular expression).")
     ("record_resources", "Recording with model meshes and materials.")
+    ("initial_sim_time", po::value<double>(),
+     "Initial simulation time (seconds).")
     ("seed",  po::value<double>(), "Start with a given random number seed.")
     ("iters",  po::value<unsigned int>(), "Number of iterations to simulate.")
     ("minimal_comms", "Reduce the TCP/IP traffic output by gzserver")
@@ -751,6 +751,10 @@ void Server::ProcessParams()
       params.recordResources =
           this->dataPtr->params.count("record_resources") > 0;
       util::LogRecord::Instance()->Start(params);
+    }
+    else {
+      gzerr << "Unknown parameter[" << iter->first << "] with value["
+            << iter->second << "]" << std::endl;
     }
   }
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -121,6 +121,7 @@ set(tests
   world_entity_below_point.cc
   world_playback.cc
   world_population.cc
+  world_with_initial_sim_time_from_cli.cc
   worlds_installed.cc
   )
 

--- a/test/integration/world_with_initial_sim_time_from_cli.cc
+++ b/test/integration/world_with_initial_sim_time_from_cli.cc
@@ -28,19 +28,10 @@ class WorldWithInitialSimTimeFromCliTest : public ServerFixture
   /// \brief Class constructor.
   public: WorldWithInitialSimTimeFromCliTest()
   {
-    // Start the server with a log file and paused.
+    // Start the server with an inital sim time and paused.
     this->LoadArgs("-u --initial_sim_time " + std::to_string(initialSimTime));
     this->world = physics::get_world("default");
-
-    // Prepare the transport.
-    this->node = transport::NodePtr(new transport::Node());
-    this->node->Init();
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
   }
-
-  /// \brief Gazebo transport node.
-  public: transport::NodePtr node;
 
   /// \brief Pointer to the world.
   public: physics::WorldPtr world;

--- a/test/integration/world_with_initial_sim_time_from_cli.cc
+++ b/test/integration/world_with_initial_sim_time_from_cli.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <string>
+#include "gazebo/common/Time.hh"
+#include "gazebo/test/ServerFixture.hh"
+
+using namespace gazebo;
+
+const double initialSimTime = 1675117690.123456;
+
+/// \brief Helper class that initializes each test.
+class WorldWithInitialSimTimeFromCliTest : public ServerFixture
+{
+  /// \brief Class constructor.
+  public: WorldWithInitialSimTimeFromCliTest()
+  {
+    // Start the server with a log file and paused.
+    this->LoadArgs("-u --initial_sim_time " + std::to_string(initialSimTime));
+    this->world = physics::get_world("default");
+
+    // Prepare the transport.
+    this->node = transport::NodePtr(new transport::Node());
+    this->node->Init();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  }
+
+  /// \brief Gazebo transport node.
+  public: transport::NodePtr node;
+
+  /// \brief Pointer to the world.
+  public: physics::WorldPtr world;
+};
+
+/////////////////////////////////////////////////
+/// \brief Check that the initial simulation time is set correctly.
+TEST_F(WorldWithInitialSimTimeFromCliTest, Pause)
+{
+  ASSERT_TRUE(this->world != NULL);
+  EXPECT_TRUE(this->world->IsPaused());
+
+  // check that the simulation time is the same as the initial sim time
+  EXPECT_DOUBLE_EQ(this->world->SimTime().Double(), initialSimTime);
+}
+
+/////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/integration/world_with_initial_sim_time_from_cli.cc
+++ b/test/integration/world_with_initial_sim_time_from_cli.cc
@@ -48,7 +48,7 @@ class WorldWithInitialSimTimeFromCliTest : public ServerFixture
 
 /////////////////////////////////////////////////
 /// \brief Check that the initial simulation time is set correctly.
-TEST_F(WorldWithInitialSimTimeFromCliTest, Pause)
+TEST_F(WorldWithInitialSimTimeFromCliTest, CheckInitialSimTime)
 {
   ASSERT_TRUE(this->world != NULL);
   EXPECT_TRUE(this->world->IsPaused());


### PR DESCRIPTION
This PR adds the `--initial_sim_time` flag to `gzserver`. If the flag and a value is not provided, the behavior is not changed. This works with large times, such as epoch time and floating point numbers (see the test).

FYI @scpeters 