### PR TITLE
Fix build with graphviz 9

### DIFF
--- a/cmake/SearchForStuff.cmake
+++ b/cmake/SearchForStuff.cmake
@@ -771,6 +771,9 @@ if (NOT GRAPHVIZ_FOUND)
 else ()
   message (STATUS "Looking for libgraphviz-dev - found")
   set (HAVE_GRAPHVIZ ON CACHE BOOL "HAVE GRAPHVIZ" FORCE)
+  if (${GRAPHVIZ_CGRAPH_PKG_VERSION} VERSION_LESS 9.0)
+    set(GRAPHVIZ_VERSION_LT_9 TRUE)
+  endif ()
 endif ()
 
 ########################################

--- a/gazebo/gui/CMakeLists.txt
+++ b/gazebo/gui/CMakeLists.txt
@@ -206,6 +206,11 @@ add_dependencies(gzclient gazebo_gui)
 target_compile_definitions(gazebo_gui
   PRIVATE BUILDING_DLL_GZ_GUI
 )
+if (GRAPHVIZ_VERSION_LT_9)
+  target_compile_definitions(gazebo_gui
+    PRIVATE GRAPHVIZ_VERSION_LT_9
+  )
+endif()
 
 target_link_libraries(gazebo_gui
   libgazebo_client

--- a/gazebo/gui/qgv/private/QGVCore.h
+++ b/gazebo/gui/qgv/private/QGVCore.h
@@ -102,7 +102,10 @@ class QGVCore
       rdr.len = strlen(cp);
       rdr.cur = 0;
 
+#ifdef GRAPHVIZ_VERSION_LT_9
+      // This variable only exists for versions before Graphviz 9.0
       disc.mem = &AgMemDisc;
+#endif
       disc.id = &AgIdDisc;
       disc.io = &memIoDisc;
       g = agread(&rdr, &disc);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo-classic/issues/3344

## Summary

As noted in https://github.com/gazebosim/gazebo-classic/issues/3344, gazebo11 has been failing to compile against graphviz 9.0, which was recently released into homebrew-core. The console error complained about the unrecognized member variable `men` in the `Agdisc_s` struct, and that variable was removed from the data structure defined in `cgraph.h` in [gitlab.com/graphviz/graphviz@0f6504e90775c72](https://gitlab.com/graphviz/graphviz/-/commit/0f6504e90775c7259b192d382bfe910e4e98dcef), which was released in version 9.0.

This pull request defines a `GRAPHVIZ_VERSION_LT_9` macro if the graphviz version is less than 9, and put an `ifdef` around the reference to the variable that only exists in old versions.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
