### PR TITLE
Fix build with ffmpeg 6.0

### DIFF
--- a/gazebo/common/AudioDecoder.cc
+++ b/gazebo/common/AudioDecoder.cc
@@ -365,8 +365,10 @@ bool AudioDecoder::SetFile(const std::string &_filename)
   }
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 60, 100)
+#if LIBAVCODEC_VERSION_MAJOR < 60
   if (this->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
     this->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+#endif
 #else
   if (this->codec->capabilities & CODEC_CAP_TRUNCATED)
     this->codecCtx->flags |= CODEC_FLAG_TRUNCATED;

--- a/gazebo/common/Video.cc
+++ b/gazebo/common/Video.cc
@@ -217,8 +217,10 @@ bool Video::Load(const std::string &_filename)
   // Inform the codec that we can handle truncated bitstreams -- i.e.,
   // bitstreams where frame boundaries can fall in the middle of packets
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 60, 100)
+#if LIBAVCODEC_VERSION_MAJOR < 60
   if (codec->capabilities & AV_CODEC_CAP_TRUNCATED)
     this->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+#endif
 #else
   if (codec->capabilities & CODEC_CAP_TRUNCATED)
     this->codecCtx->flags |= CODEC_FLAG_TRUNCATED;


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/osrf/homebrew-simulation/issues/2241.

## Summary

The macOS build has been broken since ffmpeg 6.0 was merged into homebrew-core in https://github.com/Homebrew/homebrew-core/pull/124363.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-ci-gazebo11-homebrew-amd64&build=174)](https://build.osrfoundation.org/job/gazebo-ci-gazebo11-homebrew-amd64/174/) https://build.osrfoundation.org/job/gazebo-ci-gazebo11-homebrew-amd64/174/

A similar fix has already been merged in gazebosim/gz-common#497.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
