### PR TITLE
Prepare for 11.13.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 11)
-set (GAZEBO_MINOR_VERSION 12)
+set (GAZEBO_MINOR_VERSION 13)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -165,9 +165,6 @@
     * [Pull request #3156](https://github.com/osrf/gazebo/pull/3156)
     * Inspired by a contribution from Alex Dewar <alex.dewar@gmx.co.uk>
 
-1. Fix focal builds: use python3 with check_test_ran.py
-    * [Pull request #3155](https://github.com/osrf/gazebo/pull/3155)
-
 1. Load model plugins even after sensor timeout
     * [Pull request #3154](https://github.com/osrf/gazebo/pull/3154)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,57 @@
 ## Gazebo 11
 
+## Gazebo 11.13.0 (2023-05-17)
+
+1. Fix build with ffmpeg 6.0
+   * [Pull request #3318](https://github.com/gazebosim/gazebo-classic/pull/3318)
+
+1. Allow user to name a specific light that will generate lens flare
+   * [Pull request #3305](https://github.com/gazebosim/gazebo-classic/pull/3305)
+   * A contribution from Terry Welsh 
+
+1. JointController: improve thread safety
+   * [Pull request #3303](https://github.com/gazebosim/gazebo-classic/pull/3303)
+
+1. Fix pkg-config-related CMake warning
+   * [Pull request #3295](https://github.com/gazebosim/gazebo-classic/pull/3301)
+
+1. Fix template specialization in constructors to fix GCC11 build
+   * [Pull request #3295](https://github.com/gazebosim/gazebo-classic/pull/3295)
+   * A contribution from Ondřej Svoboda
+
+1. Set initial sim time from the command-line
+   * [Pull request #3294](https://github.com/gazebosim/gazebo-classic/pull/3294)
+
+1. Fix typo in README
+   * [Pull request #3291](https://github.com/gazebosim/gazebo-classic/pull/3291)
+
+1. msgs.cc: add missing <array> include
+   * [Pull request #3290](https://github.com/gazebosim/gazebo-classic/pull/3290)
+
+1.  Fix crash with DEM and Camera
+   * [Pull request #3279](https://github.com/gazebosim/gazebo-classic/pull/3279)
+
+1.  Fix focal builds: use python3 with check_test_ran.py
+   * [Pull request #3278](https://github.com/gazebosim/gazebo-classic/pull/3278)
+
+1. Fix for wide angle lens flare occlusion bug
+   * [Pull request #3276](https://github.com/gazebosim/gazebo-classic/pull/3276)
+   * With the contribution of Terry Welsh 
+
+1. Fix for opende heightfield and console spam
+   * [Pull request #3271](https://github.com/gazebosim/gazebo-classic/pull/3271)
+
+1. Fixes in conda-forge CI
+   * [Pull request #3270](https://github.com/gazebosim/gazebo-classic/pull/3270)
+   * [Pull request #3287](https://github.com/gazebosim/gazebo-classic/pull/3287)
+   * [Pull request #3315](https://github.com/gazebosim/gazebo-classic/pull/3315)
+
+1. Fix Instance() method of Singleton classes
+   * [Pull request #3269](https://github.com/gazebosim/gazebo-classic/pull/3269)
+
+1. Fix disappearing shadows when looking from certain angles
+   * [Pull request #3267](https://github.com/gazebosim/gazebo-classic/pull/3267)
+
 ## Gazebo 11.12.0 (2022-09-14)
 
 1. BulletLink: add and set force and torque

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Gazebo 11.13.0 (2023-05-17)
 
+1. Fix wide-angle lens flare occlusion lag
+   * [Pull request #3325](https://github.com/gazebosim/gazebo-classic/pull/3325)
+
 1. Add missing spaces to several rendering messages 
    * [Pull request #3322](https://github.com/gazebosim/gazebo-classic/pull/3322)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@
    * [Pull request #3303](https://github.com/gazebosim/gazebo-classic/pull/3303)
 
 1. Fix pkg-config-related CMake warning
-   * [Pull request #3295](https://github.com/gazebosim/gazebo-classic/pull/3301)
+   * [Pull request #3301](https://github.com/gazebosim/gazebo-classic/pull/3301)
 
 1. Fix template specialization in constructors to fix GCC11 build
    * [Pull request #3295](https://github.com/gazebosim/gazebo-classic/pull/3295)
@@ -52,8 +52,11 @@
 1. Fix disappearing shadows when looking from certain angles
    * [Pull request #3267](https://github.com/gazebosim/gazebo-classic/pull/3267)
 
-1. Use DistanceBetweenPoints when loading DEMs
+1. Support Lunar DEMs
+   * [Pull request #3257](https://github.com/gazebosim/gazebo-classic/pull/3257)
+   * [Pull request #3250](https://github.com/gazebosim/gazebo-classic/pull/3250)
    * [Pull request #3252](https://github.com/gazebosim/gazebo-classic/pull/3252)
+   * [Pull request #3258](https://github.com/gazebosim/gazebo-classic/pull/3258)
 
 1. Add support for cross-compilation in Gazebo
    * [Pull request #3190](https://github.com/gazebosim/gazebo-classic/pull/3190)  

--- a/Changelog.md
+++ b/Changelog.md
@@ -52,6 +52,12 @@
 1. Fix disappearing shadows when looking from certain angles
    * [Pull request #3267](https://github.com/gazebosim/gazebo-classic/pull/3267)
 
+1. Use DistanceBetweenPoints when loading DEMs
+   * [Pull request #3252](https://github.com/gazebosim/gazebo-classic/pull/3252)
+
+1. Add support for cross-compilation in Gazebo
+   * [Pull request #3190](https://github.com/gazebosim/gazebo-classic/pull/3190)  
+
 ## Gazebo 11.12.0 (2022-09-14)
 
 1. BulletLink: add and set force and torque

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Gazebo 11.13.0 (2023-05-17)
 
+1. Add missing spaces to several rendering messages 
+   * [Pull request #3322](https://github.com/gazebosim/gazebo-classic/pull/3322)
+
 1. Fix build with ffmpeg 6.0
    * [Pull request #3318](https://github.com/gazebosim/gazebo-classic/pull/3318)
 


### PR DESCRIPTION
I tought a release could be useful for downstream package mantainers, especially the ffmpeg 6 and gcc 11 fixes. I tried to prepare the Changelog.md (manually, not sure if there is a smarter way) and the CMake change looking at the past PRs, please correct me if I did something wrong. @scpeters @j-rivero 

I added "A contribution from" for people outside former OpenRobotics or usual contributors, but I could have missed something.

Comparison to 11.12.0: https://github.com/gazebosim/gazebo-classic/compare/gazebo11_11.12.0...traversaro:gazebo:rel1113