### PR TITLE
Apply initial sim time also after a reset.

### DIFF
--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -412,8 +412,10 @@ bool Server::ParseArgs(int _argc, char **_argv)
   {
     try
     {
-      physics::get_world()->SetSimTime(
-          common::Time(this->dataPtr->vm["initial_sim_time"].as<double>()));
+      common::Time initialSimTime {
+        this->dataPtr->vm["initial_sim_time"].as<double>()};
+      physics::get_world()->SetSimTime(initialSimTime);
+      physics::get_world()->SetInitialSimTime(initialSimTime);
       gzmsg << "Setting initial sim time to [" <<
         physics::get_world()->SimTime() << "]\n" << std::endl;
     }

--- a/gazebo/Server.cc
+++ b/gazebo/Server.cc
@@ -199,7 +199,7 @@ bool Server::ParseArgs(int _argc, char **_argv)
     ("record_resources", "Recording with model meshes and materials.")
     ("seed",  po::value<double>(), "Start with a given random number seed.")
     ("initial_sim_time", po::value<double>(),
-     "Initial simulation time (seconds).")
+     "Initial simulation time (seconds). This time is also used after reset.")
     ("iters",  po::value<unsigned int>(), "Number of iterations to simulate.")
     ("minimal_comms", "Reduce the TCP/IP traffic output by gzserver")
     ("server-plugin,s", po::value<std::vector<std::string> >(),

--- a/gazebo/physics/World.cc
+++ b/gazebo/physics/World.cc
@@ -1455,7 +1455,7 @@ Light_V World::Lights() const
 //////////////////////////////////////////////////
 void World::ResetTime()
 {
-  this->dataPtr->simTime = common::Time(0);
+  this->dataPtr->simTime = common::Time(this->dataPtr->initialSimTime);
   this->dataPtr->pauseTime = common::Time(0);
   this->dataPtr->startTime = common::Time::GetWallTime();
   this->dataPtr->realTimeOffset = common::Time(0);
@@ -1526,6 +1526,12 @@ gazebo::common::Time World::SimTime() const
 void World::SetSimTime(const common::Time &_t)
 {
   this->dataPtr->simTime = _t;
+}
+
+//////////////////////////////////////////////////
+void World::SetInitialSimTime(const common::Time &_t)
+{
+  this->dataPtr->initialSimTime = _t;
 }
 
 //////////////////////////////////////////////////

--- a/gazebo/physics/World.hh
+++ b/gazebo/physics/World.hh
@@ -240,6 +240,10 @@ namespace gazebo
       /// \return The real time.
       public: common::Time RealTime() const;
 
+      /// \brief Set the initial sim time.
+      /// \param[in] _t The new simulation time
+      public: void SetInitialSimTime(const common::Time &_t);
+
       /// \brief Returns the state of the simulation true if paused.
       /// \return True if paused.
       public: bool IsPaused() const;

--- a/gazebo/physics/WorldPrivate.hh
+++ b/gazebo/physics/WorldPrivate.hh
@@ -86,6 +86,9 @@ namespace gazebo
       /// \brief Clock time when simulation was started.
       public: common::Time startTime;
 
+      /// \brief Initial simulation time.
+      public: common::Time initialSimTime;
+
       /// \brief True if simulation is paused.
       public: bool pause;
 

--- a/test/integration/world_with_initial_sim_time_from_cli.cc
+++ b/test/integration/world_with_initial_sim_time_from_cli.cc
@@ -46,7 +46,17 @@ TEST_F(WorldWithInitialSimTimeFromCliTest, CheckInitialSimTime)
 
   // check that the simulation time is the same as the initial sim time
   EXPECT_DOUBLE_EQ(this->world->SimTime().Double(), initialSimTime);
+
+  // check that after a step, the simulation time advances
+  this->world->Step(2);
+  EXPECT_GT(this->world->SimTime().Double() - initialSimTime, 1e-4);
+
+  // check that the simulation time is again the same as the initial sim time
+  // after a reset
+  this->world->Reset();
+  EXPECT_DOUBLE_EQ(this->world->SimTime().Double(), initialSimTime);
 }
+
 
 /////////////////////////////////////////////////
 int main(int argc, char **argv)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo-classic/pull/3294#issuecomment-1618394550

## Summary
Initial sim time should also be respected after a reset.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
