### PR TITLE
Wheel slip nonlinear effect (breaks ABI, not for merging)

### DIFF
--- a/gazebo/physics/Model.cc
+++ b/gazebo/physics/Model.cc
@@ -297,6 +297,14 @@ void Model::LoadJoints()
 //////////////////////////////////////////////////
 void Model::Init()
 {
+  // Cache the total mass of the model
+  this->mass = 0.0;
+  for (uint64_t i = 0; i < this->modelSDFDom->LinkCount(); ++i)
+  {
+    this->mass +=
+        this->modelSDFDom->LinkByIndex(i)->Inertial().MassMatrix().Mass();
+  }
+
   // Record the model's initial pose (for reseting)
   this->SetInitialRelativePose(this->SDFPoseRelativeToParent());
   this->SetRelativePose(this->SDFPoseRelativeToParent());
@@ -1861,6 +1869,7 @@ void Model::PluginInfo(const common::URI &_pluginUri,
       << std::endl;
 }
 
+//////////////////////////////////////////////////
 std::optional<sdf::SemanticPose> Model::SDFSemanticPose() const
 {
   if (nullptr != this->modelSDFDom)
@@ -1868,4 +1877,10 @@ std::optional<sdf::SemanticPose> Model::SDFSemanticPose() const
     return this->modelSDFDom->SemanticPose();
   }
   return std::nullopt;
+}
+
+//////////////////////////////////////////////////
+double Model::GetMass() const
+{
+  return this->mass;
 }

--- a/gazebo/physics/Model.hh
+++ b/gazebo/physics/Model.hh
@@ -93,6 +93,10 @@ namespace gazebo
       /// \return The SDF DOM for this model.
       public: const sdf::Model *GetSDFDom() const;
 
+      /// \brief Get the total mass of this model.
+      /// \return The mass of the model, cached during initialization.
+      public: double GetMass() const;
+
       /// \internal
       /// \brief Get the SDF element for the model, without all effects of
       /// scaling. This is useful in cases when the scale will be applied
@@ -567,6 +571,9 @@ namespace gazebo
 
       /// \brief SDF Model DOM object
       private: const sdf::Model *modelSDFDom = nullptr;
+
+      /// \brief Cached mass of the entire model.
+      private: double mass = 0.0;
     };
     /// \}
   }

--- a/gazebo/physics/ode/ODECollision.cc
+++ b/gazebo/physics/ode/ODECollision.cc
@@ -185,6 +185,24 @@ bool ODECollision::ParseWheelPlowingParams(
     return false;
   }
 
+  const std::string kNonlinearSlip = "nonlinear_slip";
+  if (wheelElem->HasElement(kNonlinearSlip))
+  {
+    sdf::ElementPtr nonlinearSlipElem = wheelElem->GetElement(kNonlinearSlip);
+    if (nonlinearSlipElem->HasElement("lower"))
+    {
+      sdf::ElementPtr lowerElem = nonlinearSlipElem->GetElement("lower");
+      _plowing.nonlinearSlipLowerDegree = lowerElem->Get<double>("degree");
+      _plowing.nonlinearSlipLowerPerDegree = lowerElem->Get<double>("per_degree");
+    }
+    if (nonlinearSlipElem->HasElement("upper"))
+    {
+      sdf::ElementPtr upperElem = nonlinearSlipElem->GetElement("upper");
+      _plowing.nonlinearSlipUpperDegree = upperElem->Get<double>("degree");
+      _plowing.nonlinearSlipUpperPerDegree = upperElem->Get<double>("per_degree");
+    }
+  }
+
   _plowing.maxAngle = plowingMaxAngle;
   _plowing.saturationVelocity = plowingSaturationVelocity;
   _plowing.deadbandVelocity = plowingDeadbandVelocity;

--- a/gazebo/physics/ode/ODECollision.hh
+++ b/gazebo/physics/ode/ODECollision.hh
@@ -49,6 +49,22 @@ namespace gazebo
       /// \brief Plowing deadband velocity: the linear wheel velocity [m/s]
       /// below which no plowing effect occurs.
       public: double deadbandVelocity = 0.0;
