### PR TITLE
CMake: use find_package(PkgConfig)

### DIFF
--- a/cmake/FindFreeimage.cmake
+++ b/cmake/FindFreeimage.cmake
@@ -1,4 +1,4 @@
-include (FindPkgConfig)
+find_package(PkgConfig)
 include (${gazebo_cmake_dir}/GazeboUtils.cmake)
 
 ########################################

--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -2,7 +2,7 @@ include (${gazebo_cmake_dir}/GazeboUtils.cmake)
 include (CheckCXXSourceCompiles)
 
 include (${gazebo_cmake_dir}/FindOS.cmake)
-include (FindPkgConfig)
+find_package(PkgConfig)
 include (${gazebo_cmake_dir}/FindFreeimage.cmake)
 
 execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --modversion protobuf

--- a/cmake/gazebo-config.cmake.in
+++ b/cmake/gazebo-config.cmake.in
@@ -35,7 +35,7 @@ set (GAZEBO_HAS_DART_BULLET @HAVE_DART_BULLET@)
 # Set whether Gazebo was built with Ignition Fuel Tools support
 set (GAZEBO_HAS_IGNITION_FUEL_TOOLS @HAVE_IGNITION_FUEL_TOOLS@)
 
-include (FindPkgConfig)
+find_package(PkgConfig)
 
 #################################################
 # @PKG_NAME@_PROTO_PATH, @PKG_NAME@_PROTO_INCLUDE_DIRS, and

--- a/examples/stand_alone/arrange/CMakeLists.txt
+++ b/examples/stand_alone/arrange/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
-include (FindPkgConfig)
 
 find_package(gazebo REQUIRED)
 find_package(Protobuf REQUIRED)

--- a/examples/stand_alone/custom_main_pkgconfig/CMakeLists.txt
+++ b/examples/stand_alone/custom_main_pkgconfig/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
-include (FindPkgConfig)
+find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
   pkg_check_modules(GAZEBO gazebo)
 endif()

--- a/test/pkgconfig/plugin/CMakeLists.txt
+++ b/test/pkgconfig/plugin/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
-include (FindPkgConfig)
+find_package(PkgConfig)
 if (PKG_CONFIG_FOUND)
   pkg_check_modules(GAZEBO gazebo)
   string (REPLACE ";" " " GAZEBO_CFLAGS "${GAZEBO_CFLAGS}")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fix warning:
~~~
CMake Warning (dev) at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (gazebo).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake-3.22/Modules/FindPkgConfig.cmake:99 (find_package_handle_standard_args)
  /usr/lib/x86_64-linux-gnu/cmake/gazebo/gazebo-config.cmake:72 (include)
  /home/jrivero/code/ros2/ws_gazebo_ros_pkgs_jammy/install/gazebo_dev/share/gazebo_dev/cmake/gazebo_dev-extras.cmake:2 (find_package)
  /home/jrivero/code/ros2/ws_gazebo_ros_pkgs_jammy/install/gazebo_dev/share/gazebo_dev/cmake/gazebo_devConfig.cmake:41 (include)
  CMakeLists.txt:26 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.           
~~~

when `find_package(gazebo)` is called with CMake >= 3.22, see for example https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1374 .

For more information on how `Find***.cmake` scripts work and how they are supposed to be used, check https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html#find-modules .

In [`examples/stand_alone/arrange/CMakeLists.txt`](https://github.com/gazebosim/gazebo-classic/pull/3301/files#diff-fe9d487626bc864b32cb1a3f7b8f414d28bbcc45a712c4831ed33b601227e550) I simply removed the `include(FindPkgConfig)` as it was not used at all.


<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
