### PR TITLE
Prepare for an 11.14.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 11)
-set (GAZEBO_MINOR_VERSION 13)
+set (GAZEBO_MINOR_VERSION 14)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,45 @@
 ## Gazebo 11
 
+## Gazebo 11.14.0 (2023-10-06)
+
+1. Visual::SetPose performance improvement / minor fixes
+    * [Pull request #3350](https://github.com/gazebosim/gazebo/pull/3350)
+   * A contribution from Janosch Machowinski
+
+1. Apply initial sim time also after a reset.
+    * [Pull request #3340](https://github.com/gazebosim/gazebo/pull/3340)
+   * A contribution from Martin Pecka
+
+1. Remove using namespace SimTK
+    * [Pull request #3347](https://github.com/gazebosim/gazebo/pull/3347)
+    * A contrubition from Silvio Traversaro
+
+1. Fix build with graphviz 9
+    * [Pull request #3345](https://github.com/gazebosim/gazebo/pull/3345)
+
+1. Add support for compiling on windows x64 and x86 with vcpkg-provided dependencies
+    * [Pull request #3320](https://github.com/gazebosim/gazebo/pull/3320)
+    * [Pull request #3349](https://github.com/gazebosim/gazebo/pull/3349)
+   * A contribution from talregev
+
+1. gzclient: improve startup reliability
+    * [Pull request #3338](https://github.com/gazebosim/gazebo/pull/3338)
+
+1. CI: add non concurrency to all GitHub workflows
+    * [Pull request #3337](https://github.com/gazebosim/gazebo/pull/3337)
+   * A contribution from talregev
+
+1. Set `HOME_ENV` according the OS
+    * [Pull request #3334](https://github.com/gazebosim/gazebo/pull/3334)
+   * A contribution from talregev
+
+1. Allow usage of lambdas as transport subscription callbacks
+    * [Pull request #3309](https://github.com/gazebosim/gazebo/pull/3309)
+   * A contribution from Patrick Roncagliolo
+
+1. Fix for finding new versions of protobuf
+    * [Pull request #3331](https://github.com/gazebosim/gazebo/pull/3331)
+
 ## Gazebo 11.13.0 (2023-05-17)
 
 1. Fix wide-angle lens flare occlusion lag


### PR DESCRIPTION
# 🎈 Release

Preparation for 11.14.0 release.

Comparison to 11.13.0: https://github.com/gazebosim/gazebo-classic/compare/gazebo11_11.13.0...scpeters/bump_11.14

<!-- Add links to PRs that require this release (if needed) -->


## Checklist
- [X] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [X] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