+
+      /// \brief The slope value in degrees below which the nonlinear slip
+      /// effect is applied.
+      public: double nonlinearSlipLowerDegree = -361.0;
+
+      /// \brief The slope value in degrees above which the nonlinear slip
+      /// effect is applied.
+      public: double nonlinearSlipUpperDegree = 361.0;
+
+      /// \brief The rate of change in slip compliance per degree of slope
+      /// below the "lower degree" value.
+      public: double nonlinearSlipLowerPerDegree = 0.0;
+
+      /// \brief The rate of change in slip compliance per degree of slope
+      /// above the "upper degree" value.
+      public: double nonlinearSlipUpperPerDegree = 0.0;
     };
 
     /// \brief Base class for all ODE collisions.

--- a/gazebo/physics/ode/ODELink.hh
+++ b/gazebo/physics/ode/ODELink.hh
@@ -83,6 +83,10 @@ namespace gazebo
       // Documentation inherited
       public: virtual void SetTorque(const ignition::math::Vector3d &_torque);
 
+      /// Get sum of forces expressed in world frame that have been added by
+      /// Link::Add*Force during this timestep.
+      public: const ignition::math::Vector3d &AddedForce() const;
+
       // Documentation inherited
       public: virtual void AddForce(const ignition::math::Vector3d &_force);
 
@@ -196,6 +200,9 @@ namespace gazebo
 
       /// \brief Cache torque applied on body
       private: ignition::math::Vector3d torque;
+
+      /// \brief Cache force applied by AddForce
+      private: ignition::math::Vector3d addedForce;
     };
     /// \}
   }

--- a/test/models/plowing_nonlinear_slip_trisphere_cycle/model.config
+++ b/test/models/plowing_nonlinear_slip_trisphere_cycle/model.config
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+
+<model>
+  <name>Tricycle with spherical wheels and plowing effect with nonlinear slip</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+
+  <author>
+    <name>Steve Peters</name>
+    <email>scpeters@osrfoundation.org</email>
+  </author>
+
+  <author>
+    <name>Aditya Pande</name>
+    <email>aditya.pande@openrobotics.org</email>
+  </author>
+
+  <description>
+    A tricycle with spherical wheels and front-wheel steering.
+    The first friction direction for each wheel is parallel to the joint axis
+    for each wheel spin joint, which corresponds to the wheel's lateral
+    direction.
+    The plowing and nonlinear slip parameters are specified in the //collision/gz:plowing_wheel
+    element for each wheel's sperical collision element.
+  </description>
+</model>

