### PR TITLE
fix: Don't divide time by zero if single stepping.

### DIFF
--- a/gazebo/sensors/SensorManager.cc
+++ b/gazebo/sensors/SensorManager.cc
@@ -207,7 +207,7 @@ void PublishPerformanceMetrics()
   if (ignition::math::equal(diffSimTime.Double(), 0.0))
     return;
 
-  if (realTime == 0)
+  if (diffRealtime == common::Time::Zero)
     realTimeFactor = 0;
   else
     realTimeFactor = diffSimTime / diffRealtime;


### PR DESCRIPTION
## Summary
When stepping, the console always showed a warning "[gzserver-6] [Err] [Time.cc:684] Time divide by zero".
This commit fixes the warning, caused by a check on a wrong variable.
