### PR TITLE
[CI][vcpkg][Windows] Build gazebo for windows with cmake vcpkg

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -10,6 +10,10 @@ on:
   # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}@conda]'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ gazebo11 ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: linux-build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,69 @@
+name: Windows
+on:
+  push:
+    branches: [ gazebo11 ]
+  pull_request:
+    branches: [ gazebo11 ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: windows-build
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: deps\vcpkg\cache\windows
+          key: windows-${{ hashFiles('.github\workflows\windows.yml') }}
+
+      - name: Setup msbuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Fix vcpkg
+        run: vcpkg.exe integrate remove
+
+      - name: Clone vcpkg
+        shell: cmd
+        run: |
+          git clone https://github.com/microsoft/vcpkg/
+          vcpkg\bootstrap-vcpkg.bat
+
+      - name: Configure Gazebo
+        shell: cmd
+        run: |
+          set VCPKG_BINARY_SOURCES=clear;files,%CD%\deps\vcpkg\cache\windows,readwrite;
+          cmake . -B build ^
+              -DCMAKE_TOOLCHAIN_FILE=vcpkg\scripts\buildsystems\vcpkg.cmake ^
+              -DVCPKG_MANIFEST_DIR=deps\vcpkg\manifests\windows ^
+              -DVCPKG_INSTALLED_DIR=%CD%\vcpkg\installed ^
+              -DVCPKG_TARGET_TRIPLET=x64-windows-release ^
+              -DVCPKG_HOST_TRIPLET=x64-windows-release ^
+              -DVCPKG_INSTALL_OPTIONS=--clean-after-build ^
+              -DUSE_EXTERNAL_TINYXML=ON ^
+              -DUSE_EXTERNAL_TINYXML2=ON ^
+              -DCMAKE_INSTALL_PREFIX=%CD%\vcpkg\installed\x64-windows-release
+
+      - name: Build Gazebo
+        shell: cmd
+        run: |
+          cmake --build build --config Release
+
+      - name: Install Gazebo
+        shell: cmd
+        run: |
+          cmake --install build --config Release
+          
+      - name: Tests suite compilation
+        shell: cmd
+        run: |
+          echo compile and run tests here

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 build_*
 build-*
 Ogre.log
+deps/vcpkg/cache
 .DS_Store
 *.swp
 *.orig

--- a/deps/vcpkg/manifests/windows/vcpkg.json
+++ b/deps/vcpkg/manifests/windows/vcpkg.json
@@ -1,0 +1,156 @@
+{
+  "name": "gazebo",
+  "description": "Open source robotics simulator.",
+  "homepage": "http://gazebosim.org",
+  "license": "Apache-2.0",
+  "builtin-baseline": "19af97cba8ca48474e4ad15a24ed50271a9ecdac",
+  "dependencies": [
+    "boost-asio",
+    "boost-date-time",
+    "boost-filesystem",
+    "boost-format",
+    "boost-interprocess",
+    "boost-iostreams",
+    "boost-program-options",
+    "boost-property-tree",
+    "boost-regex",
+    "boost-system",
+    "boost-thread",
+    "boost-uuid",
+    "ccd",
+    "freeimage",
+    {
+      "name": "hdf5",
+      "features": [
+        "cpp"
+      ]
+    },
+    "ignition-common3",
+    "ignition-fuel-tools4",
+    "ignition-math6",
+    "ignition-msgs5",
+    "ignition-transport8",
+    {
+      "name": "libtar",
+      "platform": "!windows"
+    },
+    "ogre",
+    "opengl",
+    {
+      "name": "pkgconf",
+      "host": true
+    },
+    "protobuf",
+    "qt5-base",
+    "qwt",
+    "sdformat9",
+    "tbb",
+    "tiny-process-library",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "bullet",
+    "dart",
+    "ffmpeg",
+    "gdal",
+    "graphviz",
+    "gts",
+    "libusb",
+    "openal",
+    "simbody"
+  ],
+  "features": {
+    "bullet": {
+      "description": "Use the bullet physics engine",
+      "dependencies": [
+        "bullet3"
+      ]
+    },
+    "dart": {
+      "description": "Use the dart physics engine",
+      "dependencies": [
+        "dartsim"
+      ]
+    },
+    "ffmpeg": {
+      "description": "Enable audio-video capabilities",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "features": [
+            "avcodec",
+            "avformat",
+            "swscale"
+          ]
+        }
+      ]
+    },
+    "gdal": {
+      "description": "Enable digital elevation terrains support",
+      "dependencies": [
+        "gdal"
+      ]
+    },
+    "graphviz": {
+      "description": "Enable model editor's schematic view",
+      "dependencies": [
+        "graphviz"
+      ]
+    },
+    "gts": {
+      "description": "Enable CSG support",
+      "dependencies": [
+        "gts"
+      ]
+    },
+    "libusb": {
+      "description": "Enable USB peripheral support",
+      "dependencies": [
+        "libusb"
+      ]
+    },
+    "openal": {
+      "description": "Enable audio support",
+      "dependencies": [
+        "openal-soft"
+      ]
+    },
+    "plugins": {
+      "description": "Build gazebo plugins",
+      "supports": "!linux"
+    },
+    "simbody": {
+      "description": "Use the simbody physics engine",
+      "dependencies": [
+        "simbody"
+      ]
+    },
+    "tools": {
+      "description": "Build gazebo tools",
+      "supports": "!(linux & static)"
+    }
+  },
+  "overrides": [
+    {
+      "name": "ogre",
+      "version": "1.12.9",
+      "port-version": 10
+    },
+    {
+      "name": "qwt",
+      "version": "6.1.5"
+    },
+    {
+      "name": "graphviz",
+      "version": "2.49.1",
+      "port-version": 4
+    }
+  ]
+}


### PR DESCRIPTION
Build gazebo for windows with cmake vcpkg.
To find all dependencies need to change cmake that it will compile both with native and vcpkg build.
I will do it in next PR, and I will need community help.

All dependencies are cache, and It much faster configure when it take it from the cache folder.

@traversaro
@chapulina