### PR TITLE
Fix build with graphviz 10.0

### DIFF
--- a/gazebo/gui/qgv/QGVSubGraph.cpp
+++ b/gazebo/gui/qgv/QGVSubGraph.cpp
@@ -44,13 +44,13 @@ QString QGVSubGraph::name() const
 
 QGVNode *QGVSubGraph::addNode(const QString &label)
 {
-    Agnode_t *node = agnode(_sgraph->graph(), NULL, TRUE);
+    Agnode_t *node = agnode(_sgraph->graph(), NULL, 1);
     if (node == NULL)
     {
         qWarning()<<"Invalid sub node :"<<label;
         return 0;
     }
-    agsubnode(_sgraph->graph(), node, TRUE);
+    agsubnode(_sgraph->graph(), node, 1);
 
     QGVNode *item = new QGVNode(new QGVNodePrivate(node), _scene);
     item->setLabel(label);
@@ -66,10 +66,10 @@ QGVSubGraph *QGVSubGraph::addSubGraph(const QString &_name, bool cluster)
     if (cluster)
     {
         sgraph = agsubg(_sgraph->graph(),
-            ("cluster_" + _name).toLocal8Bit().data(), TRUE);
+            ("cluster_" + _name).toLocal8Bit().data(), 1);
     }
     else
-        sgraph = agsubg(_sgraph->graph(), _name.toLocal8Bit().data(), TRUE);
+        sgraph = agsubg(_sgraph->graph(), _name.toLocal8Bit().data(), 1);
 
     if (sgraph == NULL)
     {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #3372.

## Summary

The `TRUE` macro has been removed in graphviz 10.0, which was recently released in homebrew-core. The fix is to replace `TRUE` with `1`.

To test: verify that the homebrew build compiles successfully.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
