### PR TITLE
gzclient: improve startup reliability

### DIFF
--- a/gazebo/gui/MainWindow.hh
+++ b/gazebo/gui/MainWindow.hh
@@ -285,6 +285,12 @@ namespace gazebo
       /// \param[in] _msg Pointer to the light message.
       private: void OnLight(ConstLightPtr &_msg);
 
+      /// \brief Called when the scene info service replies with the scene
+      /// message.
+      /// \param[in] _msg The message.
+      /// \param[in] _result Flag indicating if service call succeeded.
+      private: void OnSceneInfo(const msgs::Scene &_msg, const bool _result);
+
       private: void OnResponse(ConstResponsePtr &_msg);
       private: void OnWorldModify(ConstWorldModifyPtr &_msg);
       private: void OnManipMode(const std::string &_mode);


### PR DESCRIPTION
# 🦟 Bug fix

This is an additional fix for https://github.com/gazebosim/gazebo-classic/issues/681, following up from #3121

## Summary

In #3121, a call to the `/scene_info` service was added in the `Scene` class to improve the reliability of initializing `gzclient`. This improved reliability, but I have still observed flaky gzclient startups, particularly when loading worlds with large Digital Elevation Maps (DEMs). I found another place where `~/request` and `~/response` topics are used to get scene info in the `MainWindow` class, which I suspect is an additional source of unreliable start-up behavior.

This applies similar changes from #3121 to the `MainWindow` class by getting scene info from the /scene_info service and falling back to using the request / response topics if the service is not available or the service call fails.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
