### PR TITLE
Allow user to name a specific light that will generate lens flare.

### DIFF
--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -560,30 +560,22 @@ void LensFlare::Update()
 
   LightPtr light;
 
-  // Use the preferred light, if there is one
+  // Use the specified light, if there is one
   if (!this->dataPtr->lightName.empty())
   {
     light = this->dataPtr->camera->GetScene()->LightByName(
         this->dataPtr->lightName);
-    static bool notPrintedYet = true;
-    if (!light && notPrintedYet)
-    {
-      gzwarn << "There exists no light named " << this->dataPtr->lightName
-             << std::endl;
-      notPrintedYet = false;
-    }
   }
-
-  // Get the first directional light
-  if (!light)
+  else // Get the first directional light
   {
-    for (unsigned int i = 0; i < this->dataPtr->camera->GetScene()->LightCount();
-        ++i)
+    for (unsigned int i = 0;
+         i < this->dataPtr->camera->GetScene()->LightCount(); ++i)
     {
-      LightPtr lp = this->dataPtr->camera->GetScene()->LightByIndex(i);
-      if (lp->Type() == "directional")
+      LightPtr directionalLight =
+          this->dataPtr->camera->GetScene()->LightByIndex(i);
+      if (directionalLight->Type() == "directional")
       {
-        light = lp;
+        light = directionalLight;
         break;
       }
     }

--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -40,6 +40,9 @@ namespace gazebo
       /// \brief Pointer to light
       public: LightPtr light;
 
+      /// \brief Pointer to light
+      public: std::string lightName;
+
       /// \brief Pointer to camera
       public: CameraPtr camera;
 
@@ -84,6 +87,12 @@ namespace gazebo
     void LensFlareCompositorListener::SetLight(LightPtr _light)
     {
       this->dataPtr->light = _light;
+    }
+
+    //////////////////////////////////////////////////
+    void LensFlareCompositorListener::SetLightName(std::string _name)
+    {
+      this->dataPtr->lightName = _name;
     }
 
     //////////////////////////////////////////////////
@@ -405,8 +414,11 @@ namespace gazebo
       /// \brief Pointer to camera
       public: CameraPtr camera;
 
-      /// \brief Name of directional light
+      /// \brief Name of preferred light
       public: std::string lightName;
+
+      /// \brief Name of light currently generating lens flare
+      public: std::string lightNameCurrentlyInUse;
 
       /// \brief Flag to indicate whether or not to remove lens flare effect.
       public: bool removeLensFlare = false;
@@ -485,6 +497,17 @@ void LensFlare::SetCamera(CameraPtr _camera)
 }
 
 //////////////////////////////////////////////////
+void LensFlare::SetLightName(std::string _name)
+{
+  this->dataPtr->lightName = _name;
+  if (this->dataPtr->lensFlareCompositorListener)
+  {
+    this->dataPtr->lensFlareCompositorListener->SetLightName(
+        this->dataPtr->lightName);
+  }
+}
+
+//////////////////////////////////////////////////
 void LensFlare::SetScale(const double _scale)
 {
   this->dataPtr->lensFlareScale = std::max(0.0, _scale);
@@ -531,29 +554,47 @@ void LensFlare::Update()
     this->dataPtr->requestSub.reset();
     this->dataPtr->lensFlareInstance->setEnabled(false);
     this->dataPtr->removeLensFlare = false;
-    this->dataPtr->lightName = "";
+    this->dataPtr->lightNameCurrentlyInUse = "";
     return;
   }
 
+  LightPtr light;
 
-  // Get the first directional light
-  LightPtr directionalLight;
-  for (unsigned int i = 0; i < this->dataPtr->camera->GetScene()->LightCount();
-      ++i)
+  // Use the preferred light, if there is one
+  if (!this->dataPtr->lightName.empty())
   {
-    LightPtr light = this->dataPtr->camera->GetScene()->LightByIndex(i);
-    if (light->Type() == "directional")
+    light = this->dataPtr->camera->GetScene()->LightByName(
+        this->dataPtr->lightName);
+    static bool notPrintedYet = true;
+    if (!light && notPrintedYet)
     {
-      directionalLight = light;
-      break;
+      gzwarn << "There exists no light named " << this->dataPtr->lightName
+             << std::endl;
+      notPrintedYet = false;
     }
   }