--- a/test/models/plowing_nonlinear_slip_trisphere_cycle/model.sdf
+++ b/test/models/plowing_nonlinear_slip_trisphere_cycle/model.sdf
@@ -1,0 +1,459 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <model name="plowing_effect_trisphere_cycle" xmlns:gz="https://gazebosim.org/schema">
+    <link name="frame">
+      <pose>-0.40855911616047164 0 0.38502293110800634  0 -0.522020852957719 0</pose>
+      <inertial>
+        <pose>0.0 0 0  0 0 0</pose>
+        <mass>10</mass>
+        <inertia>
+          <ixx>0.22799999999999998</ixx>
+          <iyy>0.7435210984814149</iyy>
+          <izz>0.9655210984814149</izz>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <collision name="axle_collision">
+        <pose>-0.4713346258704366 0 0  1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>1.0392304845413263</length>
+            <radius>0.03</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="axle_visual">
+        <pose>-0.4713346258704366 0 0  1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>1.0392304845413263</length>
+            <radius>0.03</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="frame_left_collision">
+        <pose>0 0.17155177419583564 0  0 1.5707963267948966 -0.3490658503988659</pose>
+        <geometry>
+          <cylinder>
+            <length>1.0031676644991372</length>
+            <radius>0.03</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="frame_left_visual">
+        <pose>0 0.17155177419583564 0  0 1.5707963267948966 -0.3490658503988659</pose>
+        <geometry>
+          <cylinder>
+            <length>1.0031676644991372</length>
+            <radius>0.03</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="frame_right_collision">
+        <pose>0 -0.17155177419583564 0  0 1.5707963267948966 0.3490658503988659</pose>
+        <geometry>
+          <cylinder>
+            <length>1.0031676644991372</length>
+            <radius>0.03</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="frame_right_visual">
+        <pose>0 -0.17155177419583564 0  0 1.5707963267948966 0.3490658503988659</pose>
+        <geometry>
+          <cylinder>
+            <length>1.0031676644991372</length>
+            <radius>0.03</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <link name="fork">
+      <pose>0.04144088383952833 0 0.38502293110800634  0 -0.17453292519943295 0</pose>
+      <inertial>
+        <mass>3</mass>
+        <inertia>
+          <ixx>0.15820312499999997</ixx>
+          <iyy>0.058359374999999984</iyy>
+          <izz>0.10265624999999999</izz>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <collision name="handlebars_collision">
+        <pose>0 0 0.397747564417433  1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.6363961030678927</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="handlebars_visual">
+        <pose>0 0 0.397747564417433  1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.6363961030678927</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="headtube_collision">
+        <pose>0 0 0.2386485386504598  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.31819805153394637</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="headtube_visual">
+        <pose>0 0 0.2386485386504598  0 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.31819805153394637</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="spindle_collision">
+        <pose>0 0 -0.23864853865045976  1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.6363961030678927</length>
+            <radius>0.015</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="spindle_visual">
+        <pose>0 0 -0.23864853865045976  1.5707963267948966 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.6363961030678927</length>
+            <radius>0.015</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="fork_left_collision">
+        <pose>0 0.15909902576697318 -0.07954951288348658  0.7853981633974483 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.45</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="fork_left_visual">
+        <pose>0 0.15909902576697318 -0.07954951288348658  0.7853981633974483 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.45</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+      <collision name="fork_right_collision">
+        <pose>0 -0.15909902576697318 -0.07954951288348658  -0.7853981633974483 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.45</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <visual name="fork_right_visual">
+        <pose>0 -0.15909902576697318 -0.07954951288348658  -0.7853981633974483 0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.45</length>
+            <radius>0.0375</radius>
+          </cylinder>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <link name="wheel_front">
+      <pose>0.08288176767905665 0 0.15  0 0 0</pose>
+      <inertial>
+        <mass>0.5</mass>
+        <inertia>
+          <ixx>0.0045</ixx>
+          <iyy>0.0045</iyy>
+          <izz>0.0045</izz>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <collision name="collision">
+        <gz:plowing_wheel>
+          <max_degrees>5</max_degrees>
+          <deadband_velocity>0.3</deadband_velocity>
+          <saturation_velocity>0.4</saturation_velocity>
+          <nonlinear_slip>
+            <lower>
+              <degree>-6</degree>
+              <per_degree>0.01</per_degree>
+            </lower>
+            <upper>
+              <degree>6</degree>
+              <per_degree>0.01</per_degree>
+            </upper>
+          </nonlinear_slip>
+        </gz:plowing_wheel>
+        <geometry>
+          <sphere>
+            <radius>0.15</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>4000</kp>
+              <kd>16</kd>
+              <max_vel>10</max_vel>
+              <min_depth>0.0005</min_depth>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.7</mu>
+              <mu2>0.7</mu2>
+              <fdir1>0 1 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <sphere>
+            <radius>0.15</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Black</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="wheel_front_steer" type="revolute">
+      <parent>frame</parent>
+      <child>fork</child>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <dynamics>
+        <friction>1.0</friction> 
+        </dynamics>
+        <limit>
+          <lower>-0.9599310885968813</lower>
+          <upper>0.9599310885968813</upper>
+        </limit>
+      </axis>
+    </joint>
+    <joint name="wheel_front_spin" type="revolute">
+      <parent>fork</parent>
+      <child>wheel_front</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+      </axis>
+    </joint>
+    <link name="wheel_rear_left">
+      <pose>-0.8171182323209433 0.5196152422706631 0.15  0 0 0</pose>
+      <inertial>
+        <mass>0.5</mass>
+        <inertia>
+          <ixx>0.0045</ixx>
+          <iyy>0.0045</iyy>
+          <izz>0.0045</izz>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <collision name="collision">
+        <gz:plowing_wheel>
+          <max_degrees>5</max_degrees>
+          <deadband_velocity>0.3</deadband_velocity>
+          <saturation_velocity>0.4</saturation_velocity>
+          <nonlinear_slip>
+            <lower>
+              <degree>-6</degree>
+              <per_degree>0.01</per_degree>
+            </lower>
+            <upper>
+              <degree>6</degree>
+              <per_degree>0.01</per_degree>
+            </upper>
+          </nonlinear_slip>
+        </gz:plowing_wheel>
+        <geometry>
+          <sphere>
+            <radius>0.15</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>4000</kp>
+              <kd>16</kd>
+              <max_vel>10</max_vel>
+              <min_depth>0.0005</min_depth>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.7</mu>
+              <mu2>0.7</mu2>
+              <fdir1>0 1 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <sphere>
+            <radius>0.15</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Black</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="wheel_rear_left_spin" type="revolute">
+      <parent>frame</parent>
+      <child>wheel_rear_left</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+      </axis>
+    </joint>
+    <link name="wheel_rear_right">
+      <pose>-0.8171182323209433 -0.5196152422706631 0.15  0 0 0</pose>
+      <inertial>
+        <mass>0.5</mass>
+        <inertia>
+          <ixx>0.0045</ixx>
+          <iyy>0.0045</iyy>
+          <izz>0.0045</izz>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyz>0</iyz>
+        </inertia>
+      </inertial>
+      <collision name="collision">
+        <gz:plowing_wheel>
+          <max_degrees>5</max_degrees>
+          <deadband_velocity>0.3</deadband_velocity>
+          <saturation_velocity>0.4</saturation_velocity>
+          <nonlinear_slip>
+            <lower>
+              <degree>-6</degree>
+              <per_degree>0.01</per_degree>
+            </lower>
+            <upper>
+              <degree>6</degree>
+              <per_degree>0.01</per_degree>
+            </upper>
+          </nonlinear_slip>
+        </gz:plowing_wheel>
+        <geometry>
+          <sphere>
+            <radius>0.15</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>4000</kp>
+              <kd>16</kd>
+              <max_vel>10</max_vel>
+              <min_depth>0.0005</min_depth>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.7</mu>
+              <mu2>0.7</mu2>
+              <fdir1>0 1 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <sphere>
+            <radius>0.15</radius>
+          </sphere>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Black</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+    <joint name="wheel_rear_right_spin" type="revolute">
+      <parent>frame</parent>
+      <child>wheel_rear_right</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+      </axis>
+    </joint>
+  </model>
+</sdf>

