### PR TITLE
Improvements to WideAngleCamera LensFlare bug fix

### DIFF
--- a/worlds/lensflare_wideangle_cam.world
+++ b/worlds/lensflare_wideangle_cam.world
@@ -78,7 +78,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -88,7 +88,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -101,7 +101,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -111,7 +111,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -138,7 +138,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -148,7 +148,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -161,7 +161,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -171,7 +171,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -205,7 +205,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -215,7 +215,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -228,7 +228,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -238,7 +238,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -272,7 +272,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -282,7 +282,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -295,7 +295,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -305,7 +305,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -339,7 +339,7 @@
         </visual>
         <sensor name="camera_sensor_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -349,7 +349,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>
@@ -362,7 +362,7 @@
         </sensor>
         <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
           <camera>
-            <horizontal_fov>1.047</horizontal_fov>
+            <horizontal_fov>3.14159</horizontal_fov>
             <image>
               <width>320</width>
               <height>240</height>
@@ -372,7 +372,7 @@
               <far>100</far>
             </clip>
             <lens>
-              <type>gnomonical</type>
+              <type>equidistant</type>
               <scale_to_hfov>true</scale_to_hfov>
               <cutoff_angle>1.5707</cutoff_angle>
               <env_texture_size>512</env_texture_size>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3273

## Summary
This PR improves an existing bug fix branch. Test with and without this PR by running `gazebo --verbose worlds/lensflare_wideangle_cam.world` and look at the various camera images in Topic Visualization.

Additionally, I tried posing the cameras and obstacles in that world file many different ways. Lens flares appear to behave as they should.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
