### PR TITLE
Fix wide-angle lens flare occlusion lag

### DIFF
--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -305,7 +305,8 @@ namespace gazebo
                 ignition::math::Pose3d(
                   Conversions::ConvertIgn(cam->getDerivedPosition()),
                   Conversions::ConvertIgn(quat)));
-            this->dataPtr->wideAngleDummyCamera->OgreCamera()->getParentSceneNode()->_update(true, true);
+            this->dataPtr->wideAngleDummyCamera->OgreCamera()
+                ->getParentSceneNode()->_update(true, true);
 
             // OcclusionScale() was built for a regular perspective projection
             // camera and cannot be passed a WideAngleCamera. A cleaner solution

--- a/gazebo/rendering/LensFlare.cc
+++ b/gazebo/rendering/LensFlare.cc
@@ -305,6 +305,7 @@ namespace gazebo
                 ignition::math::Pose3d(
                   Conversions::ConvertIgn(cam->getDerivedPosition()),
                   Conversions::ConvertIgn(quat)));
+            this->dataPtr->wideAngleDummyCamera->OgreCamera()->getParentSceneNode()->_update(true, true);
 
             // OcclusionScale() was built for a regular perspective projection
             // camera and cannot be passed a WideAngleCamera. A cleaner solution

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -1599,9 +1599,9 @@ TEST_F(CameraSensor, LensFlareWideAngleCameraOcclusion)
     {
       for (unsigned int x = 0; x < width*3; x+=3)
       {
-        EXPECT_EQ(img[(y*width*3) + x], img2[(y*width*3) + x]);
-        EXPECT_EQ(img[(y*width*3) + x + 1], img2[(y*width*3) + x + 1]);
-        EXPECT_EQ(img[(y*width*3) + x + 2], img2[(y*width*3) + x + 2]);
+        EXPECT_NEAR(img[(y*width*3) + x], img2[(y*width*3) + x], 2);
+        EXPECT_NEAR(img[(y*width*3) + x + 1], img2[(y*width*3) + x + 1], 2);
+        EXPECT_NEAR(img[(y*width*3) + x + 2], img2[(y*width*3) + x + 2], 2);
       }
     }
   }

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -1433,8 +1433,11 @@ TEST_F(CameraSensor, LensFlareWideAngleCamera)
   physics::ModelPtr model = world->ModelByName(modelNameLensFlare);
   ASSERT_TRUE(model != nullptr);
 
+  // use fully scoped sensor name
   sensors::SensorPtr sensorLensFlare =
-    sensors::get_sensor(cameraNameLensFlare);
+    sensors::get_sensor(world->Name() + "::"
+                 + modelNameLensFlare + "::link::"
+                 + cameraNameLensFlare);
   sensors::CameraSensorPtr camSensorLensFlare =
     std::dynamic_pointer_cast<sensors::CameraSensor>(sensorLensFlare);
   ASSERT_TRUE(camSensorLensFlare != nullptr);
@@ -1446,8 +1449,11 @@ TEST_F(CameraSensor, LensFlareWideAngleCamera)
   model = world->ModelByName(modelNameWithoutLensFlare);
   ASSERT_TRUE(model != nullptr);
 
+  // use fully scoped sensor name
   sensors::SensorPtr sensorWithoutLensFlare =
-    sensors::get_sensor(cameraNameWithoutLensFlare);
+    sensors::get_sensor(world->Name() + "::"
+          + modelNameWithoutLensFlare + "::link::"
+          + cameraNameWithoutLensFlare);
   sensors::CameraSensorPtr camSensorWithoutLensFlare =
     std::dynamic_pointer_cast<sensors::CameraSensor>(sensorWithoutLensFlare);
   ASSERT_TRUE(camSensorWithoutLensFlare != nullptr);

