### PR TITLE
Fix manpage installation when GZ_CLI_EXECUTABLE_NAME is used

### DIFF
--- a/cmake/Man.cmake
+++ b/cmake/Man.cmake
@@ -14,21 +14,34 @@ if (NOT GZIP)
 else (NOT GZIP)
   message (STATUS "Looking for gzip to generate manpages - found")
 
+  # macro can also be called with a third argument that contains a modified name
+  # of the manpage to be installed.
   macro(roffman _source _section)
+    set(_extra_macro_args ${ARGN})
+    list(LENGTH _extra_macro_args _num_extra_macro_args)
+
+    if (_num_extra_macro_args EQUAL 0)
+      set(_destination _source)
+    elseif(_num_extra_macro_args EQUAL 1)
+      set(_destination ${_extra_macro_args})
+    else()
+      message(FATAL_ERROR "roffman macro called with unexpected number of extra arguments '${ARGN}'")
+    endif()
+
     add_custom_command(
-      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_source}.${_section}.gz
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_destination}.${_section}.gz
       COMMAND ${GZIP} -c ${CMAKE_CURRENT_SOURCE_DIR}/${_source}.${_section}.roff
-        > ${CMAKE_CURRENT_BINARY_DIR}/${_source}.${_section}.gz
+        > ${CMAKE_CURRENT_BINARY_DIR}/${_destination}.${_section}.gz
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_source}.${_section}.roff
     )
 
     set(MANPAGE_TARGET "man-${_source}")
 
     add_custom_target(${MANPAGE_TARGET}
-      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_source}.${_section}.gz)
+      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_destination}.${_section}.gz)
     add_dependencies(man ${MANPAGE_TARGET})
 
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${_source}.${_section}.gz
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${_destination}.${_section}.gz
       DESTINATION share/man/man${_section}
     )
   endmacro(roffman _source _section)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 gz_install_executable(${GZ_CLI_EXECUTABLE_NAME})
 
 if (NOT WIN32)
-  roffman(${GZ_CLI_EXECUTABLE_NAME} 1)
+  roffman(gz 1 ${GZ_CLI_EXECUTABLE_NAME})
 endif()
 
 install (PROGRAMS gzprop DESTINATION ${BIN_INSTALL_DIR})


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The install steps is failing when `GZ_CLI_EXECUTABLE_NAME` is being used in the step to install the man files. This happens after #3368.

```
-- Installing: /home/jenkins/workspace/gazebo11-debbuilder/build/gazebo/debian/tmp/usr/bin/gz11
-- Set runtime path of "/home/jenkins/workspace/gazebo11-debbuilder/build/gazebo/debian/tmp/usr/bin/gz11-11.15.0" to ""
CMake Error at tools/cmake_install.cmake:74 (file):
  file INSTALL cannot find
  "/home/jenkins/workspace/gazebo11-debbuilder/build/gazebo/obj-x86_64-linux-gnu/tools/gz11.1.gz":
  No such file or directory.
Call Stack (most recent call first):
  cmake_install.cmake:103 (include)


make[1]: *** [Makefile:100: install] Error 1
```  

The PR implements modifies slightly the `roffman` macro to support a third optional parameter that defines a different generated name. That parameter is being used when `GZ_CLI_EXECUTABLE_NAME` is defined.

Tested with `GZ_CLI_EXECUTABLE_NAME` in [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo11-debbuilder&build=205)](https://build.osrfoundation.org/job/gazebo11-debbuilder/205/).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.