### PR TITLE
Allow usage of lambdas as transport subscription callbacks

### DIFF
--- a/gazebo/transport/Node.hh
+++ b/gazebo/transport/Node.hh
@@ -288,6 +288,36 @@ namespace gazebo
 
         return result;
       }
+      
+      /// \brief Subscribe to a topic using a bost::function as the callback,
+      /// allowing to pass lambdas.
+      /// \param[in] _topic The topic to subscribe to
+      /// \param[in] _cb Function to be called on receipt of new message
+      /// \param[in] _latching If true, latch latest incoming message;
+      /// otherwise don't latch
+      /// \return Pointer to new Subscriber object
+      public: template<typename M>
+      SubscriberPtr Subscribe(const std::string &_topic,
+          const boost::function<void (const boost::shared_ptr<M const> &)> &_cb,
+                     bool _latching = false)
+      {
+        SubscribeOptions ops;
+        std::string decodedTopic = this->DecodeTopicName(_topic);
+        ops.template Init<M>(decodedTopic, shared_from_this(), _latching);
+
+        {
+          boost::recursive_mutex::scoped_lock lock(this->incomingMutex);
+          this->callbacks[decodedTopic].push_back(
+              CallbackHelperPtr(new CallbackHelperT<M>(_cb, _latching)));
+        }
+
+        SubscriberPtr result =
+          transport::TopicManager::Instance()->Subscribe(ops);
+
+        result->SetCallbackId(this->callbacks[decodedTopic].back()->GetId());
+
+        return result;
+      }
 
       /// \brief Subscribe to a topic using a bare function as the callback
       /// \param[in] _topic The topic to subscribe to

--- a/gazebo/transport/Node.hh
+++ b/gazebo/transport/Node.hh
@@ -288,7 +288,7 @@ namespace gazebo
 
         return result;
       }
-      
+
       /// \brief Subscribe to a topic using a bost::function as the callback,
       /// allowing to pass lambdas.
       /// \param[in] _topic The topic to subscribe to

--- a/test/integration/transport.cc
+++ b/test/integration/transport.cc
@@ -154,35 +154,32 @@ TEST_F(TransportTest, PubSub)
 }
 
 // Standard pub/sub using lambdas
-TEST_F(TransportTest, PubSubLambda)
+TEST_F(TransportTest, PubSubNoncapturingLambda)
 {
   Load("worlds/empty.world");
 
   transport::NodePtr node = transport::NodePtr(new transport::Node());
   node->Init();
   transport::PublisherPtr scenePub = node->Advertise<msgs::Scene>("~/scene");
-  transport::SubscriberPtr sceneSub = node->Subscribe("~/scene",
-      [](ConstScenePtr &/*_msg*/) -> void{g_sceneMsg=true;});
+  transport::SubscriberPtr sceneSub = node->Subscribe<msgs::Scene>("~/scene",
+      +[](ConstScenePtr & _msg) -> void {
+      	g_sceneMsg=true;
+	  }
+  );
+}
 
-  msgs::Scene msg;
-  msgs::Init(msg, "test");
-  msg.set_name("default");
+TEST_F(TransportTest, PubSubCapturingLambda)
+{
+  Load("worlds/empty.world");
 
-  scenePub->Publish(msg);
-
-  std::vector<transport::PublisherPtr> pubs;
-  std::vector<transport::SubscriberPtr> subs;
-
-  for (unsigned int i = 0; i < 10; ++i)
-  {
-    pubs.push_back(node->Advertise<msgs::Scene>("~/scene"));
-    subs.push_back(node->Subscribe<msgs::Scene>("~/scene", 
-    [](ConstScenePtr &/*_msg*/) -> void {g_sceneMsg=true;}));
-    scenePub->Publish(msg);
-  }
-
-  pubs.clear();
-  subs.clear();
+  transport::NodePtr node = transport::NodePtr(new transport::Node());
+  node->Init();
+  transport::PublisherPtr scenePub = node->Advertise<msgs::Scene>("~/scene");
+  transport::SubscriberPtr sceneSub = node->Subscribe<msgs::Scene>("~/scene",
+      [this](ConstScenePtr & _msg) -> void {
+      	g_sceneMsg=true;
+	  }
+  );
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/transport.cc
+++ b/test/integration/transport.cc
@@ -176,8 +176,8 @@ TEST_F(TransportTest, PubSubLambda)
   for (unsigned int i = 0; i < 10; ++i)
   {
     pubs.push_back(node->Advertise<msgs::Scene>("~/scene"));
-    subs.push_back(node->Subscribe("~/scene", 
-    [](ConstScenePtr &/*_msg*/) -> void{g_sceneMsg=true;}));
+    subs.push_back(node->Subscribe<msgs::Scene>("~/scene", 
+    [](ConstScenePtr &/*_msg*/) -> void {g_sceneMsg=true;}));
     scenePub->Publish(msg);
   }
 

--- a/test/integration/transport.cc
+++ b/test/integration/transport.cc
@@ -153,6 +153,38 @@ TEST_F(TransportTest, PubSub)
   subs.clear();
 }
 
+// Standard pub/sub using lambdas
+TEST_F(TransportTest, PubSubLambda)
+{
+  Load("worlds/empty.world");
+
+  transport::NodePtr node = transport::NodePtr(new transport::Node());
+  node->Init();
+  transport::PublisherPtr scenePub = node->Advertise<msgs::Scene>("~/scene");
+  transport::SubscriberPtr sceneSub = node->Subscribe("~/scene",
+      [](ConstScenePtr &/*_msg*/) -> void{g_sceneMsg=true;});
+
+  msgs::Scene msg;
+  msgs::Init(msg, "test");
+  msg.set_name("default");
+
+  scenePub->Publish(msg);
+
+  std::vector<transport::PublisherPtr> pubs;
+  std::vector<transport::SubscriberPtr> subs;
+
+  for (unsigned int i = 0; i < 10; ++i)
+  {
+    pubs.push_back(node->Advertise<msgs::Scene>("~/scene"));
+    subs.push_back(node->Subscribe("~/scene", 
+    [](ConstScenePtr &/*_msg*/) -> void{g_sceneMsg=true;}));
+    scenePub->Publish(msg);
+  }
+
+  pubs.clear();
+  subs.clear();
+}
+
 /////////////////////////////////////////////////
 TEST_F(TransportTest, DirectPublish)
 {


### PR DESCRIPTION
This patch adds one method to gazebo::transport::Node, enabling users to pass a lambda (even a capturing one) as callback to call when a message is received.

This does not modify any previously existing logic. Before this patch, only pure functions or class methods were supported.

This is a prerequisite for https://github.com/ros-controls/gazebo_ros2_control/issues/185 (even if an out-of-tree redefinition of the Node class is possible without Gazebo recompilation, if this PR is not merged in time).