--- a/test/integration/camera_sensor.cc
+++ b/test/integration/camera_sensor.cc
@@ -1521,7 +1521,7 @@ TEST_F(CameraSensor, LensFlareWideAngleCamera)
 /////////////////////////////////////////////////
 TEST_F(CameraSensor, LensFlareWideAngleCameraOcclusion)
 {
-  Load("worlds/lensflare_wideangle_cam.world", true);
+  LoadArgs(" --lockstep -u worlds/lensflare_wideangle_cam.world");
 
   // Make sure the render engine is available.
   if (rendering::RenderEngine::Instance()->GetRenderPathType() ==

--- a/worlds/lensflare_wideangle_cam.world
+++ b/worlds/lensflare_wideangle_cam.world
@@ -385,5 +385,64 @@
       </link>
     </model>
 
+    <!-- model with two wide-angle cameras with slow update rates, with and without lens flare plugin -->
+    <model name="slow_wide_angle_cameras">
+     <static>true</static>
+     <pose>0 12 11.0 0 0 0</pose>
+     <link name="link">
+      <visual name="visual">
+       <geometry>
+        <box>
+         <size>0.1 0.1 0.1</size>
+        </box>
+       </geometry>
+      </visual>
+      <sensor name="camera_sensor_lensflare" type="wideanglecamera">
+       <camera>
+        <horizontal_fov>3.14159</horizontal_fov>
+        <image>
+         <width>320</width>
+         <height>240</height>
+        </image>
+        <clip>
+         <near>0.1</near>
+         <far>100</far>
+        </clip>
+        <lens>
+         <type>equidistant</type>
+         <scale_to_hfov>true</scale_to_hfov>
+         <cutoff_angle>1.5707</cutoff_angle>
+         <env_texture_size>512</env_texture_size>
+        </lens>
+       </camera>
+       <always_on>1</always_on>
+       <update_rate>1</update_rate>
+       <visualize>true</visualize>
+       <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+      </sensor>
+      <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
+       <camera>
+        <horizontal_fov>3.14159</horizontal_fov>
+        <image>
+         <width>320</width>
+         <height>240</height>
+        </image>
+        <clip>
+         <near>0.1</near>
+         <far>100</far>
+        </clip>
+        <lens>
+         <type>equidistant</type>
+         <scale_to_hfov>true</scale_to_hfov>
+         <cutoff_angle>1.5707</cutoff_angle>
+         <env_texture_size>512</env_texture_size>
+        </lens>
+       </camera>
+       <always_on>1</always_on>
+       <update_rate>1</update_rate>
+       <visualize>true</visualize>
+      </sensor>
+     </link>
+    </model>
   </world>
 </sdf>

--- a/worlds/lensflare_wideangle_cam.world
+++ b/worlds/lensflare_wideangle_cam.world
@@ -387,62 +387,62 @@
 
     <!-- model with two wide-angle cameras with slow update rates, with and without lens flare plugin -->
     <model name="slow_wide_angle_cameras">
-     <static>true</static>
-     <pose>0 12 11.0 0 0 0</pose>
-     <link name="link">
-      <visual name="visual">
-       <geometry>
-        <box>
-         <size>0.1 0.1 0.1</size>
-        </box>
-       </geometry>
-      </visual>
-      <sensor name="camera_sensor_lensflare" type="wideanglecamera">
-       <camera>
-        <horizontal_fov>3.14159</horizontal_fov>
-        <image>
-         <width>320</width>
-         <height>240</height>
-        </image>
-        <clip>
-         <near>0.1</near>
-         <far>100</far>
-        </clip>
-        <lens>
-         <type>equidistant</type>
-         <scale_to_hfov>true</scale_to_hfov>
-         <cutoff_angle>1.5707</cutoff_angle>
-         <env_texture_size>512</env_texture_size>
-        </lens>
-       </camera>
-       <always_on>1</always_on>
-       <update_rate>1</update_rate>
-       <visualize>true</visualize>
-       <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
-      </sensor>
-      <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
-       <camera>
-        <horizontal_fov>3.14159</horizontal_fov>
-        <image>
-         <width>320</width>
-         <height>240</height>
-        </image>
-        <clip>
-         <near>0.1</near>
-         <far>100</far>
-        </clip>
-        <lens>
-         <type>equidistant</type>
-         <scale_to_hfov>true</scale_to_hfov>
-         <cutoff_angle>1.5707</cutoff_angle>
-         <env_texture_size>512</env_texture_size>
-        </lens>
-       </camera>
-       <always_on>1</always_on>
-       <update_rate>1</update_rate>
-       <visualize>true</visualize>
-      </sensor>
-     </link>
+      <static>true</static>
+      <pose>0 12 11.0 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <box>
+              <size>0.1 0.1 0.1</size>
+            </box>
+          </geometry>
+        </visual>
+        <sensor name="camera_sensor_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>3.14159</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>equidistant</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>1</update_rate>
+          <visualize>true</visualize>
+          <plugin name="lensflare" filename="libLensFlareSensorPlugin.so"/>
+        </sensor>
+        <sensor name="camera_sensor_without_lensflare" type="wideanglecamera">
+          <camera>
+            <horizontal_fov>3.14159</horizontal_fov>
+            <image>
+              <width>320</width>
+              <height>240</height>
+            </image>
+            <clip>
+              <near>0.1</near>
+              <far>100</far>
+            </clip>
+            <lens>
+              <type>equidistant</type>
+              <scale_to_hfov>true</scale_to_hfov>
+              <cutoff_angle>1.5707</cutoff_angle>
+              <env_texture_size>512</env_texture_size>
+            </lens>
+          </camera>
+          <always_on>1</always_on>
+          <update_rate>1</update_rate>
+          <visualize>true</visualize>
+        </sensor>
+      </link>
     </model>
   </world>
 </sdf>


### PR DESCRIPTION
Fixes #3310 

This forces an update of the wide angle dummy camera, which updates the Ogre camera's view matrix. 

---

One way to check that this fixes the bug, is to use [this](https://github.com/audrow/gazebo-classic/blob/audrow/debug-lens-flare/worlds/lensflare_wideangle_cam.world) world file. Open it in Gazebo, and then move the only camera (`wide_angle_cameras_occluded_higher`) from it's starting height (`z=21`) to `z=11`, where it will have a wall between it and the light source. You can then move it back to `z=21`.

You should see lens flare when the light source is in the image and now lens flare when the light source is occluded. 