--- a/test/worlds/plowing_effect_tricycle_demo.world
+++ b/test/worlds/plowing_effect_tricycle_demo.world
@@ -25,7 +25,7 @@
 -->
 <sdf version="1.6">
   <world name="default">
-	<gravity>0 0 -9.75</gravity>
+    <gravity>0 0 -9.75</gravity>
     <include>
       <uri>model://plowing_effect_ground_plane</uri>
     </include>
@@ -40,18 +40,18 @@
 
       <plugin name="wheel_slip" filename="libWheelSlipPlugin.so">
         <wheel link_name="wheel_front">
-		<slip_compliance_lateral>3.0</slip_compliance_lateral>
-		<slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
           <wheel_normal_force>32</wheel_normal_force>
         </wheel>
         <wheel link_name="wheel_rear_left">
-		<slip_compliance_lateral>3.0</slip_compliance_lateral>
-		<slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
           <wheel_normal_force>32</wheel_normal_force>
         </wheel>
         <wheel link_name="wheel_rear_right">
-		<slip_compliance_lateral>3.0</slip_compliance_lateral>
-		<slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
           <wheel_normal_force>32</wheel_normal_force>
         </wheel>
       </plugin>
@@ -101,18 +101,18 @@
 
       <plugin name="wheel_slip" filename="libWheelSlipPlugin.so">
         <wheel link_name="wheel_front">
-		<slip_compliance_lateral>3.0</slip_compliance_lateral>
-		<slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
           <wheel_normal_force>32</wheel_normal_force>
         </wheel>
         <wheel link_name="wheel_rear_left">
-		<slip_compliance_lateral>3.0</slip_compliance_lateral>
-		<slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
           <wheel_normal_force>32</wheel_normal_force>
         </wheel>
         <wheel link_name="wheel_rear_right">
