### PR TITLE
conda-forge CI: Pin libprotobuf to 4.24

### DIFF
--- a/.github/workflows/conda-forge.yml
+++ b/.github/workflows/conda-forge.yml
@@ -42,7 +42,7 @@ jobs:
         # Compilation related dependencies
         mamba install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install libprotobuf libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt-main ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd-double boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp simbody hdf5 openal-soft glib gts dartsim
+        mamba install libprotobuf==4.24.* libsdformat libignition-cmake2 libignition-math6 libignition-transport8 libignition-common3 libignition-fuel-tools4 qt-main ogre=1.10 freeimage curl tbb-devel qwt tinyxml2 libccd-double boost-cpp libcurl tinyxml bzip2 zlib ffmpeg graphviz libgdal libusb bullet-cpp simbody hdf5 openal-soft glib gts dartsim
 
     - name: Linux-only Dependencies [Linux]
       if: contains(matrix.os, 'ubuntu')


### PR DESCRIPTION
# 🦟 Bug fix

There is an intricate bug due to the interaction of a Visual Studio bug (https://developercommunity.visualstudio.com/t/c2370-is-falsely-emitted-when-a-static-const-membe/898167) and a protobuf problem (https://github.com/protocolbuffers/protobuf/issues/14602) for which gazebo can't compile with libprotobuf 4.25 on Windows, so the conda-forge CI is now failing (see https://github.com/gazebosim/gazebo-classic/actions/runs/7735348265/job/21090856649 and https://github.com/conda-forge/gazebo-feedstock/pull/201). As I do not see a short term solution, let's pin libprotobuf here to avoid a noisy CI failure in the conda-forge CI.

Fortunatly, the problem is not present in protobuf 4.26 .

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

