### PR TITLE
Prepare 11.15.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ string (TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 string (TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPER)
 
 set (GAZEBO_MAJOR_VERSION 11)
-set (GAZEBO_MINOR_VERSION 14)
+set (GAZEBO_MINOR_VERSION 15)
 # The patch version may have been bumped for prerelease purposes; be sure to
 # check gazebo-release/ubuntu/debian/changelog@default to determine what the
 # next patch version should be for a regular release.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,28 @@
 ## Gazebo 11
 
+## Gazebo 11.15.0 (2024-02-14)
+
+1. Set gz tool name via GZ_CLI_EXECUTABLE_NAME
+    * [Pull request #3368](https://github.com/gazebosim/gazebo/pull/3368)
+
+1. vcpkg: update to the latest hash
+    * [Pull request #3367](https://github.com/gazebosim/gazebo/pull/3367)
+
+1. conda-forge CI: Pin libprotobuf to 4.24
+    * [Pull request #3365](https://github.com/gazebosim/gazebo/pull/3365)
+
+1. fix: Don't divide time by zero if single stepping.
+    * [Pull request #3352](https://github.com/gazebosim/gazebo/pull/3352)
+
+1. Port sensor update rate fix
+    * [Pull request #3353](https://github.com/gazebosim/gazebo/pull/3353)
+
+1. Add signal handlers for Windows
+    * [Pull request #3167](https://github.com/gazebosim/gazebo/pull/3167)
+
+1. Remove GZ_SINGLETON_DECLARE definition workaround (fix for armhf)
+    * [Pull request #3283](https://github.com/gazebosim/gazebo/pull/3283)
+
 ## Gazebo 11.14.0 (2023-10-06)
 
 1. Visual::SetPose performance improvement / minor fixes


### PR DESCRIPTION
# 🎈 Release

Preparation for 11.15.0

Comparison to 11.14.0: https://github.com/gazebosim/gazebo-classic/compare/gazebo11_11.14.0...gazebo11

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