-		<slip_compliance_lateral>3.0</slip_compliance_lateral>
-		<slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
           <wheel_normal_force>32</wheel_normal_force>
         </wheel>
       </plugin>

--- a/test/worlds/plowing_nonlinear_slip_tricycle_demo.world
+++ b/test/worlds/plowing_nonlinear_slip_tricycle_demo.world
@@ -1,0 +1,166 @@
+<?xml version="1.0" ?>
+<!--
+  Demonstration of wheel plowing effect with tricycle models.
+  Be sure to add the test/models folder to your GAZEBO_MODEL_PATH before
+  running this world.
+
+  This world contains a ground plane with gz:plowing_terrain defined
+  and two tricycle models with the WheelSlipPlugin that use spherical wheels
+  to simplify the contact geometry.
+  The trisphere_cycle model does not have plowing enabled, while the
+  plowing_effect_trisphere_cycle model does have plowing enabled.
+  Each model has a JointControlPlugin that enables a speed controller on each
+  wheel to cause the tricycles to drive forward.
+
+  Though the joint controllers are controlling the same wheel speeds, the
+  increased drag caused by the plowing effect reduces the linear speed
+  that is reached by the plowing_effect_trisphere_cycle model.
+  Enable "View Contacts" and "View transparent" or "View Wireframe" in gzclient
+  to see the change in contact point location and normal direction due to the
+  plowing effect.
+
+  Try adjusting wheel slip parameters or the gz:plowing_wheel parameters in
+  test/models/plowing_effect_trisphere_cycle/model.sdf to experiment
+  with the plowing effect.
+-->
+<sdf version="1.6">
+  <world name="default">
+    <gravity>-2 0 -9.75</gravity>
+    <include>
+      <uri>model://plowing_effect_ground_plane</uri>
+    </include>
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <include>
+      <uri>model://plowing_effect_trisphere_cycle</uri>
+      <name>plowing_tricycle</name>
+      <pose>0 0 0  0 0 0</pose>
+
+      <plugin name="wheel_slip" filename="libWheelSlipPlugin.so">
+        <wheel link_name="wheel_front">
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_left">
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_right">
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+      </plugin>
+
+      <plugin name="joint_control" filename="libJointControlPlugin.so">
+        <controller type="position">
+          <joint>wheel_front_steer</joint>
+          <target>0</target>
+          <pid_gains>9 0 0.1</pid_gains>
+        </controller>
+        <controller type="velocity">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <joint>wheel_front_spin</joint>
+          <target>6.0</target>
+          <pid_gains>9 0 0</pid_gains>
+        </controller>
+        <controller type="force">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <target>2.15</target>
+        </controller>
+      </plugin>
+
+      <!-- enable these plugins if using ros2
+      <plugin name="ground_truth" filename="libgazebo_ros_p3d.so">
+        <alwaysOn>true</alwaysOn>
+        <frameName>world</frameName>
+        <body_name>frame</body_name>
+        <topicName>odom</topicName>
+        <updateRate>30.0</updateRate>
+      </plugin>
+
+      <plugin name="wheel_rotation" filename="libgazebo_ros_joint_state_publisher.so">
+        <updateRate>30.0</updateRate>
+        <joint_name>wheel_rear_left_spin</joint_name>
+        <joint_name>wheel_rear_right_spin</joint_name>
+      </plugin>
+      -->
+
+    </include>
+
+    <include>
+      <uri>model://plowing_nonlinear_slip_trisphere_cycle</uri>
+      <name>nonlinear_slip_tricycle</name>
+      <pose>0 2 0  0 0 0</pose>
+
+      <plugin name="wheel_slip" filename="libWheelSlipPlugin.so">
+        <wheel link_name="wheel_front">
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_left">
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+        <wheel link_name="wheel_rear_right">
+          <slip_compliance_lateral>3.0</slip_compliance_lateral>
+          <slip_compliance_longitudinal>3.0</slip_compliance_longitudinal>
+          <wheel_normal_force>32</wheel_normal_force>
+        </wheel>
+      </plugin>
+
+      <plugin name="joint_control" filename="libJointControlPlugin.so">
+        <controller type="position">
+          <joint>wheel_front_steer</joint>
+          <target>0</target>
+          <pid_gains>9 0 0.1</pid_gains>
+        </controller>
+        <controller type="velocity">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <joint>wheel_front_spin</joint>
+          <target>6.0</target>
+          <pid_gains>9 0 0</pid_gains>
+        </controller>
+        <controller type="force">
+          <joint>wheel_rear_left_spin</joint>
+          <joint>wheel_rear_right_spin</joint>
+          <target>2.15</target>
+        </controller>
+      </plugin>
+
+      <!-- enable these plugins if using ros2
+      <plugin name="ground_truth" filename="libgazebo_ros_p3d.so">
+        <alwaysOn>true</alwaysOn>
+        <frameName>world</frameName>
+        <body_name>frame</body_name>
+        <topicName>odom</topicName>
+        <updateRate>30.0</updateRate>
+      </plugin>
+
+      <plugin name="wheel_rotation" filename="libgazebo_ros_joint_state_publisher.so">
+        <updateRate>30.0</updateRate>
+        <joint_name>wheel_rear_left_spin</joint_name>
+        <joint_name>wheel_rear_right_spin</joint_name>
+      </plugin>
+      -->
+
+    </include>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>1.5 -4 2.5  0 0.5 1.6</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+    </gui>
+  </world>
+</sdf>
+


