### PR TITLE
Added environment variable GAZEBO_SUPPRESS_EOL_WARNING that disables EOL notices.

### DIFF
--- a/gazebo/gazebo_shared.cc
+++ b/gazebo/gazebo_shared.cc
@@ -30,7 +30,8 @@ void gazebo_shared::printVersion()
 {
   fprintf(stderr, "%s", GAZEBO_VERSION_HEADER);
 
-  char *ignoreEol = getenv("GAZEBO_SUPPRESS_EOL_WARNING");
+  const char *ignoreEol =
+    gazebo::common::getEnv("GAZEBO_SUPPRESS_EOL_WARNING");
   if (ignoreEol != nullptr && strncmp(ignoreEol, "1", 1) == 0)
     return;
 

--- a/gazebo/gazebo_shared.cc
+++ b/gazebo/gazebo_shared.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
  */
+#include <cstdlib>
+
 #include <sdf/sdf.hh>
 
 #include "gazebo/transport/TransportIface.hh"
@@ -27,6 +29,11 @@
 void gazebo_shared::printVersion()
 {
   fprintf(stderr, "%s", GAZEBO_VERSION_HEADER);
+
+  char *ignoreEol = getenv("GAZEBO_SUPPRESS_EOL_WARNING");
+  if (ignoreEol != nullptr && strncmp(ignoreEol, "1", 1) == 0)
+    return;
+
   const char* msg = R"(
 #     # ####### ####### ###  #####  #######
 ##    # #     #    #     #  #     # #

--- a/gazebo/gui/MainWindow.cc
+++ b/gazebo/gui/MainWindow.cc
@@ -1678,7 +1678,7 @@ void MainWindow::ShowMenuBar(QMenuBar *_bar)
   this->dataPtr->menuLayout->addWidget(this->dataPtr->menuBar);
 
   if (!this->dataPtr->eolNotice) {
-    char *ignoreEol = getenv("GAZEBO_SUPPRESS_EOL_WARNING");
+    const char *ignoreEol = common::getEnv("GAZEBO_SUPPRESS_EOL_WARNING");
     if (ignoreEol == nullptr || strncmp(ignoreEol, "1", 1) != 0) {
       // Add Gazebo classic EOL notice label
       this->dataPtr->eolNotice = new QLabel(this->dataPtr->menuBar);

--- a/gazebo/gui/MainWindow.cc
+++ b/gazebo/gui/MainWindow.cc
@@ -1678,15 +1678,18 @@ void MainWindow::ShowMenuBar(QMenuBar *_bar)
   this->dataPtr->menuLayout->addWidget(this->dataPtr->menuBar);
 
   if (!this->dataPtr->eolNotice) {
-    // Add Gazebo classic EOL notice label
-    this->dataPtr->eolNotice = new QLabel(this->dataPtr->menuBar);
-    this->dataPtr->eolNotice->setText(R"(<font color='#ff9966'>
-        This version of Gazebo reaches end-of-life in January 2025.
-        Consider <a style='color: #ffcc00' 
-        href='https://gazebosim.org/docs/latest/gazebo_classic_migration/
-        '>migrating to the new Gazebo</a></font>)");
-    this->dataPtr->menuLayout->addStretch(1);
-    this->dataPtr->menuLayout->addWidget(this->dataPtr->eolNotice);
+    char *ignoreEol = getenv("GAZEBO_SUPPRESS_EOL_WARNING");
+    if (ignoreEol == nullptr || strncmp(ignoreEol, "1", 1) != 0) {
+      // Add Gazebo classic EOL notice label
+      this->dataPtr->eolNotice = new QLabel(this->dataPtr->menuBar);
+      this->dataPtr->eolNotice->setText(R"(<font color='#ff9966'>
+          This version of Gazebo reaches end-of-life in January 2025.
+          Consider <a style='color: #ffcc00' 
+          href='https://gazebosim.org/docs/latest/gazebo_classic_migration/
+          '>migrating to the new Gazebo</a></font>)");
+      this->dataPtr->menuLayout->addStretch(1);
+      this->dataPtr->menuLayout->addWidget(this->dataPtr->eolNotice);
+    }
   }
 
 


### PR DESCRIPTION
# 🎉 New feature

Closes https://github.com/gazebosim/gazebo-classic/pull/3405#issuecomment-2480484097

## Summary
Added environment variable `GAZEBO_SUPPRESS_EOL_WARNING`. If set to `1`, the EOL notice added in #3405 will not be shown.

## Test it
Launch Gazebo and check for the notices both in console and in menubar.

The notice in About screen has been left untouched intentionally.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.