-  if (!directionalLight)
+
+  // Get the first directional light
+  if (!light)
+  {
+    for (unsigned int i = 0; i < this->dataPtr->camera->GetScene()->LightCount();
+        ++i)
+    {
+      LightPtr lp = this->dataPtr->camera->GetScene()->LightByIndex(i);
+      if (lp->Type() == "directional")
+      {
+        light = lp;
+        break;
+      }
+    }
+  }
+
+  if (!light)
     return;
 
-  this->dataPtr->lightName = directionalLight->Name();
+  this->dataPtr->lightNameCurrentlyInUse = light->Name();
 
-  this->dataPtr->lensFlareCompositorListener->SetLight(directionalLight);
+  this->dataPtr->lensFlareCompositorListener->SetLight(light);
   this->dataPtr->lensFlareInstance->setEnabled(true);
 
   // disconnect
@@ -575,7 +616,7 @@ void LensFlare::OnRequest(ConstRequestPtr &_msg)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   if (_msg->request() == "entity_delete" &&
-      _msg->data() == this->dataPtr->lightName)
+      _msg->data() == this->dataPtr->lightNameCurrentlyInUse)
   {
     this->dataPtr->removeLensFlare = true;
     this->dataPtr->preRenderConnection = event::Events::ConnectPreRender(

--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -40,9 +40,6 @@ namespace gazebo
       /// \brief Pointer to light
       public: LightPtr light;
 
-      /// \brief Pointer to light
-      public: std::string lightName;
-
       /// \brief Pointer to camera
       public: CameraPtr camera;
 
@@ -87,12 +84,6 @@ namespace gazebo
     void LensFlareCompositorListener::SetLight(LightPtr _light)
     {
       this->dataPtr->light = _light;
-    }
-
-    //////////////////////////////////////////////////
-    void LensFlareCompositorListener::SetLightName(std::string _name)
-    {
-      this->dataPtr->lightName = _name;
     }
 
     //////////////////////////////////////////////////
@@ -500,11 +491,6 @@ void LensFlare::SetCamera(CameraPtr _camera)
 void LensFlare::SetLightName(std::string _name)
 {
   this->dataPtr->lightName = _name;
-  if (this->dataPtr->lensFlareCompositorListener)
-  {
-    this->dataPtr->lensFlareCompositorListener->SetLightName(
-        this->dataPtr->lightName);
-  }
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/rendering/LensFlare.hh
+++ b/gazebo/rendering/LensFlare.hh
@@ -47,9 +47,13 @@ namespace gazebo
       /// \brief Destructor
       public: ~LensFlareCompositorListener();
 
-      /// \brief Set directional light that generates lens flare
-      /// \param[in] _light Pointer to directional light
+      /// \brief Set light that generates lens flare
+      /// \param[in] _light Pointer to light
       public: void SetLight(LightPtr _light);
+
+      /// \brief Set the name of light that generates lens flare
+      /// \param[in] _name Light that generates lens flare
+      public: void SetLightName(std::string _name);
 
       /// \brief Set the scale of lens flare.
       /// \param[in] _scale Scale of lens flare
@@ -120,6 +124,10 @@ namespace gazebo
       /// \brief Set the camera which lensFlare will be applied to.
       /// \param[in] _camera Camera to be distorted
       public: void SetCamera(CameraPtr _camera);
+
+      /// \brief Set the name of light that generates lens flare.
+      /// \param[in] _name Light that generates lens flare
+      public: void SetLightName(std::string _name);
 
       /// \brief Set the scale of lens flare. Must be greater than 0.
       /// \param[in] _scale Scale of lens flare

--- a/gazebo/rendering/LensFlare.hh
+++ b/gazebo/rendering/LensFlare.hh
@@ -51,10 +51,6 @@ namespace gazebo
       /// \param[in] _light Pointer to light
       public: void SetLight(LightPtr _light);
 
-      /// \brief Set the name of light that generates lens flare
-      /// \param[in] _name Light that generates lens flare
-      public: void SetLightName(std::string _name);
-
       /// \brief Set the scale of lens flare.
       /// \param[in] _scale Scale of lens flare
       public: void SetScale(const double _scale);

--- a/plugins/LensFlareSensorPlugin.cc
+++ b/plugins/LensFlareSensorPlugin.cc
@@ -33,6 +33,9 @@ namespace gazebo
     /// \brief Lens flare
     public: std::vector<rendering::LensFlarePtr> lensFlares;
 
+    /// \brief Name of light that generates lens flare
+    public: std::string lightName;
+
     /// \brief Lens flare scale
     public: double scale = 1.0;
 
@@ -76,6 +79,11 @@ void LensFlareSensorPlugin::Load(sensors::SensorPtr _sensor,
   {
     gzerr << "Invalid SDF pointer." << std::endl;
     return;
+  }
+
+  if (_sdf->HasElement("light_name"))
+  {
+    this->dataPtr->lightName = _sdf->Get<std::string>("light_name");
   }
 
   if (_sdf->HasElement("scale"))
@@ -128,6 +136,17 @@ void LensFlareSensorPlugin::Load(sensors::SensorPtr _sensor,
 }
 
 /////////////////////////////////////////////////
+void LensFlareSensorPlugin::SetLightName(std::string _name)
+{
+  this->dataPtr->lightName = _name;
+
+  for (auto flare : this->dataPtr->lensFlares)
+  {
+    flare->SetLightName(_name);
+  }
+}
+
+/////////////////////////////////////////////////
 void LensFlareSensorPlugin::SetScale(const double _scale)
 {
   this->dataPtr->scale = _scale;
@@ -172,6 +191,7 @@ void LensFlareSensorPlugin::AddLensFlare(rendering::CameraPtr _camera)
   {
     lensFlare->SetCompositorName(this->dataPtr->compositorName);
   }
+  lensFlare->SetLightName(this->dataPtr->lightName);
   lensFlare->SetScale(this->dataPtr->scale);
   lensFlare->SetColor(this->dataPtr->color);
   lensFlare->SetOcclusionSteps(this->dataPtr->occlusionSteps);

--- a/plugins/LensFlareSensorPlugin.hh
+++ b/plugins/LensFlareSensorPlugin.hh
@@ -30,6 +30,7 @@ namespace gazebo
   /// The plugin has the following optional parameter:
   /// <color>           Color of lens flare.
   /// <compositor>      Name of the lens flare compositor to use.
+  /// <light_name>      Name of the light source to use.
   /// <occlusion_steps> Number of steps used when checking for occlusions.
   /// <scale>           Scale of lens flare. Must be greater than 0.
   /// \todo A potentially useful feature would be an option for constantly
@@ -45,6 +46,10 @@ namespace gazebo
     // Documentation inherited
     public: virtual void Load(sensors::SensorPtr _sensor,
         sdf::ElementPtr _sdf);
+
+    /// \brief Set the light name.
+    /// \param[in] _name Scale of lens flare
+    public: void SetLightName(std::string _name);
 
     /// \brief Set the scale of lens flare.
     /// \param[in] _scale Scale of lens flare

--- a/worlds/lensflare_plugin.world
+++ b/worlds/lensflare_plugin.world
@@ -2,13 +2,33 @@
 <sdf version="1.6">
   <world name="default">
 
-  <!-- Light Source -->
+  <!-- Light Sources -->
   <light type="directional" name="sun">
     <cast_shadows>true</cast_shadows>
     <pose>0 0 0 0.0 0.0 0.0</pose>
     <diffuse>1.0 1.0 1.0 1.0</diffuse>
     <specular>0.2 0.2 0.2 1</specular>
     <direction>-1.0 0.0 -0.2</direction>
+  </light>
+
+  <!-- spot light -->
+  <light type="spot" name="spot_light">
+    <pose>5 1 1 0 1.4 0</pose>
+    <diffuse>1 1 1 1</diffuse>
+    <specular>.2 .2 .2 1</specular>
+    <attenuation>
+      <range>10</range>
+      <linear>0.01</linear>
+      <constant>0.2</constant>
+      <quadratic>0.0</quadratic>
+    </attenuation>
+    <direction>0 0 -1</direction>
+    <spot>
+      <inner_angle>0.1</inner_angle>
+      <outer_angle>0.5</outer_angle>
+      <falloff>1.2</falloff>
+    </spot>
+    <cast_shadows>false</cast_shadows>
   </light>
 
     <!-- A ground plane -->
@@ -77,6 +97,40 @@
           <visualize>true</visualize>
           <plugin name="lensflare" filename="libLensFlareSensorPlugin.so">
             <scale>0.1</scale>
+          </plugin>
+        </sensor>
+      </link>
+    </model>
+
+    <!-- camera model with lens flare plugin that uses the spot light -->
+    <model name="camera_lensflare_spot">
+      <static>true</static>
+      <pose>0 0 0.05 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor_lensflare_spot" type="camera">
+          <camera>
+            <horizontal_fov>0.78539816339744828</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>30</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so">
+            <light_name>spot_light</light_name>
           </plugin>
         </sensor>
       </link>


### PR DESCRIPTION
# 🎉 New feature

Closes # not applicable

## Summary
Allow user to name a specific light that will generate lens flare.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.