### PR DESCRIPTION
# 🎉 New feature

Adds a nonlinear effect to the wheel slip model (not for merging due to ABI breaks)

## Summary

Driving on deformable terrain can currently be modeled using the `ode` physics engine in Gazebo using the `WheelSlipPlugin` to get a linear slip model (steady wheel slip roughly proportional to the slope angle when driving uphill or downhill) and the plowing parameters added in https://github.com/gazebosim/gazebo-classic/pull/3164. In cases for which the linear slip model only matches experimental data within a particular range of slope angles, a nonlinear aspect to the model would be useful.

This pull request adds a nonlinear wheel slip effect in ODEPhysics in the portion of the contact callback function where the wheel plowing model is currently implemented. This nonlinear effect iterates over each contact point/normal pair and computes for each pair an equivalent slope angle from the projection of gravity and some other body forces into the wheel's longitudinal/normal plane. For each pair of collisions in contact, the equivalent slope angle is averaged over the set of contact points for that collision pair. If the equivalent slope is below the lower threshold or above the upper threshold, the longitudinal slip compliance is altered in proportion to the difference from the threshold according to the following equation:

~~~
if (aboveThreshold) {
  longitudinal_slip_compliance *=
    (1 + nonlinearSlipUpperPerDegree * degreesAboveThreshold);
}
else if (belowThreshold) {
  longitudinal_slip_compliance *=
    (1 + nonlinearSlipLowerPerDegree * degreesBelowThreshold);
}
~~~

The slope threshold values are specified in degrees in the `//nonlinear_slip/lower/degree` and `//nonlinear_slip/upper/degree` parameters with the proportionality parameters are specified in `//nonlinear_slip/lower/per_degree` and `//nonlinear_slip/upper/per_degree`

~~~
<nonlinear_slip>
  <lower>
    <degree>-6</degree>
    <per_degree>0.01</per_degree>
  </lower>
  <upper>
    <degree>6</degree>
    <per_degree>0.01</per_degree>
  </upper>
</nonlinear_slip>
~~~

## Test it

1. In a terminal, append `test/models` from the local clone of the gazebo-classic source repository to the `GAZEBO_MODEL_PATH` variable
2. Run the example world with

~~~
gazebo --verbose test/worlds/plowing_nonlinear_slip_tricycle_demo.world
~~~

The loads a world with two tricycles driving "uphill" against an inclined gravity vector on a flat plane. The inclination angle of the gravity vector is larger than the upper nonlinear slope threshold, so the nonlinear effect causes that tricycle to reach a reduced linear speed compared to the other tricycle with no nonlinear slip parameters. Reducing the gravity inclination below the threshold (such as with gravity of `-1 0 -9.75`) will cause both tricycles to drive at the same speed, since their slip parameters will be identical.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
