### PR TITLE
conda-forge CI: Switch from libccd to libccd-double

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -36,7 +36,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt-main ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp simbody hdf5 openal-soft glib gts dartsim
+        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt-main ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd-double boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp simbody hdf5 openal-soft glib gts dartsim
 
     - name: Linux-only Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3313 

## Summary

In conda-forge, the `libccd` package contains the (deprecated and not updated) single precision build of libccd, while `libccd-double` containes the double precision build of libccd. 

See https://github.com/conda-forge/libccd-feedstock/pull/5 and https://github.com/conda-forge/gazebo-feedstock/pull/137 .

Pulling `libccd` was forcing us to use a quite old boost, that in the end created problems.

## Checklist
- [ ] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
