### PR TITLE
Fix missing direction of ray (#3297)

### DIFF
--- a/gazebo/physics/RayShape.cc
+++ b/gazebo/physics/RayShape.cc
@@ -74,6 +74,10 @@ void RayShape::SetPoints(const ignition::math::Vector3d &_posStart,
   this->relativeStartPos = _posStart;
   this->relativeEndPos = _posEnd;
 
+  // Compute the relative direction of the ray
+  this->relativeDir  = this->relativeEndPos - this->relativeStartPos;
+  this->relativeDir.Normalize();
+
   if (this->collisionParent)
   {
     this->globalStartPos =
@@ -114,10 +118,7 @@ void RayShape::SetLength(double _len)
 {
   this->contactLen = _len;
 
-  ignition::math::Vector3d dir = this->relativeEndPos - this->relativeStartPos;
-  dir.Normalize();
-
-  this->relativeEndPos = dir * _len + this->relativeStartPos;
+  this->relativeEndPos = this->relativeDir * _len + this->relativeStartPos;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/RayShape.hh
+++ b/gazebo/physics/RayShape.hh
@@ -157,6 +157,9 @@ namespace gazebo
 
       /// \brief End position of the ray in global cs
       protected: ignition::math::Vector3d globalEndPos;
+      
+      /// \brief Direction of the ray, relative to the body
+      protected: ignition::math::Vector3d relativeDir;
 
       /// \brief Name of the object this ray collided with
       private: std::string collisionName;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #3297

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
When 'relativeEndPos' and 'relativeStartPos'  are close, zero vector will be generated, which will cause the ray to lose its direction forever.
```
void RayShape::SetLength(double _len)
{
  this->contactLen = _len;

  ignition::math::Vector3d dir = this->relativeEndPos - this->relativeStartPos;
  dir.Normalize();

  this->relativeEndPos = dir * _len + this->relativeStartPos;
}
```
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
