### PR TITLE
Make a more prominent notice about the new Gazebo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@ Gazebo - A dynamic multi-robot simulator
 ----------------------------------------
 ![image](https://user-images.githubusercontent.com/10261903/174557418-1a83fbb7-e12b-4edb-b99f-5aaf8eed5cae.png)
 
+> **Note**
+>  ### A new version of Gazebo (formerly known as Ignition) is now available. Please visit https://gazebosim.org or https://github.com/gazebosim/gz-sim to learn more.
+
+
 This is the [Gazebo Classic](http://classic.gazebosim.org) simulator.  Gazebo simulates multiple robots in a
 3D environment, with extensive dynamic interaction between objects.
-
-For the latest version of Gazebo, see
-
-* http://gazebosim.org
-* https://github.com/gazebosim/gz-sim
-
 
 Documentation
 -------------


### PR DESCRIPTION
The [gazebo-classic](https://classic.gazebosim.org/) website has been updated with similar content.